### PR TITLE
chore: allow EB deploy reruns to reuse existing versions

### DIFF
--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -89,7 +89,7 @@ jobs:
           region: ${{ env.AWS_REGION }}
           version_label: mosaic-${{ github.sha }}
           deployment_package: deploy.zip
-          use_existing_version_if_available: false
+          use_existing_version_if_available: true
           wait_for_deployment: true
           wait_for_environment_recovery: true
 


### PR DESCRIPTION
## Summary
- Set \use_existing_version_if_available: true\ in the EB deploy workflow so manual reruns on the same commit reuse an existing application version instead of failing with a duplicate version error.

## Context
Previous deploy run created version \mosaic-9cc9f4f7e4b53d827b7cdbc7e062feec1d9cb355\ but failed during environment update. Reruns failed because the version already exists.

## Test plan
- [ ] Merge to main
- [ ] Run Deploy to Elastic Beanstalk manually on main
- [ ] Confirm deploy proceeds past version creation and completes environment update

Made with [Cursor](https://cursor.com)