### PR TITLE
Release: Allow Vercel launch preview origin in CORS allowlist

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,6 +90,7 @@ const allowedOrigins = Array.from(
   new Set([
     'https://www.mosaicbizhub.com',
     'https://app.mosaicbizhub.com',
+    'https://mosaic-biz-frontend-launch.vercel.app',
     'http://localhost:3000',
     'http://localhost:8081',
     'https://app.minorityownedbusiness.info',


### PR DESCRIPTION
## Summary

- Promotes the CORS allowlist update from staging so the Vercel launch preview frontend can call the production API with credentials.
- Single-line change in pp.js; no controller or route changes.

## Changes included

| Commit | Description |
|--------|-------------|
| 9bfe3ee | Allow Vercel launch preview origin in CORS allowlist |
| 