### PR TITLE
Migrate EB deploy workflow to GitHub OIDC auth

### DIFF
--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,17 @@
+# Excluded from Elastic Beanstalk deployment bundles (eb CLI / zip workflows)
+.git/
+.github/
+node_modules/
+.env
+.env.*
+tests/
+docs/
+*.zip
+*.log
+logs/
+debug-data.js
+fix-product-data.js
+fix-variants.js
+test-products.js
+*.txt
+!package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+  push:
+    branches:
+      - main
+      - staging
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -2,9 +2,10 @@ name: Deploy to Elastic Beanstalk
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  # push:
+  #   branches:
+  #     - main
+  # Re-enable after first successful manual deploy and production environment + AWS OIDC role are confirmed.
 
 concurrency:
   group: deploy-production
@@ -12,8 +13,8 @@ concurrency:
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-  EB_APPLICATION_NAME: ${{ vars.EB_APPLICATION_NAME || 'mosaic-backend' }}
-  EB_ENVIRONMENT_NAME: ${{ vars.EB_ENVIRONMENT_NAME || 'Mosaic-backend' }}
+  EB_APPLICATION_NAME: ${{ vars.EB_APPLICATION_NAME || 'mosaic-biz-hub-backend' }}
+  EB_ENVIRONMENT_NAME: ${{ vars.EB_ENVIRONMENT_NAME || 'mosaic-backend-env' }}
   PRODUCTION_API_URL: https://api.mosaicbizhub.com
 
 jobs:
@@ -27,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies
@@ -42,6 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -66,11 +70,20 @@ jobs:
             -x "test-products.js" \
             -x "*.txt"
 
+      - name: Configure AWS credentials
+        id: aws_creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+          output-credentials: true
+
       - name: Deploy to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v22
         with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ steps.aws_creds.outputs.aws-access-key-id }}
+          aws_secret_key: ${{ steps.aws_creds.outputs.aws-secret-access-key }}
+          aws_session_token: ${{ steps.aws_creds.outputs.aws-session-token }}
           application_name: ${{ env.EB_APPLICATION_NAME }}
           environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
           region: ${{ env.AWS_REGION }}

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -1,0 +1,121 @@
+name: Deploy to Elastic Beanstalk
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  EB_APPLICATION_NAME: ${{ vars.EB_APPLICATION_NAME || 'mosaic-backend' }}
+  EB_ENVIRONMENT_NAME: ${{ vars.EB_ENVIRONMENT_NAME || 'Mosaic-backend' }}
+  PRODUCTION_API_URL: https://api.mosaicbizhub.com
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  deploy:
+    name: Deploy
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create deployment package
+        run: |
+          shopt -s dotglob
+          zip -r deploy.zip . \
+            -x "*.git*" \
+            -x "*node_modules/*" \
+            -x "*.env*" \
+            -x "*tests/*" \
+            -x "*docs/*" \
+            -x "*.github/*" \
+            -x "*.zip" \
+            -x "*logs/*" \
+            -x "*.log" \
+            -x "debug-data.js" \
+            -x "fix-product-data.js" \
+            -x "fix-variants.js" \
+            -x "test-products.js" \
+            -x "*.txt"
+
+      - name: Deploy to Elastic Beanstalk
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ env.EB_APPLICATION_NAME }}
+          environment_name: ${{ env.EB_ENVIRONMENT_NAME }}
+          region: ${{ env.AWS_REGION }}
+          version_label: mosaic-${{ github.sha }}
+          deployment_package: deploy.zip
+          use_existing_version_if_available: false
+          wait_for_deployment: true
+          wait_for_environment_recovery: true
+
+      - name: Post-deploy health probe
+        run: |
+          echo "Deployed commit: ${{ github.sha }}"
+          echo "Version label: mosaic-${{ github.sha }}"
+          for i in 1 2 3 4 5; do
+            status=$(curl -s -o /tmp/health.json -w "%{http_code}" "${PRODUCTION_API_URL}/")
+            echo "Attempt $i: HTTP $status"
+            if [ "$status" = "200" ]; then
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Health probe failed after 5 attempts"
+          exit 1
+
+      - name: Post-deploy auth probe
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" "${PRODUCTION_API_URL}/api/users/auth/check")
+          echo "Auth check (unauthenticated): HTTP $status"
+          if [ "$status" != "401" ]; then
+            echo "Expected 401 for unauthenticated auth/check"
+            exit 1
+          fi
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "## Production deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Commit | \`${{ github.sha }}\` |"
+            echo "| Version label | \`mosaic-${{ github.sha }}\` |"
+            echo "| EB application | \`${{ env.EB_APPLICATION_NAME }}\` |"
+            echo "| EB environment | \`${{ env.EB_ENVIRONMENT_NAME }}\` |"
+            echo "| Region | \`${{ env.AWS_REGION }}\` |"
+            echo "| API URL | \`${{ env.PRODUCTION_API_URL }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -72,12 +72,12 @@ Workflow: [`.github/workflows/deploy-eb-production.yml`](.github/workflows/deplo
 
 **Flow:** `npm ci` → `npm test` → source-only ZIP → Elastic Beanstalk → health probe on `https://api.mosaicbizhub.com/`
 
