### PR TITLE
Add GitHub Actions CI and EB deploy automation

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,17 @@
+# Excluded from Elastic Beanstalk deployment bundles (eb CLI / zip workflows)
+.git/
+.github/
+node_modules/
+.env
+.env.*
+tests/
+docs/
+*.zip
+*.log
+logs/
+debug-data.js
+fix-product-data.js
+fix-variants.js
+test-products.js
+*.txt
+!package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+  push:
+    branches:
+      - main
+      - staging
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -1,0 +1,121 @@
+name: Deploy to Elastic Beanstalk
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  EB_APPLICATION_NAME: ${{ vars.EB_APPLICATION_NAME || 'mosaic-backend' }}
+  EB_ENVIRONMENT_NAME: ${{ vars.EB_ENVIRONMENT_NAME || 'Mosaic-backend' }}
+  PRODUCTION_API_URL: https://api.mosaicbizhub.com
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  deploy:
+    name: Deploy
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create deployment package
+        run: |
+          shopt -s dotglob
+          zip -r deploy.zip . \
+            -x "*.git*" \
+            -x "*node_modules/*" \
+            -x "*.env*" \
+            -x "*tests/*" \
+            -x "*docs/*" \
+            -x "*.github/*" \
+            -x "*.zip" \
+            -x "*logs/*" \
+            -x "*.log" \
+            -x "debug-data.js" \
+            -x "fix-product-data.js" \
+            -x "fix-variants.js" \
+            -x "test-products.js" \
+            -x "*.txt"
+
+      - name: Deploy to Elastic Beanstalk
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ env.EB_APPLICATION_NAME }}
+          environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
+          region: ${{ env.AWS_REGION }}
+          version_label: mosaic-${{ github.sha }}
+          deployment_package: deploy.zip
+          use_existing_version_if_available: false
+          wait_for_deployment: true
+          wait_for_environment_recovery: true
+
+      - name: Post-deploy health probe
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          echo "Version label: mosaic-${{ github.sha }}"
+          for i in 1 2 3 4 5; do
+            status=$(curl -s -o /tmp/health.json -w "%{http_code}" "${PRODUCTION_API_URL}/")
+            echo "Attempt $i: HTTP $status"
+            if [ "$status" = "200" ]; then
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Health probe failed after 5 attempts"
+          exit 1
+
+      - name: Post-deploy auth probe
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" "${PRODUCTION_API_URL}/api/users/auth/check")
+          echo "Auth check (unauthenticated): HTTP $status"
+          if [ "$status" != "401" ]; then
+            echo "Expected 401 for unauthenticated auth/check"
+            exit 1
+          fi
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "## Production deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| Version label | \`mosaic-${{ github.sha }}\` |"
+            echo "| EB application | \`${{ env.EB_APPLICATION_NAME }}\` |"
+            echo "| EB environment | \`${{ env.EB_ENVIRONMENT_NAME }}\` |"
+            echo "| Region | \`${{ env.AWS_REGION }}\` |"
+            echo "| API URL | \`${{ env.PRODUCTION_API_URL }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -61,18 +61,42 @@ Use **`https://api.mosaicbizhub.com`** for smoke tests and Stripe webhook URLs. 
 
 ## Deployment steps
 
+### Automated (GitHub Actions — preferred)
+
+Workflow: [`.github/workflows/deploy-eb-production.yml`](.github/workflows/deploy-eb-production.yml)
+
+**Triggers:**
+
+- Push to `main` (after merge from `staging`)
+- Manual **Run workflow** (`workflow_dispatch`) on `main` — use for first deploy and rollbacks
+
+**Flow:** `npm ci` → `npm test` → source-only ZIP → Elastic Beanstalk → health probe on `https://api.mosaicbizhub.com/`
+
+**One-time setup:** [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — AWS IAM, GitHub secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), variables (`AWS_REGION`, `EB_APPLICATION_NAME`, `EB_ENVIRONMENT_NAME`), and optional `production` environment reviewers.
+
+**Per release:**
+
+1. Merge approved PR `staging` → `main`; note commit SHA.
+2. CI runs on push; deploy workflow runs tests then deploys to EB environment **`Mosaic-backend`** (application **`mosaic-backend`**, region **`us-east-1`**).
+3. Confirm workflow summary shows deployed SHA and health probe PASS.
+4. Verify EB boot logs (Mongo connected, no missing-env crash).
+5. Run [production-smoke-checklist.md](docs/production-smoke-checklist.md) with **test accounts only**.
+6. Fill [production-proof-pack-template.md](docs/production-proof-pack-template.md); retain for release record.
+
+**Rollback via GitHub Actions:** Run **Deploy to Elastic Beanstalk** workflow manually and select a previous known-good commit on `main`.
+
+### Manual ZIP (legacy fallback)
+
+If GitHub Actions is unavailable:
+
 1. Identify exact commit on `main` to release (post-merge SHA).
