### PR TITLE
Add production Sentry monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,10 +86,14 @@ APP_URL=http://localhost:3000
 
 # Optional storage/provider settings
 
-# Optional observability (production: set on EB only)
+# Optional observability (production: set on EB only — never commit real DSN)
 # SENTRY_DSN=
 # SENTRY_ENVIRONMENT=production
 # SENTRY_RELEASE=mosaic-local
+# SENTRY_TRACES_SAMPLE_RATE=0.05
+# SENTRY_PROFILES_SAMPLE_RATE=0
+# SENTRY_ENABLED=true
+# ENABLE_SENTRY_DEBUG_ROUTE=false
 
 STORAGE_PROVIDER=aws
 

--- a/app.js
+++ b/app.js
@@ -231,7 +231,15 @@ app.get('/', (req, res) => {
   res.json({ message: 'Mosaic Biz Hub API is working 9 feb ' });
 });
 
-if (process.env.SENTRY_DSN) {
+const { isSentryEnabled } = require('./instrument');
+
+if (process.env.ENABLE_SENTRY_DEBUG_ROUTE === 'true' && isSentryEnabled()) {
+  app.get('/internal/sentry-debug', (_req, _res) => {
+    throw new Error('Sentry debug route test error');
+  });
+}
+
+if (isSentryEnabled()) {
   const Sentry = require('./instrument');
   Sentry.setupExpressErrorHandler(app);
 }

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -109,12 +109,32 @@ See `mosaic-biz-frontend/.env.example` when present.
 
 ## Observability (optional but recommended)
 
-Set in Elastic Beanstalk only — **not** in GitHub Actions variables.
+Set in Elastic Beanstalk only — **not** in GitHub Actions variables. Never commit DSN values to git.
 
 | Variable | Notes |
 |----------|-------|
-| `SENTRY_DSN` | Sentry project DSN; when unset, Sentry is disabled |
+| `SENTRY_DSN` | Sentry project DSN; required to enable monitoring |
 | `SENTRY_ENVIRONMENT` | e.g. `production` |
-| `SENTRY_RELEASE` | e.g. `mosaic-<git-sha>` for deploy correlation |
+| `SENTRY_RELEASE` | e.g. `mosaic-c7955cc06f7ef87ac6d8747e053a2f5f66ff3037` (match EB version label) |
+| `SENTRY_TRACES_SAMPLE_RATE` | e.g. `0.05` — parsed as float 0–1; default `0` if unset |
+| `SENTRY_PROFILES_SAMPLE_RATE` | e.g. `0` — parsed as float 0–1; default `0` if unset |
+| `SENTRY_ENABLED` | `true` to enable when DSN is set; `false` or `0` disables Sentry |
+| `ENABLE_SENTRY_DEBUG_ROUTE` | `true` only for temporary verification; default off (`false` or unset) |
 
-After first deploy with `SENTRY_DSN`, verify a test event appears in the Sentry project dashboard. The SDK scrubs OTP, passwords, tokens, and webhook secrets from payloads ([`instrument.js`](../instrument.js)).
+**Production example (set in EB console):**
+
+```
+SENTRY_DSN=<from Sentry project settings>
+SENTRY_ENVIRONMENT=production
+SENTRY_RELEASE=mosaic-c7955cc06f7ef87ac6d8747e053a2f5f66ff3037
+SENTRY_TRACES_SAMPLE_RATE=0.05
+SENTRY_PROFILES_SAMPLE_RATE=0
+SENTRY_ENABLED=true
+ENABLE_SENTRY_DEBUG_ROUTE=false
+```
+
+After deploy with Sentry vars set, verify events in the Sentry dashboard. For a one-time test, temporarily set `ENABLE_SENTRY_DEBUG_ROUTE=true`, call `GET /internal/sentry-debug`, then set back to `false`.
+
+The SDK uses `sendDefaultPii: false` and scrubs OTP, passwords, tokens, and webhook secrets from payloads ([`instrument.js`](../instrument.js)).
+
+**Not used in backend runtime:** `SENTRY_AUTH_TOKEN` (CI/build/source maps only).

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 require('./instrument');
 
 const dns = require('dns');
@@ -8,7 +9,6 @@ if (process.platform === 'win32') {
   dns.setServers(['8.8.8.8', '1.1.1.1']);
 }
 
-require('dotenv').config();
 const app = require('./app');
 const connectDB = require('./config/Db');
 

--- a/instrument.js
+++ b/instrument.js
@@ -38,12 +38,30 @@ function scrubObject(input) {
   );
 }
 
-if (process.env.SENTRY_DSN) {
+function parseSampleRate(envVal, fallback) {
+  if (envVal === undefined || envVal === '') return fallback;
+  const parsed = Number.parseFloat(envVal);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) return fallback;
+  return parsed;
+}
+
+function isSentryEnabled() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return false;
+  const enabled = process.env.SENTRY_ENABLED;
+  if (enabled === 'false' || enabled === '0') return false;
+  return true;
+}
+
+if (isSentryEnabled()) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
     release: process.env.SENTRY_RELEASE,
-    tracesSampleRate: 0,
+    enabled: true,
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0),
+    profilesSampleRate: parseSampleRate(process.env.SENTRY_PROFILES_SAMPLE_RATE, 0),
     beforeSend(event) {
       if (event.request?.headers) {
         event.request.headers = scrubObject(event.request.headers);
@@ -60,3 +78,4 @@ if (process.env.SENTRY_DSN) {
 }
 
 module.exports = Sentry;
+module.exports.isSentryEnabled = isSentryEnabled;


### PR DESCRIPTION
## Summary

Adds production-ready Sentry error monitoring for the Express backend, building on the minimal scaffold from post-deploy hardening.

- Fix bootstrap order: `dotenv.config()` runs before `instrument.js` so local `.env` Sentry vars load correctly
- Env-driven init: `SENTRY_DSN`, `SENTRY_ENABLED`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILES_SAMPLE_RATE`
- `sendDefaultPii: false` plus existing PII scrubbing in `beforeSend`
- Express error handler via `Sentry.setupExpressErrorHandler` after all routes
- Opt-in debug route `GET /internal/sentry-debug` (only when `ENABLE_SENTRY_DEBUG_ROUTE=true`)

Push-to-main auto-deploy is **not** changed.

## EB environment variables (set in console — not GitHub)

```
SENTRY_DSN=<from Sentry project>
SENTRY_ENVIRONMENT=production
SENTRY_RELEASE=mosaic-c7955cc06f7ef87ac6d8747e053a2f5f66ff3037
SENTRY_TRACES_SAMPLE_RATE=0.05
SENTRY_PROFILES_SAMPLE_RATE=0
SENTRY_ENABLED=true
ENABLE_SENTRY_DEBUG_ROUTE=false
```

## Test plan

- [x] `npm test` — 57/57 pass
- [ ] Infra sets EB vars above (DSN never committed)
- [ ] Manual `workflow_dispatch` deploy after merge
- [ ] Optionally set `ENABLE_SENTRY_DEBUG_ROUTE=true`, call `GET /internal/sentry-debug`, confirm event in Sentry with release tag, set flag back to `false`
- [ ] Confirm `SENTRY_ENABLED=false` disables reporting and debug route

## Notes

- Caught controller errors (try/catch → 500 JSON) are not auto-reported; unhandled errors and `next(err)` paths are
- `SENTRY_AUTH_TOKEN` is for CI/build only — not used in backend runtime
- Targets `chore/post-deploy-hardening`; merge hardening first or rebase onto `main` as needed