-**One-time setup:** [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — AWS IAM, GitHub secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), variables (`AWS_REGION`, `EB_APPLICATION_NAME`, `EB_ENVIRONMENT_NAME`), and optional `production` environment reviewers.
+**One-time setup:** [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — AWS IAM OIDC role, GitHub variables (`AWS_REGION`, `EB_APPLICATION_NAME`, `EB_ENVIRONMENT_NAME`, `AWS_ROLE_TO_ASSUME`), and `production` environment reviewers. No long-lived AWS access keys in GitHub.
 
 **Per release:**
 
 1. Merge approved PR `staging` → `main`; note commit SHA.
-2. CI runs on push; deploy workflow runs tests then deploys to EB environment **`Mosaic-backend`** (application **`mosaic-backend`**, region **`us-east-1`**).
+2. CI runs on push; deploy workflow runs tests then deploys to EB environment **`mosaic-backend-env`** (application **`mosaic-biz-hub-backend`**, region **`us-east-1`**).
 3. Confirm workflow summary shows deployed SHA and health probe PASS.
 4. Verify EB boot logs (Mongo connected, no missing-env crash).
 5. Run [production-smoke-checklist.md](docs/production-smoke-checklist.md) with **test accounts only**.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -61,18 +61,42 @@ Use **`https://api.mosaicbizhub.com`** for smoke tests and Stripe webhook URLs. 
 
 ## Deployment steps
 
+### Automated (GitHub Actions — preferred)
+
+Workflow: [`.github/workflows/deploy-eb-production.yml`](.github/workflows/deploy-eb-production.yml)
+
+**Triggers:**
+
+- Push to `main` (after merge from `staging`)
+- Manual **Run workflow** (`workflow_dispatch`) on `main` — use for first deploy and rollbacks
+
+**Flow:** `npm ci` → `npm test` → source-only ZIP → Elastic Beanstalk → health probe on `https://api.mosaicbizhub.com/`
+
+**One-time setup:** [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — AWS IAM, GitHub secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), variables (`AWS_REGION`, `EB_APPLICATION_NAME`, `EB_ENVIRONMENT_NAME`), and optional `production` environment reviewers.
+
+**Per release:**
+
+1. Merge approved PR `staging` → `main`; note commit SHA.
+2. CI runs on push; deploy workflow runs tests then deploys to EB environment **`Mosaic-backend`** (application **`mosaic-backend`**, region **`us-east-1`**).
+3. Confirm workflow summary shows deployed SHA and health probe PASS.
+4. Verify EB boot logs (Mongo connected, no missing-env crash).
+5. Run [production-smoke-checklist.md](docs/production-smoke-checklist.md) with **test accounts only**.
+6. Fill [production-proof-pack-template.md](docs/production-proof-pack-template.md); retain for release record.
+
+**Rollback via GitHub Actions:** Run **Deploy to Elastic Beanstalk** workflow manually and select a previous known-good commit on `main`.
+
+### Manual ZIP (legacy fallback)
+
+If GitHub Actions is unavailable:
+
 1. Identify exact commit on `main` to release (post-merge SHA).
-2. Infrastructure owner deploys `main` to AWS Elastic Beanstalk.
-3. Verify boot logs:
-   - MongoDB connected
-   - Server listening on expected port
-   - No missing-env or Stripe init crashes
-4. Run [production-smoke-checklist.md](docs/production-smoke-checklist.md) with **test accounts only**.
-5. Fill [production-proof-pack-template.md](docs/production-proof-pack-template.md); retain for release record.
+2. Infrastructure owner uploads ZIP to AWS Elastic Beanstalk (exclude `node_modules`, `.env`, `.git` — see [`.ebignore`](.ebignore)).
+3. Follow verification steps below.
 
 **Minimum post-deploy smoke:**
 
 - `GET https://api.mosaicbizhub.com/` → 200
+- `GET https://api.mosaicbizhub.com/api/users/auth/check` (unauthenticated) → 401
 - Auth login/logout with test user
 - One Stripe webhook delivery check in Dashboard
 - One non-destructive protected route
@@ -118,6 +142,7 @@ Deployment and smoke tests **do not fix** open P0 code issues. See [launch-readi
 
 ## Related docs
 
+- [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md) — GitHub Actions + AWS one-time setup
 - [docs/DECISION_REGISTER.md](docs/DECISION_REGISTER.md) — MVP decisions and deferrals
 - [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) — **release owner runbook** (smoke, rollback, Go/No-Go)
 - [STAGING.md](STAGING.md)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ npm run dev
 | `npm run dev` | Start the API with `nodemon` |
 | `npm start` | Start the API with `node index.js` |
 | `npm test` | Run automated tests (`node --test tests/**/*.test.js`, 57 cases) — see [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) |
+| CI | GitHub Actions [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs tests on PR/push to `staging`/`main` |
 
 ## Operational docs
 
@@ -103,7 +104,7 @@ Key entry points:
 1. Work on a feature branch; open PR to `staging`.
 2. Complete integration checklist in [STAGING.md](STAGING.md) (code review, local boot — no hosted staging).
 3. Open PR `staging` → `main`; required reviewers approve.
-4. Deploy `main` to AWS Elastic Beanstalk; follow [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for smoke and sign-off.
+4. Deploy `main` to AWS Elastic Beanstalk via GitHub Actions ([`.github/workflows/deploy-eb-production.yml`](.github/workflows/deploy-eb-production.yml)); follow [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) for smoke and sign-off. One-time setup: [docs/github-actions-eb-setup.md](docs/github-actions-eb-setup.md).
 5. Record proof in [docs/production-proof-pack-template.md](docs/production-proof-pack-template.md).
 
 Hosted staging is deferred — see [docs/hosted-staging-decision.md](docs/hosted-staging-decision.md).

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -108,6 +108,31 @@ Current release path: validate on `staging` branch → merge to `main` → deplo
 
 ---
 
+## Post-merge gate — 2026-06-16 (GitHub Actions EB deploy)
+
+GitHub Actions CI/CD added on branch `chore/github-actions-eb-deploy`:
+
+| Item | Value |
+|------|-------|
+| CI workflow | `.github/workflows/ci.yml` — `npm ci` + `npm test` on PR/push to `staging`/`main` |
+| Deploy workflow | `.github/workflows/deploy-eb-production.yml` — test gate + source ZIP + EB deploy + health probes |
+| GitHub variables | `AWS_REGION=us-east-1`, `EB_APPLICATION_NAME=mosaic-backend`, `EB_ENVIRONMENT_NAME=Mosaic-backend` |
+| Setup doc | [github-actions-eb-setup.md](github-actions-eb-setup.md) |
+| Local `npm test` | **57/57 pass** (2026-06-16) |
+
+### Production baseline probes (pre-automated-deploy)
+
+Probed before first GitHub Actions deploy:
+
+| Check | Result |
+|-------|--------|
+| `GET https://api.mosaicbizhub.com/` | **200** — `{"message":"Mosaic Biz Hub API is working 9 feb "}` |
+| `GET https://api.mosaicbizhub.com/api/users/auth/check` (unauth) | **401** |
+
+**Pending (infra owner):** Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets; create `production` GitHub environment with reviewers; run **Deploy to Elastic Beanstalk** via `workflow_dispatch` on `main`. CORS fix (`mosaic-biz-frontend-launch.vercel.app`) is in git @ `5db1a78` but not confirmed live until EB deploy completes.
+
+---
+
 ## Post-merge gate — 2026-06-14 (PR #9 merged)
 
 PR [#9](https://github.com/DeveloperTWH/backend/pull/9) merged to `main` at `2026-06-14T21:38:12Z`.

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -116,7 +116,8 @@ GitHub Actions CI/CD added on branch `chore/github-actions-eb-deploy`:
 |------|-------|
 | CI workflow | `.github/workflows/ci.yml` — `npm ci` + `npm test` on PR/push to `staging`/`main` |
 | Deploy workflow | `.github/workflows/deploy-eb-production.yml` — test gate + source ZIP + EB deploy + health probes |
-| GitHub variables | `AWS_REGION=us-east-1`, `EB_APPLICATION_NAME=mosaic-backend`, `EB_ENVIRONMENT_NAME=Mosaic-backend` |
+| GitHub variables | `AWS_REGION=us-east-1`, `EB_APPLICATION_NAME=mosaic-biz-hub-backend`, `EB_ENVIRONMENT_NAME=mosaic-backend-env`, `AWS_ROLE_TO_ASSUME=<IAM role ARN>` |
+| Deploy auth | GitHub OIDC → IAM role (see [github-actions-eb-setup.md](github-actions-eb-setup.md)) |
 | Setup doc | [github-actions-eb-setup.md](github-actions-eb-setup.md) |
 | Local `npm test` | **57/57 pass** (2026-06-16) |
 
@@ -129,7 +130,7 @@ Probed before first GitHub Actions deploy:
 | `GET https://api.mosaicbizhub.com/` | **200** — `{"message":"Mosaic Biz Hub API is working 9 feb "}` |
 | `GET https://api.mosaicbizhub.com/api/users/auth/check` (unauth) | **401** |
 
-**Pending (infra owner):** Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets; create `production` GitHub environment with reviewers; run **Deploy to Elastic Beanstalk** via `workflow_dispatch` on `main`. CORS fix (`mosaic-biz-frontend-launch.vercel.app`) is in git @ `5db1a78` but not confirmed live until EB deploy completes.
+**Pending (infra owner):** Create GitHub OIDC IAM role with environment-scoped trust (`repo:DeveloperTWH/backend:environment:production`); set GitHub variables including `AWS_ROLE_TO_ASSUME`; create `production` GitHub environment with reviewers; run **Deploy to Elastic Beanstalk** via `workflow_dispatch` on `main`. CORS fix (`mosaic-biz-frontend-launch.vercel.app`) is in git @ `5db1a78` but not confirmed live until EB deploy completes.
 
 ---
 

--- a/docs/github-actions-eb-setup.md
+++ b/docs/github-actions-eb-setup.md
@@ -1,0 +1,178 @@
+# GitHub Actions — Elastic Beanstalk Setup
+
+One-time configuration for CI and production deploy workflows. Application secrets stay on EB; GitHub only needs deploy credentials.
+
+---
+
+## AWS metadata (confirm in console)
+
+| Field | Expected value | How to verify |
+|-------|----------------|---------------|
+| **Region** | `us-east-1` | EB console region selector |
+| **EB application name** | `mosaic-backend` | EB → Applications (inferred from hostname `mosaic-backend.us-east-1.elasticbeanstalk.com`) |
+| **EB environment name** | `Mosaic-backend` | EB → Environments — **confirm exact casing** |
+| **Platform** | Node.js 18+ on Amazon Linux | Environment → Configuration → Platform |
+| **Health check path** | `/` | Configuration → Load balancer |
+| **Canonical API** | `https://api.mosaicbizhub.com` | Custom domain on environment |
+
+Record before first deploy:
+
+- Current application version label on EB (rollback baseline)
+- Deployed commit SHA if known (from last manual ZIP)
+
+---
+
+## GitHub repository configuration
+
+Repository: `DeveloperTWH/backend`
+
+### Secrets (Settings → Secrets and variables → Actions → Secrets)
+
+**Option A — Access keys (MVP):**
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | IAM user access key with EB deploy permissions |
+| `AWS_SECRET_ACCESS_KEY` | Matching secret key |
+
+**Option B — OIDC (recommended long-term):**
+
+| Secret | Description |
+|--------|-------------|
+| `AWS_ROLE_ARN` | IAM role ARN trusted by GitHub OIDC |
+
+When using OIDC, omit access-key secrets and configure the deploy workflow to assume the role (see IAM section below).
+
+### Variables (Settings → Secrets and variables → Actions → Variables)
+
+| Variable | Value |
+|----------|-------|
+| `AWS_REGION` | `us-east-1` |
+| `EB_APPLICATION_NAME` | `mosaic-backend` (adjust if console differs) |
+| `EB_ENVIRONMENT_NAME` | `Mosaic-backend` (adjust if console differs) |
+
+Set via CLI:
+
+```bash
+gh variable set AWS_REGION --body "us-east-1" -R DeveloperTWH/backend
+gh variable set EB_APPLICATION_NAME --body "mosaic-backend" -R DeveloperTWH/backend
+gh variable set EB_ENVIRONMENT_NAME --body "Mosaic-backend" -R DeveloperTWH/backend
+```
+
+### Production environment (optional but recommended)
+
+Create environment **`production`** with:
+
+- **Deployment branches:** `main` only
+- **Required reviewers:** release owner + infra owner
+
+```bash
+gh api -X PUT repos/DeveloperTWH/backend/environments/production \
+  -f wait_timer=0 \
+  -f reviewers='[]' \
+  -f deployment_branch_policy='{"protected_branches":false,"custom_branch_policies":true}' \
+  -f custom_branch_policies='[{"name":"main","type":"branch"}]'
+```
+
+Add reviewers in the GitHub UI: Settings → Environments → production → Required reviewers.
+
+---
+
+## IAM policy (deploy user or role)
+
+Minimum permissions for `einaregilsson/beanstalk-deploy`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticbeanstalk:CreateApplicationVersion",
+        "elasticbeanstalk:UpdateEnvironment",
+        "elasticbeanstalk:DescribeApplications",
+        "elasticbeanstalk:DescribeEnvironments",
+        "elasticbeanstalk:DescribeEvents",
+        "elasticbeanstalk:DescribeApplicationVersions"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::elasticbeanstalk-*",
+        "arn:aws:s3:::elasticbeanstalk-*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "ec2:DescribeInstances",
+        "ec2:DescribeImages",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### OIDC trust policy (GitHub → AWS)
+
+Replace `ACCOUNT_ID` and restrict `sub` to this repo:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:DeveloperTWH/backend:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## First deploy checklist
+
+1. [ ] EB application/environment names verified in AWS console
+2. [ ] GitHub secrets and variables configured
+3. [ ] `production` environment reviewers added (if using approval gate)
+4. [ ] Record current EB version as rollback baseline
+5. [ ] Run **Deploy to Elastic Beanstalk** workflow via **workflow_dispatch** on `main`
+6. [ ] Confirm workflow health probe: `GET https://api.mosaicbizhub.com/` → 200
+7. [ ] Run [production-smoke-checklist.md](production-smoke-checklist.md) minimum tier
+8. [ ] Update [deploy-verification.md](deploy-verification.md) with deployed SHA
+
+After first successful manual deploy, push-to-`main` auto-deploy is enabled in the workflow (gated by `production` environment when configured).
+
+---
+
+## Rollback
+
+1. GitHub Actions → **Deploy to Elastic Beanstalk** → **Run workflow** → select previous known-good commit on `main`
+2. Or AWS Console → EB → Application versions → Deploy previous version
+3. Re-run minimum smoke (P0.1, P1.4)

--- a/docs/github-actions-eb-setup.md
+++ b/docs/github-actions-eb-setup.md
@@ -171,6 +171,20 @@ After first successful manual deploy, push-to-`main` auto-deploy is enabled in t
 
 ---
 
+## First deploy attempt (2026-06-16)
+
+Workflow run on merge of PR #12 (`main` @ `8b098ad`):
+
+| Step | Result |
+|------|--------|
+| `npm ci` + `npm test` | **PASS** |
+| Create deployment ZIP | **PASS** |
+| Deploy to EB | **FAIL** — `AWS Access Key not specified!` |
+
+**Action required:** Repo admin adds `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets, creates `production` environment (optional reviewers), then re-runs **Deploy to Elastic Beanstalk** via Actions → Run workflow on `main`.
+
+---
+
 ## Rollback
 
 1. GitHub Actions → **Deploy to Elastic Beanstalk** → **Run workflow** → select previous known-good commit on `main`

--- a/docs/github-actions-eb-setup.md
+++ b/docs/github-actions-eb-setup.md
@@ -1,17 +1,18 @@
 # GitHub Actions — Elastic Beanstalk Setup
 
-One-time configuration for CI and production deploy workflows. Application secrets stay on EB; GitHub only needs deploy credentials.
+One-time configuration for CI and production deploy workflows. Deploy auth uses **GitHub OIDC → IAM role assumption** (no long-lived AWS access keys in GitHub). Application runtime secrets stay on EB; GitHub only needs deploy role + EB metadata variables.
 
 ---
 
-## AWS metadata (confirm in console)
+## AWS metadata (confirmed in console)
 
-| Field | Expected value | How to verify |
-|-------|----------------|---------------|
+| Field | Value | How to verify |
+|-------|-------|---------------|
 | **Region** | `us-east-1` | EB console region selector |
-| **EB application name** | `mosaic-backend` | EB → Applications (inferred from hostname `mosaic-backend.us-east-1.elasticbeanstalk.com`) |
-| **EB environment name** | `Mosaic-backend` | EB → Environments — **confirm exact casing** |
-| **Platform** | Node.js 18+ on Amazon Linux | Environment → Configuration → Platform |
+| **EB application name** | `mosaic-biz-hub-backend` | EB → Applications |
+| **EB environment name** | `mosaic-backend-env` | EB → Environments |
+| **EB domain** | `mosaic-backend.us-east-1.elasticbeanstalk.com` | Environment overview |
+| **Platform** | Node.js 22 running on 64bit Amazon Linux 2023/6.6.1 | Configuration → Platform |
 | **Health check path** | `/` | Configuration → Load balancer |
 | **Canonical API** | `https://api.mosaicbizhub.com` | Custom domain on environment |
 
@@ -26,40 +27,33 @@ Record before first deploy:
 
 Repository: `DeveloperTWH/backend`
 
-### Secrets (Settings → Secrets and variables → Actions → Secrets)
-
-**Option A — Access keys (MVP):**
-
-| Secret | Description |
-|--------|-------------|
-| `AWS_ACCESS_KEY_ID` | IAM user access key with EB deploy permissions |
-| `AWS_SECRET_ACCESS_KEY` | Matching secret key |
-
-**Option B — OIDC (recommended long-term):**
-
-| Secret | Description |
-|--------|-------------|
-| `AWS_ROLE_ARN` | IAM role ARN trusted by GitHub OIDC |
-
-When using OIDC, omit access-key secrets and configure the deploy workflow to assume the role (see IAM section below).
-
 ### Variables (Settings → Secrets and variables → Actions → Variables)
 
 | Variable | Value |
 |----------|-------|
 | `AWS_REGION` | `us-east-1` |
-| `EB_APPLICATION_NAME` | `mosaic-backend` (adjust if console differs) |
-| `EB_ENVIRONMENT_NAME` | `Mosaic-backend` (adjust if console differs) |
+| `EB_APPLICATION_NAME` | `mosaic-biz-hub-backend` |
+| `EB_ENVIRONMENT_NAME` | `mosaic-backend-env` |
+| `AWS_ROLE_TO_ASSUME` | IAM role ARN (see IAM section below) |
 
-Set via CLI:
+Set via CLI (replace `ACCOUNT_ID` with your 12-digit AWS account ID):
 
 ```bash
 gh variable set AWS_REGION --body "us-east-1" -R DeveloperTWH/backend
-gh variable set EB_APPLICATION_NAME --body "mosaic-backend" -R DeveloperTWH/backend
-gh variable set EB_ENVIRONMENT_NAME --body "Mosaic-backend" -R DeveloperTWH/backend
+gh variable set EB_APPLICATION_NAME --body "mosaic-biz-hub-backend" -R DeveloperTWH/backend
+gh variable set EB_ENVIRONMENT_NAME --body "mosaic-backend-env" -R DeveloperTWH/backend
+gh variable set AWS_ROLE_TO_ASSUME --body "arn:aws:iam::ACCOUNT_ID:role/github-actions-eb-deploy-production" -R DeveloperTWH/backend
 ```
 
-### Production environment (optional but recommended)
+Optional — scope role ARN to the production environment only:
+
+```bash
+gh variable set AWS_ROLE_TO_ASSUME --env production --body "arn:aws:iam::ACCOUNT_ID:role/github-actions-eb-deploy-production" -R DeveloperTWH/backend
+```
+
+**Do not** add runtime application secrets (`MONGO_URI`, Stripe keys, runtime S3 keys, etc.) to GitHub. Those belong in Elastic Beanstalk environment properties.
+
+### Production environment (recommended)
 
 Create environment **`production`** with:
 
@@ -69,24 +63,64 @@ Create environment **`production`** with:
 ```bash
 gh api -X PUT repos/DeveloperTWH/backend/environments/production \
   -f wait_timer=0 \
-  -f reviewers='[]' \
   -f deployment_branch_policy='{"protected_branches":false,"custom_branch_policies":true}' \
   -f custom_branch_policies='[{"name":"main","type":"branch"}]'
 ```
 
 Add reviewers in the GitHub UI: Settings → Environments → production → Required reviewers.
 
+The deploy workflow job uses `environment: production`, which scopes the OIDC `sub` claim to `repo:DeveloperTWH/backend:environment:production`.
+
 ---
 
-## IAM policy (deploy user or role)
+## AWS IAM setup (OIDC)
 
-Minimum permissions for `einaregilsson/beanstalk-deploy`:
+Replace `ACCOUNT_ID` with your 12-digit AWS account ID.
+
+### Step A — GitHub OIDC identity provider (one-time, if not present)
+
+AWS Console → IAM → Identity providers → Add provider:
+
+- **Provider URL:** `https://token.actions.githubusercontent.com`
+- **Audience:** `sts.amazonaws.com`
+
+### Step B — IAM role trust policy (environment-scoped)
+
+Role name suggestion: `github-actions-eb-deploy-production`
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:DeveloperTWH/backend:environment:production"
+        }
+      }
+    }
+  ]
+}
+```
+
+Only workflow runs gated by the GitHub **`production`** environment can assume this role.
+
+### Step C — Permissions policy (least privilege)
+
+Attach inline policy `GitHubActionsEBDeployProduction` to the role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ElasticBeanstalkDeploy",
       "Effect": "Allow",
       "Action": [
         "elasticbeanstalk:CreateApplicationVersion",
@@ -96,22 +130,28 @@ Minimum permissions for `einaregilsson/beanstalk-deploy`:
         "elasticbeanstalk:DescribeEvents",
         "elasticbeanstalk:DescribeApplicationVersions"
       ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:ListBucket"
-      ],
       "Resource": [
-        "arn:aws:s3:::elasticbeanstalk-*",
-        "arn:aws:s3:::elasticbeanstalk-*/*"
+        "arn:aws:elasticbeanstalk:us-east-1:ACCOUNT_ID:application/mosaic-biz-hub-backend",
+        "arn:aws:elasticbeanstalk:us-east-1:ACCOUNT_ID:application/mosaic-biz-hub-backend/*",
+        "arn:aws:elasticbeanstalk:us-east-1:ACCOUNT_ID:environment/mosaic-biz-hub-backend/mosaic-backend-env"
       ]
     },
     {
+      "Sid": "ElasticBeanstalkRegionalBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::elasticbeanstalk-us-east-1-ACCOUNT_ID",
+        "arn:aws:s3:::elasticbeanstalk-us-east-1-ACCOUNT_ID/*"
+      ]
+    },
+    {
+      "Sid": "DeployWaitDescribe",
       "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
@@ -127,47 +167,50 @@ Minimum permissions for `einaregilsson/beanstalk-deploy`:
 }
 ```
 