-2. Infrastructure owner deploys `main` to AWS Elastic Beanstalk.
-3. Verify boot logs:
-   - MongoDB connected
-   - Server listening on expected port
-   - No missing-env or Stripe init crashes
-4. Run [production-smoke-checklist.md](docs/production-smoke-checklist.md) with **test accounts only**.
-5. Fill [production-proof-pack-template.md](docs/production-proof-pack-template.md); retain for release record.
+2. Infrastructure owner uploads ZIP to AWS Elastic Beanstalk (exclude `node_modules`, `.env`, `.git` — see [`.ebignore`](.ebignore)).
+3. Follow verification steps below.
 
 **Minimum post-deploy smoke:**
 
 - `GET https://api.mosaicbizhub.com/` → 200
+- `GET https://api.mosaicbizhub.com/api/users/auth/check` (unauthenticated) → 401
 - Auth login/logout with test user
 - One Stripe webhook delivery check in Dashboard
 - One non-destructive protected route
@@ -118,6 +142,7 @@ Deployment and smoke tests **do not fix** open P0 code issues. See [launch-readi
 
 ## Related docs
 
+- [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — GitHub Actions + AWS one-time setup
 - [docs/DECISION_REGISTER.md](docs/DECISION_REGISTER.md) — MVP decisions and deferrals
 - [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) — **release owner runbook** (smoke, rollback, Go/No-Go)
 - [STAGING.md](STAGING.md)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ npm run dev
 | `npm run dev` | Start the API with `nodemon` |
 | `npm start` | Start the API with `node index.js` |
 | `npm test` | Run automated tests (`node --test tests/**/*.test.js`, 57 cases) — see [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) |
+| CI | GitHub Actions [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs tests on PR/push to `staging`/`main` |
 
 ## Operational docs
 
@@ -103,7 +104,7 @@ Key entry points:
 1. Work on a feature branch; open PR to `staging`.
 2. Complete integration checklist in [STAGING.md](STAGING.md) (code review, local boot — no hosted staging).
 3. Open PR `staging` → `main`; required reviewers approve.
-4. Deploy `main` to AWS Elastic Beanstalk; follow [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for smoke and sign-off.
+4. Deploy `main` to AWS Elastic Beanstalk via GitHub Actions ([`.github/workflows/deploy-eb-production.yml`](.github/workflows/deploy-eb-production.yml)); follow [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for smoke and sign-off. One-time setup: [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md).
 5. Record proof in [docs/production-proof-pack-template.md](docs/production-proof-pack-template.md).
 
 Hosted staging is deferred — see [docs/hosted-staging-decision.md](docs/hosted-staging-decision.md).

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -108,6 +108,31 @@ Current release path: validate on `staging` branch → merge to `main` → deplo
 
 ---
 
+## Post-merge gate — 2026-06-16 (GitHub Actions EB deploy)
+
+GitHub Actions CI/CD added on branch `chore/github-actions-eb-deploy`:
+
+| Item | Value |
+|------|-------|
+| CI workflow | `.github/workflows/ci.yml` — `npm ci` + `npm test` on PR/push to `staging`/`main` |
+| Deploy workflow | `.github/workflows/deploy-eb-production.yml` — test gate + source ZIP + EB deploy + health probes |
+| GitHub variables | `AWS_REGION=us-east-1`, `EB_APPLICATION_NAME=mosaic-backend`, `EB_ENVIRONMENT_NAME=Mosaic-backend` |
+| Setup doc | [github-actions-eb-setup.md](github-actions-eb-setup.md) |
+| Local `npm test` | **57/57 pass** (2026-06-16) |
+
+### Production baseline probes (pre-automated-deploy)
+
+Probed before first GitHub Actions deploy:
+
+| Check | Result |
+|-------|--------|
+| `GET https://api.mosaicbizhub.com/` | **200** — `{"message":"Mosaic Biz Hub API is working 9 feb "}` |
+| `GET https://api.mosaicbizhub.com/api/users/auth/check` (unauth) | **401** |
+
+**Pending (infra owner):** Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets; create `production` GitHub environment with reviewers; run **Deploy to Elastic Beanstalk** via `workflow_dispatch` on `main`. CORS fix (`mosaic-biz-frontend-launch.vercel.app`) is in git @ `5db1a78` but not confirmed live until EB deploy completes.
+
+---
+
 ## Post-merge gate — 2026-06-14 (PR #9 merged)
 
 PR [#9](https://github.com/DeveloperTWH/backend/pull/9) merged to `main` at `2026-06-14T21:38:12Z`.

--- a/docs/github-actions-eb-setup.md
+++ b/docs/github-actions-eb-setup.md
@@ -1,0 +1,178 @@
+# GitHub Actions — Elastic Beanstalk Setup
+
+One-time configuration for CI and production deploy workflows. Application secrets stay on EB; GitHub only needs deploy credentials.
+
+---
+
+## AWS metadata (confirm in console)
+
+| Field | Expected value | How to verify |
+|-------|----------------|---------------|
+| **Region** | `us-east-1` | EB console region selector |
+| **EB application name** | `mosaic-backend` | EB → Applications (inferred from hostname `mosaic-backend.us-east-1.elasticbeanstalk.com`) |
+| **EB environment name** | `Mosaic-backend` | EB → Environments — **confirm exact casing** |
+| **Platform** | Node.js 18+ on Amazon Linux | Environment → Configuration → Platform |
+| **Health check path** | `/` | Configuration → Load balancer |
+| **Canonical API** | `https://api.mosaicbizhub.com` | Custom domain on environment |
+
+Record before first deploy:
+
+- Current application version label on EB (rollback baseline)
+- Deployed commit SHA if known (from last manual ZIP)
+
+---
+
+## GitHub repository configuration
+
+Repository: `DeveloperTWH/backend`
+
+### Secrets (Settings → Secrets and variables → Actions → Secrets)
+
+**Option A — Access keys (MVP):**
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | IAM user access key with EB deploy permissions |
+| `AWS_SECRET_ACCESS_KEY` | Matching secret key |
+
+**Option B — OIDC (recommended long-term):**
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ROLE_ARN` | IAM role ARN trusted by GitHub OIDC |
+
+When using OIDC, omit access-key secrets and configure the deploy workflow to assume the role (see IAM section below).
+
+### Variables (Settings → Secrets and variables → Actions → Variables)
+
+| Variable | Value |
+|----------|-------|
+| `AWS_REGION` | `us-east-1` |
+| `EB_APPLICATION_NAME` | `mosaic-backend` (adjust if console differs) |
+| `EB_ENVIRONMENT_NAME` | `Mosaic-backend` (adjust if console differs) |
+
+Set via CLI:
+
+```bash
+gh variable set AWS_REGION --body "us-east-1" -R DeveloperTWH/backend
+gh variable set EB_APPLICATION_NAME --body "mosaic-backend" -R DeveloperTWH/backend
+gh variable set EB_ENVIRONMENT_NAME --body "Mosaic-backend" -R DeveloperTWH/backend
+```
+
+### Production environment (optional but recommended)
+
+Create environment **`production`** with:
+
+- **Deployment branches:** `main` only
+- **Required reviewers:** release owner + infra owner
+
+```bash
+gh api -X PUT repos/DeveloperTWH/backend/environments/production \
+  -f wait_timer=0 \
+  -f reviewers='[]' \
+  -f deployment_branch_policy='{"protected_branches":false,"custom_branch_policies":true}' \
+  -f custom_branch_policies='[{"name":"main","type":"branch"}]'
+```
+
+Add reviewers in the GitHub UI: Settings → Environments → production → Required reviewers.
+
+---
+
+## IAM policy (deploy user or role)
+
+Minimum permissions for `einaregilsson/beanstalk-deploy`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticbeanstalk:CreateApplicationVersion",
+        "elasticbeanstalk:UpdateEnvironment",
+        "elasticbeanstalk:DescribeApplications",
+        "elasticbeanstalk:DescribeEnvironments",
+        "elasticbeanstalk:DescribeEvents",
+        "elasticbeanstalk:DescribeApplicationVersions"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::elasticbeanstalk-*",
+        "arn:aws:s3:::elasticbeanstalk-*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "ec2:DescribeInstances",
+        "ec2:DescribeImages",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### OIDC trust policy (GitHub → AWS)
+
+Replace `ACCOUNT_ID` and restrict `sub` to this repo:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:DeveloperTWH/backend:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## First deploy checklist
+
+1. [ ] EB application/environment names verified in AWS console
+2. [ ] GitHub secrets and variables configured
+3. [ ] `production` environment reviewers added (if using approval gate)
+4. [ ] Record current EB version as rollback baseline
+5. [ ] Run **Deploy to Elastic Beanstalk** workflow via **workflow_dispatch** on `main`
+6. [ ] Confirm workflow health probe: `GET https://api.mosaicbizhub.com/` → 200
+7. [ ] Run [production-smoke-checklist.md](production-smoke-checklist.md) minimum tier
+8. [ ] Update [deploy-verification.md](deploy-verification.md) with deployed SHA
+
+After first successful manual deploy, push-to-`main` auto-deploy is enabled in the workflow (gated by `production` environment when configured).
+
+---
+
+## Rollback
+
+1. GitHub Actions → **Deploy to Elastic Beanstalk** → **Run workflow** → select previous known-good commit on `main`
+2. Or AWS Console → EB → Application versions → Deploy previous version
+3. Re-run minimum smoke (P0.1, P1.4)


### PR DESCRIPTION
## Summary
- Add CI workflow (npm ci + npm test on PR/push to staging/main)
- Add deploy workflow (test gate, source ZIP, EB deploy, health probes)
- Document AWS/GitHub setup and update DEPLOYMENT.md

## Test plan
- [x] Local npm test 57/57 pass
- [ ] Merge to main and verify CI workflow green
- [ ] Infra owner adds AWS secrets and runs workflow_dispatch deploy

Made with [Cursor](https://cursor.com)