-### OIDC trust policy (GitHub → AWS)
+Notes:
 
-Replace `ACCOUNT_ID` and restrict `sub` to this repo:
+- `s3:CreateBucket` is omitted — the regional EB bucket already exists for this application.
+- If deploy fails with `AccessDenied` on `iam:PassRole`, add a narrow `iam:PassRole` statement for the EB service/instance roles only (unlikely for version-only deploys to an existing environment).
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:DeveloperTWH/backend:*"
-        }
-      }
-    }
-  ]
-}
-```
+After creating the role, copy its ARN into the GitHub variable `AWS_ROLE_TO_ASSUME`.
+
+---
+
+## Workflow auth flow
+
+The deploy workflow (`.github/workflows/deploy-eb-production.yml`):
+
+1. Runs tests
+2. Builds a source-only ZIP
+3. Assumes the IAM role via `aws-actions/configure-aws-credentials@v4` using OIDC (`id-token: write`)
+4. Passes temporary credentials to `einaregilsson/beanstalk-deploy@v22`
+5. Runs post-deploy health probes on `https://api.mosaicbizhub.com`
+
+Push-to-`main` auto-deploy is **temporarily disabled** in the workflow (only `workflow_dispatch` runs until AWS OIDC and the GitHub `production` environment are confirmed). After first successful manual deploy, re-enable the push trigger in the workflow. When enabled, deploys are gated by the GitHub **`production`** environment.
 
 ---
 
 ## First deploy checklist
 
-1. [ ] EB application/environment names verified in AWS console
-2. [ ] GitHub secrets and variables configured
-3. [ ] `production` environment reviewers added (if using approval gate)
-4. [ ] Record current EB version as rollback baseline
-5. [ ] Run **Deploy to Elastic Beanstalk** workflow via **workflow_dispatch** on `main`
-6. [ ] Confirm workflow health probe: `GET https://api.mosaicbizhub.com/` → 200
-7. [ ] Run [production-smoke-checklist.md](production-smoke-checklist.md) minimum tier
-8. [ ] Update [deploy-verification.md](deploy-verification.md) with deployed SHA
+1. [ ] GitHub OIDC identity provider exists in AWS IAM
+2. [ ] IAM role created with environment-scoped trust policy and permissions policy above
+3. [ ] GitHub variables set (`AWS_REGION`, `EB_*`, `AWS_ROLE_TO_ASSUME`)
+4. [ ] `production` environment created with `main`-only deployment policy
+5. [ ] Required reviewers added on `production` (recommended)
+6. [ ] Record current EB version as rollback baseline
+7. [ ] Run **Deploy to Elastic Beanstalk** via **workflow_dispatch** on `main`
+8. [ ] Confirm workflow health probe: `GET https://api.mosaicbizhub.com/` → 200
+9. [ ] Run [production-smoke-checklist.md](production-smoke-checklist.md) minimum tier
+10. [ ] Update [deploy-verification.md](deploy-verification.md) with deployed SHA
 
-After first successful manual deploy, push-to-`main` auto-deploy is enabled in the workflow (gated by `production` environment when configured).
+After first successful manual deploy, re-enable push-to-`main` in the workflow; auto-deploy will then be gated by the `production` environment when configured.
+
+Remove obsolete deploy secrets if they were ever added (not used by OIDC):
+
+```bash
+gh secret delete AWS_ACCESS_KEY_ID -R DeveloperTWH/backend
+gh secret delete AWS_SECRET_ACCESS_KEY -R DeveloperTWH/backend
+```
 
 ---
 
@@ -181,7 +224,7 @@ Workflow run on merge of PR #12 (`main` @ `8b098ad`):
 | Create deployment ZIP | **PASS** |
 | Deploy to EB | **FAIL** — `AWS Access Key not specified!` |
 
-**Action required:** Repo admin adds `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets, creates `production` environment (optional reviewers), then re-runs **Deploy to Elastic Beanstalk** via Actions → Run workflow on `main`.
+**Resolution:** Migrate deploy auth to OIDC (this document). Infra owner completes IAM + GitHub variable setup, then re-runs **Deploy to Elastic Beanstalk** via Actions → Run workflow on `main`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace AWS access key secrets with OIDC role assumption via configure-aws-credentials@v4
- Update confirmed EB names (mosaic-biz-hub-backend / mosaic-backend-env)
- Temporarily disable push-to-main trigger; workflow_dispatch only until OIDC is verified
- Align deploy workflow test job to Node 22 (matches EB platform)
- Update deployment docs with IAM trust policy and setup steps

## Test plan
- [x] npm test (57/57 pass locally)
- [ ] Merge to staging
- [ ] Open staging to main PR
- [ ] Configure AWS OIDC role + GitHub variables before first manual deploy on main

Made with [Cursor](https://cursor.com)