### PR TITLE
Issue #29: Public search/filter API readiness

### DIFF
--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -765,6 +765,9 @@ exports.getProductBusinesses = async (req, res) => {
       state,
       country,
       productCategory,
+      tag,
+      tags,
+      zip,
       page = 1,
       limit = 10,
     } = req.query;
@@ -782,6 +785,32 @@ exports.getProductBusinesses = async (req, res) => {
     if (productCategory) {
       const categoryIds = productCategory.split(",");
       filters.productCategories = { $in: categoryIds };
+    }
+
+    const tagList = String(tags || tag || "")
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+    if (tagList.length) {
+      const tagClause = {
+        $or: tagList.map((item) => ({
+          tags: new RegExp(`^${item.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "i"),
+        })),
+      };
+      if (filters.businessName) {
+        filters.$and = [{ businessName: filters.businessName }, tagClause];
+        delete filters.businessName;
+      } else {
+        Object.assign(filters, tagClause);
+      }
+    }
+
+    const normalizedZip = String(zip || "").trim();
+    if (normalizedZip) {
+      filters["address.zipCode"] = new RegExp(
+        `^${normalizedZip.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+        "i"
+      );
     }
 
     const skip = (parseInt(page) - 1) * parseInt(limit);

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -15,6 +15,19 @@ const {
   toPublicListingDetail,
   toPublicBusinessCard,
 } = require('../lib/listing/publicListingDto');
+const {
+  parsePublicSearchQuery,
+  detectUnsupportedGeoParams,
+  shouldIncludeListingType,
+  resolveBusinessIdsByKeyword,
+  resolveCombinedBusinessFilters,
+  intersectBusinessIdSets,
+  loadVerifiedByBusinessIds,
+  loadTagsByBusinessIds,
+  narrowVisibleBusinessIds,
+  mergeBusinessIdFilter,
+  buildKeywordRegex,
+} = require('../lib/listing/publicSearchFilters');
 
 const getVisibleBusinessIds = async () => {
   const businesses = await Business.find({
@@ -23,6 +36,69 @@ const getVisibleBusinessIds = async () => {
 
   return businesses.map((business) => business._id.toString());
 };
+
+const emptyListResponse = (page = 1) => ({
+  success: true,
+  total: 0,
+  page: parseInt(page, 10),
+  totalPages: 0,
+  data: [],
+});
+
+async function applyBusinessScopeToFilters(filters, visibleBusinessIds, query, explicitBusinessId, options = {}) {
+  const narrowed = await narrowVisibleBusinessIds(visibleBusinessIds, query, options);
+  if (narrowed.empty) return { empty: true };
+
+  const merged = mergeBusinessIdFilter(explicitBusinessId || filters.businessId, narrowed.businessIds);
+  if (merged.empty) return { empty: true };
+
+  filters.businessId = merged.filter;
+  return { empty: false };
+}
+
+async function mapProductsWithBusinessMeta(products, listingType = 'product') {
+  const businessIds = [...new Set(
+    products
+      .map((item) => {
+        const id = item.businessId?._id || item.businessId;
+        return id ? String(id) : null;
+      })
+      .filter(Boolean)
+  )];
+
+  const [verifiedMap, tagsMap, businesses] = await Promise.all([
+    loadVerifiedByBusinessIds(businessIds),
+    loadTagsByBusinessIds(businessIds),
+    Business.find({ _id: { $in: businessIds }, isActive: true })
+      .select('_id badge tags')
+      .lean(),
+  ]);
+
+  const badgeByBusinessId = new Map(
+    businesses.map((business) => [business._id.toString(), business.badge || null])
+  );
+
+  return products.map((product) => {
+    const businessKey = product.businessId?._id
+      ? String(product.businessId._id)
+      : String(product.businessId || '');
+    const cardOptions = { listingType };
+    if (verifiedMap.has(businessKey)) cardOptions.verified = verifiedMap.get(businessKey);
+
+    const enriched = {
+      ...product,
+      badge: badgeByBusinessId.get(businessKey) || product.badge || null,
+    };
+
+    if (product.businessId && typeof product.businessId === 'object' && tagsMap.has(businessKey)) {
+      enriched.businessId = { ...product.businessId, tags: tagsMap.get(businessKey) };
+    } else if (tagsMap.has(businessKey)) {
+      enriched.tags = tagsMap.get(businessKey);
+    }
+
+    return toPublicListingCard(enriched, cardOptions);
+  });
+}
 
 exports.getAllServices = async (req, res) => {
   try {
@@ -45,9 +121,13 @@ exports.getAllServices = async (req, res) => {
       limit = 10,
       price,
       badge,
+      tag,
+      tags,
+      zip,
+      verified,
     } = req.query;
 
-    const filters = {};
+    const filters = { isPublished: true };
     const badgeValueMap = {
       silver: 'Silver',
       gold: 'Gold',
@@ -65,20 +145,30 @@ exports.getAllServices = async (req, res) => {
     }
 
     if (minorityType) filters.minorityType = minorityType;
-    if (city) filters['contact.address'] = { $regex: city, $options: 'i' };
 
     const visibleBusinessIds = await getVisibleBusinessIds();
     if (!visibleBusinessIds.length) {
-      return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+      return res.json(emptyListResponse(page));
     }
 
     if (businessId) {
       if (!visibleBusinessIds.includes(String(businessId))) {
-        return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+        return res.json(emptyListResponse(page));
       }
       filters.businessId = businessId;
     } else {
       filters.businessId = { $in: visibleBusinessIds };
+    }
+
+    const scoped = await applyBusinessScopeToFilters(
+      filters,
+      visibleBusinessIds,
+      req.query,
+      businessId,
+      { includeLocation: true }
+    );
+    if (scoped.empty) {
+      return res.json(emptyListResponse(page));
     }
 
     // Category filtering - accept both slug and ID
@@ -435,9 +525,13 @@ exports.getAllFood = async (req, res) => {
       outOfStock = false,
       price,
       badge,
+      tag,
+      tags,
+      zip,
+      verified,
     } = req.query;
 
-    const filters = {};
+    const filters = { isPublished: true };
     const badgeValueMap = {
       silver: 'Silver',
       gold: 'Gold',
@@ -458,7 +552,30 @@ exports.getAllFood = async (req, res) => {
     if (state) filters['address.state'] = { $regex: state, $options: 'i' };
     if (country) filters['address.country'] = { $regex: country, $options: 'i' };
 
-    if (businessId) filters.businessId = businessId;
+    const visibleBusinessIds = await getVisibleBusinessIds();
+    if (!visibleBusinessIds.length) {
+      return res.json(emptyListResponse(page));
+    }
+
+    if (businessId) {
+      if (!visibleBusinessIds.includes(String(businessId))) {
+        return res.json(emptyListResponse(page));
+      }
+      filters.businessId = businessId;
+    } else {
+      filters.businessId = { $in: visibleBusinessIds };
+    }
+
+    const scoped = await applyBusinessScopeToFilters(
+      filters,
+      visibleBusinessIds,
+      req.query,
+      businessId,
+      { includeLocation: false }
+    );
+    if (scoped.empty) {
+      return res.json(emptyListResponse(page));
+    }
 
     // Category filtering
     if (categoryId) {
@@ -491,7 +608,9 @@ exports.getAllFood = async (req, res) => {
     }
 
     // Price
-    if (price) {
+    if (price === 'all') {
+      // Explicit opt-out of default MVP price window
+    } else if (price) {
       const priceRange = price.split('-');
       if (priceRange.length === 2) {
         const minPrice = parseFloat(priceRange[0]);
@@ -511,6 +630,7 @@ exports.getAllFood = async (req, res) => {
         .map((value) => badgeValueMap[value] || value);
 
       const badgeBusinesses = await Business.find({
+        isActive: true,
         badge: { $in: requestedBadges }
       }).select('_id').lean();
 
@@ -845,150 +965,24 @@ const ProductCategory = require('../models/ProductCategory');
 const ProductSubcategory = require('../models/ProductSubcategory');
 const MinorityType = require('../models/MinorityType');
 
-const escapeRegex = (value = '') => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+async function resolveCategoryIdForListingType(listingType, { categoryId, categorySlug }) {
+  if (categoryId) return categoryId;
+  if (!categorySlug) return null;
 
-const buildKeywordRegex = (value = '') => new RegExp(escapeRegex(value.trim()), 'i');
-
-const buildFlexibleMatchRegex = (value = '') => {
-  const trimmed = String(value || '').trim();
-  if (!trimmed) return null;
-
-  const normalized = trimmed.replace(/[-_,]+/g, ' ').replace(/\s+/g, ' ').trim();
-  const tokens = normalized.split(' ').filter(Boolean);
-
-  if (tokens.length > 1) {
-    return new RegExp(tokens.map(escapeRegex).join('[\\s,-]*'), 'i');
+  if (listingType === 'product') {
+    const category = await ProductCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    return category?._id || null;
   }
-
-  if (normalized.length >= 5) {
-    return new RegExp(normalized.split('').map(escapeRegex).join('[\\s,-]*'), 'i');
+  if (listingType === 'service') {
+    const category = await ServiceCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    return category?._id || null;
   }
-
-  return new RegExp(escapeRegex(normalized), 'i');
-};
-
-const resolveBusinessIdsByKeyword = async (keyword) => {
-  const keywordRegex = buildFlexibleMatchRegex(keyword);
-  if (!keywordRegex) {
-    return [];
+  if (listingType === 'food') {
+    const category = await FoodCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    return category?._id || null;
   }
-
-  const [businessMatches, vendorMatches] = await Promise.all([
-    Business.find({
-      isActive: true,
-      $or: [
-        { businessName: keywordRegex },
-        { description: keywordRegex },
-        { tags: keywordRegex },
-      ],
-    }).select('_id').lean(),
-    VendorOnboardingStage1.find({
-      businessId: { $exists: true, $ne: null },
-      $or: [
-        { businessName: keywordRegex },
-        { businessBio: keywordRegex },
-      ],
-    }).select('businessId').lean(),
-  ]);
-
-  return [...new Set([
-    ...businessMatches.map((item) => item._id.toString()),
-    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
-  ])].map((id) => new mongoose.Types.ObjectId(id));
-};
-
-const resolveBusinessIdsForPublicSearch = async ({ location, minorityType }) => {
-  if (!location && !minorityType) {
-    return null;
-  }
-
-  const normalizedMinority = minorityType.replace(/-/g, ' ').trim();
-  const locationRegex = location ? buildFlexibleMatchRegex(location) : null;
-  const minorityRegex = minorityType ? buildFlexibleMatchRegex(normalizedMinority) : null;
-
-  let minorityTypeIds = [];
-  if (minorityType) {
-    if (mongoose.Types.ObjectId.isValid(minorityType)) {
-      minorityTypeIds.push(new mongoose.Types.ObjectId(minorityType));
-    }
-
-    const minorityMatches = await MinorityType.find({
-      name: minorityRegex,
-      isActive: true,
-    }).select('_id').lean();
-
-    minorityTypeIds.push(...minorityMatches.map((item) => item._id));
-    minorityTypeIds = [...new Set(minorityTypeIds.map((id) => id.toString()))]
-      .map((id) => new mongoose.Types.ObjectId(id));
-  }
-
-  const matchedSets = [];
-
-  if (locationRegex) {
-    const [businessLocationMatches, vendorLocationMatches] = await Promise.all([
-      Business.find({
-        isActive: true,
-        $or: [
-          { businessName: locationRegex },
-          { 'address.street': locationRegex },
-          { 'address.city': locationRegex },
-          { 'address.state': locationRegex },
-          { 'address.country': locationRegex },
-        ],
-      }).select('_id').lean(),
-      VendorOnboardingStage1.find({
-        businessId: { $exists: true, $ne: null },
-        $or: [
-          { businessName: locationRegex },
-          { 'address.street': locationRegex },
-          { 'address.city': locationRegex },
-          { 'address.state': locationRegex },
-          { 'address.country': locationRegex },
-        ],
-      }).select('businessId').lean(),
-    ]);
-
-    const locationIds = new Set([
-      ...businessLocationMatches.map((item) => item._id.toString()),
-      ...vendorLocationMatches.map((item) => item.businessId?.toString()).filter(Boolean),
-    ]);
-
-    matchedSets.push(locationIds);
-  }
-
-  if (minorityType) {
-    const [businessMinorityMatches, vendorMinorityMatches] = await Promise.all([
-      Business.find({
-        isActive: true,
-        ...(minorityTypeIds.length ? { minorityType: { $in: minorityTypeIds } } : { _id: null }),
-      }).select('_id').lean(),
-      VendorOnboardingStage1.find({
-        businessId: { $exists: true, $ne: null },
-        minorityCategories: { $elemMatch: { $regex: minorityRegex } },
-      }).select('businessId').lean(),
-    ]);
-
-    const minorityIds = new Set([
-      ...businessMinorityMatches.map((item) => item._id.toString()),
-      ...vendorMinorityMatches.map((item) => item.businessId?.toString()).filter(Boolean),
-    ]);
-
-    matchedSets.push(minorityIds);
-  }
-
-  if (!matchedSets.length) {
-    return null;
-  }
-
-  const [firstSet, ...restSets] = matchedSets;
-  const intersectedIds = [...firstSet].filter((id) => restSets.every((set) => set.has(id)));
-
-  if (!intersectedIds.length) {
-    return [];
-  }
-
-  return intersectedIds.map((id) => new mongoose.Types.ObjectId(id));
-};
+  return null;
+}
 
 exports.getAllProducts = async (req, res) => {
   try {
@@ -1010,6 +1004,10 @@ exports.getAllProducts = async (req, res) => {
       outOfStock = false,
       price,
       badge,
+      tag,
+      tags,
+      zip,
+      verified,
     } = req.query;
 
     const filters = { isDeleted: false, isPublished: true };
@@ -1038,11 +1036,22 @@ exports.getAllProducts = async (req, res) => {
     }
     if (businessId) {
       if (!visibleBusinessIds.includes(String(businessId))) {
-        return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+        return res.json(emptyListResponse(page));
       }
       filters.businessId = businessId;
     } else {
       filters.businessId = { $in: visibleBusinessIds };
+    }
+
+    const scoped = await applyBusinessScopeToFilters(
+      filters,
+      visibleBusinessIds,
+      req.query,
+      businessId,
+      { includeLocation: false }
+    );
+    if (scoped.empty) {
+      return res.json(emptyListResponse(page));
     }
 
     // Category filtering - accept both slug and ID
@@ -1051,7 +1060,7 @@ exports.getAllProducts = async (req, res) => {
     } else if (categorySlug) {
       const category = await ProductCategory.findOne({ slug: categorySlug });
       if (category) filters.categoryId = category._id;
-      else return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+      else return res.json(emptyListResponse(page));
     }
 
     // Subcategory filtering - accept both slug and ID
@@ -1060,23 +1069,12 @@ exports.getAllProducts = async (req, res) => {
     } else if (subcategorySlug) {
       const subcategory = await ProductSubcategory.findOne({ slug: subcategorySlug });
       if (subcategory) filters.subcategoryId = subcategory._id;
-      else return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+      else return res.json(emptyListResponse(page));
     }
 
     if (offers === 'true') filters.features = { $in: ['Offers Available'] };
     if (outOfStock === 'true') filters.stockQuantity = { $lte: 0 };
 
-    // Price filtering
-    // if (price) {
-    //   const priceRange = price.split('-');
-    //   if (priceRange.length === 2) {
-    //     const minPrice = parseFloat(priceRange[0]);
-    //     const maxPrice = parseFloat(priceRange[1]);
-    //     filters.price = { $gte: minPrice, $lte: maxPrice };
-    //   }
-    // } else {
-    //   filters.price = { $gte: 0, $lte: 200 };
-    // }
     // Price filtering (only apply if user sends price query)
 if (price) {
   const priceRange = price.split('-');
@@ -1140,37 +1138,13 @@ if (price) {
 
     let products = await Product.find(filters)
       .select('title description coverImage slug brand categoryId subcategoryId price businessId')
+      .populate('businessId', 'businessName logo badge address tags')
       .sort(sortOption)
       .skip(skip)
       .limit(parseInt(limit))
       .lean();
 
-    const businessIds = [...new Set(
-      products
-        .map((product) => product.businessId?.toString())
-        .filter(Boolean)
-    )];
-
-    const businesses = await Business.find({
-      _id: { $in: businessIds },
-      isActive: true,
-    })
-      .select('_id badge')
-      .lean();
-
-    const badgeByBusinessId = new Map(
-      businesses.map((business) => [business._id.toString(), business.badge || null])
-    );
-
-    products = products.map((product) =>
-      toPublicListingCard(
-        {
-          ...product,
-          badge: badgeByBusinessId.get(product.businessId?.toString()) || null,
-        },
-        { listingType: 'product' }
-      )
-    );
+    products = await mapProductsWithBusinessMeta(products, 'product');
 
     const total = await Product.countDocuments(filters);
     const totalPages = Math.ceil(total / limit);
@@ -1208,6 +1182,10 @@ exports.getProductsByFilters = async (req, res) => {
       page = 1,
       limit = 10,
       outOfStock = false,
+      tag,
+      tags,
+      zip,
+      verified,
     } = req.query;
 
     const filters = { isDeleted: false, isPublished: true };
@@ -1254,6 +1232,18 @@ exports.getProductsByFilters = async (req, res) => {
     } else {
       filters.businessId = { $in: visibleBusinessIds };
     }
+
+    const scoped = await applyBusinessScopeToFilters(
+      filters,
+      visibleBusinessIds,
+      req.query,
+      businessId,
+      { includeLocation: false }
+    );
+    if (scoped.empty) {
+      return res.json({ success: true, total: 0, data: [] });
+    }
+
     if (offers === 'true') filters.features = { $in: ['Offers Available'] };
     if (outOfStock === 'true') filters.stockQuantity = { $lte: 0 };
 
@@ -1322,13 +1312,13 @@ exports.getProductsByFilters = async (req, res) => {
     // Filter out products with no variants
     products = products.filter(product => product.variants && product.variants.length > 0);
 
-    const total = await Product.countDocuments(filters);
+    const filteredTotal = products.length;
 
     res.json({
       success: true,
-      total: products.length,
+      total: filteredTotal,
       page: parseInt(page),
-      totalPages: Math.ceil(total / limit),
+      totalPages: Math.ceil(filteredTotal / limit) || 0,
       data: products.map((product) => toPublicListingCard(product, { listingType: 'product' })),
     });
 
@@ -1632,61 +1622,58 @@ exports.getProductsByBusinessId = async (req, res) => {
 
 exports.searchPublicListings = async (req, res) => {
   try {
-    const {
-      keyword = '',
-      search = '',
-      location = '',
-      minorityType = '',
-      limit = 10,
-    } = req.query;
+    const parsed = parsePublicSearchQuery(req.query);
+    const unsupported = detectUnsupportedGeoParams(req.query);
+    const emptyPayload = {
+      success: true,
+      filters: {
+        keyword: parsed.keyword,
+        location: parsed.location,
+        city: parsed.city,
+        state: parsed.state,
+        country: parsed.country,
+        zip: parsed.zip,
+        minorityType: parsed.minorityType,
+        categoryId: parsed.categoryId,
+        categorySlug: parsed.categorySlug,
+        tag: parsed.tag,
+        tags: parsed.tags,
+        verified: parsed.verified,
+        listingType: parsed.listingType,
+        page: parsed.page,
+        limit: parsed.limit,
+        unsupported,
+      },
+      totals: { all: 0, products: 0, services: 0, foods: 0 },
+      data: { products: [], services: [], foods: [] },
+    };
 
-    const trimmedKeyword = String(keyword || search || '').trim();
-    const trimmedLocation = String(location || '').trim();
-    const trimmedMinorityType = String(minorityType || '').trim();
-    const parsedLimit = Math.max(1, Math.min(50, parseInt(limit, 10) || 10));
-
-    const [filteredBusinessIds, keywordBusinessIds] = await Promise.all([
-      resolveBusinessIdsForPublicSearch({
-        location: trimmedLocation,
-        minorityType: trimmedMinorityType,
+    const [combinedBusinessIds, keywordBusinessIds] = await Promise.all([
+      resolveCombinedBusinessFilters({
+        location: parsed.location,
+        city: parsed.city,
+        state: parsed.state,
+        country: parsed.country,
+        zip: parsed.zip,
+        minorityType: parsed.minorityType,
+        tag: parsed.tag,
+        tags: parsed.tags,
+        verified: parsed.verified,
       }),
-      trimmedKeyword ? resolveBusinessIdsByKeyword(trimmedKeyword) : Promise.resolve([]),
+      parsed.keyword ? resolveBusinessIdsByKeyword(parsed.keyword) : Promise.resolve([]),
     ]);
 
-    if (Array.isArray(filteredBusinessIds) && !filteredBusinessIds.length) {
-      return res.json({
-        success: true,
-        filters: {
-          keyword: trimmedKeyword,
-          location: trimmedLocation,
-          minorityType: trimmedMinorityType,
-        },
-        totals: {
-          all: 0,
-          products: 0,
-          services: 0,
-          foods: 0,
-        },
-        data: {
-          products: [],
-          services: [],
-          foods: [],
-        },
-      });
+    if (Array.isArray(combinedBusinessIds) && !combinedBusinessIds.length) {
+      return res.json(emptyPayload);
     }
 
-    const keywordRegex = trimmedKeyword ? buildKeywordRegex(trimmedKeyword) : null;
+    const keywordRegex = parsed.keyword ? buildKeywordRegex(parsed.keyword) : null;
 
-    let allowedBusinessIds = null;
+    let allowedBusinessIds = combinedBusinessIds;
     let useBusinessKeywordOnly = false;
 
-    if (Array.isArray(filteredBusinessIds)) {
-      allowedBusinessIds = filteredBusinessIds;
-    }
-
     if (Array.isArray(allowedBusinessIds) && keywordBusinessIds.length) {
-      const allowedSet = new Set(allowedBusinessIds.map((id) => id.toString()));
-      allowedBusinessIds = keywordBusinessIds.filter((id) => allowedSet.has(id.toString()));
+      allowedBusinessIds = intersectBusinessIdSets(allowedBusinessIds, keywordBusinessIds);
       useBusinessKeywordOnly = true;
     } else if (!Array.isArray(allowedBusinessIds) && keywordBusinessIds.length) {
       allowedBusinessIds = keywordBusinessIds;
@@ -1698,25 +1685,7 @@ exports.searchPublicListings = async (req, res) => {
       : {};
 
     if (Array.isArray(allowedBusinessIds) && !allowedBusinessIds.length) {
-      return res.json({
-        success: true,
-        filters: {
-          keyword: trimmedKeyword,
-          location: trimmedLocation,
-          minorityType: trimmedMinorityType,
-        },
-        totals: {
-          all: 0,
-          products: 0,
-          services: 0,
-          foods: 0,
-        },
-        data: {
-          products: [],
-          services: [],
-          foods: [],
-        },
-      });
+      return res.json(emptyPayload);
     }
 
     const productFilter = {
@@ -1724,105 +1693,156 @@ exports.searchPublicListings = async (req, res) => {
       isPublished: true,
       ...baseBusinessFilter,
     };
-
     const serviceFilter = {
       isPublished: true,
       ...baseBusinessFilter,
     };
-
     const foodFilter = {
       isPublished: true,
       ...baseBusinessFilter,
     };
 
-    if (keywordRegex) {
-      const productKeywordOr = [
-        { title: keywordRegex },
-        { description: keywordRegex },
-        { brand: keywordRegex },
-      ];
+    const resolvedCategoryId = await resolveCategoryIdForListingType(parsed.listingType === 'all' ? 'product' : parsed.listingType, parsed)
+      || (parsed.categoryId || null);
 
-      const serviceKeywordOr = [
-        { title: keywordRegex },
-        { description: keywordRegex },
-        { 'services.name': keywordRegex },
-        { 'services.description': keywordRegex },
-      ];
-
-      const foodKeywordOr = [
-        { title: keywordRegex },
-        { description: keywordRegex },
-        { businessName: keywordRegex },
-        { foodType: keywordRegex },
-        { brand: keywordRegex },
-      ];
-
-      if (!useBusinessKeywordOnly) {
-        productFilter.$or = productKeywordOr;
-        serviceFilter.$or = serviceKeywordOr;
-        foodFilter.$or = foodKeywordOr;
+    if (parsed.categoryId || parsed.categorySlug) {
+      if (shouldIncludeListingType(parsed.listingType, 'product')) {
+        const productCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('product', parsed);
+        if (productCategoryId) {
+          productFilter.categoryId = productCategoryId;
+        } else if (parsed.categorySlug) {
+          return res.json(emptyPayload);
+        }
+      }
+      if (shouldIncludeListingType(parsed.listingType, 'service')) {
+        const serviceCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('service', parsed);
+        if (serviceCategoryId) {
+          serviceFilter.categoryId = serviceCategoryId;
+        } else if (parsed.categorySlug) {
+          return res.json(emptyPayload);
+        }
+      }
+      if (shouldIncludeListingType(parsed.listingType, 'food')) {
+        const foodCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('food', parsed);
+        if (foodCategoryId) {
+          foodFilter.categoryId = foodCategoryId;
+        } else if (parsed.categorySlug) {
+          return res.json(emptyPayload);
+        }
       }
     }
 
-    const [products, services, foods] = await Promise.all([
-      Product.find(productFilter)
-        .select('title description coverImage slug brand price businessId')
-        .populate({
-          path: 'businessId',
-          select: 'businessName logo badge address minorityType',
-          populate: {
-            path: 'minorityType',
-            select: 'name',
-          },
-        })
-        .sort({ createdAt: -1 })
-        .limit(parsedLimit)
-        .lean(),
-      Service.find(serviceFilter)
-        .select('title description services coverImage slug price location contact businessId averageRating totalReviews')
-        .populate({
-          path: 'businessId',
-          select: 'businessName logo badge address minorityType',
-          populate: {
-            path: 'minorityType',
-            select: 'name',
-          },
-        })
-        .sort({ createdAt: -1 })
-        .limit(parsedLimit)
-        .lean(),
-      Food.find(foodFilter)
-        .select('title description coverImage slug price businessId foodType brand')
-        .populate({
-          path: 'businessId',
-          select: 'businessName logo badge address minorityType',
-          populate: {
-            path: 'minorityType',
-            select: 'name',
-          },
-        })
-        .sort({ createdAt: -1 })
-        .limit(parsedLimit)
-        .lean(),
-    ]);
+    if (keywordRegex && !useBusinessKeywordOnly) {
+      if (shouldIncludeListingType(parsed.listingType, 'product')) {
+        productFilter.$or = [
+          { title: keywordRegex },
+          { description: keywordRegex },
+          { brand: keywordRegex },
+        ];
+      }
+      if (shouldIncludeListingType(parsed.listingType, 'service')) {
+        serviceFilter.$or = [
+          { title: keywordRegex },
+          { description: keywordRegex },
+          { 'services.name': keywordRegex },
+          { 'services.description': keywordRegex },
+        ];
+      }
+      if (shouldIncludeListingType(parsed.listingType, 'food')) {
+        foodFilter.$or = [
+          { title: keywordRegex },
+          { description: keywordRegex },
+          { businessName: keywordRegex },
+          { foodType: keywordRegex },
+          { brand: keywordRegex },
+        ];
+      }
+    }
+
+    const skip = (parsed.page - 1) * parsed.limit;
+    const businessPopulate = {
+      path: 'businessId',
+      select: 'businessName logo badge address minorityType tags',
+      populate: { path: 'minorityType', select: 'name' },
+    };
+
+    const queryJobs = [];
+    if (shouldIncludeListingType(parsed.listingType, 'product')) {
+      queryJobs.push(
+        Product.find(productFilter)
+          .select('title description coverImage slug brand price businessId categoryId')
+          .populate(businessPopulate)
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(parsed.limit)
+          .lean()
+      );
+    } else {
+      queryJobs.push(Promise.resolve([]));
+    }
+
+    if (shouldIncludeListingType(parsed.listingType, 'service')) {
+      queryJobs.push(
+        Service.find(serviceFilter)
+          .select('title description services coverImage slug price location contact businessId averageRating totalReviews categoryId')
+          .populate(businessPopulate)
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(parsed.limit)
+          .lean()
+      );
+    } else {
+      queryJobs.push(Promise.resolve([]));
+    }
+
+    if (shouldIncludeListingType(parsed.listingType, 'food')) {
+      queryJobs.push(
+        Food.find(foodFilter)
+          .select('title description coverImage slug price businessId foodType brand categoryId')
+          .populate(businessPopulate)
+          .sort({ createdAt: -1 })
+          .skip(skip)
+          .limit(parsed.limit)
+          .lean()
+      );
+    } else {
+      queryJobs.push(Promise.resolve([]));
+    }
+
+    const [products, services, foods] = await Promise.all(queryJobs);
+
+    const allBusinessIds = [...products, ...services, ...foods]
+      .map((item) => item.businessId?._id || item.businessId)
+      .filter(Boolean)
+      .map(String);
+    const verifiedMap = await loadVerifiedByBusinessIds(allBusinessIds);
+
+    const mapCards = (items, listingType) => items.map((item) => {
+      const businessKey = item.businessId?._id
+        ? String(item.businessId._id)
+        : String(item.businessId || '');
+      const options = { listingType };
+      if (verifiedMap.has(businessKey)) options.verified = verifiedMap.get(businessKey);
+      return toPublicListingCard(item, options);
+    });
+
+    const productCards = mapCards(products, 'product');
+    const serviceCards = mapCards(services, 'service');
+    const foodCards = mapCards(foods, 'food');
 
     return res.json({
       success: true,
-      filters: {
-        keyword: trimmedKeyword,
-        location: trimmedLocation,
-        minorityType: trimmedMinorityType,
-      },
+      filters: emptyPayload.filters,
       totals: {
-        all: products.length + services.length + foods.length,
-        products: products.length,
-        services: services.length,
-        foods: foods.length,
+        all: productCards.length + serviceCards.length + foodCards.length,
+        products: productCards.length,
+        services: serviceCards.length,
+        foods: foodCards.length,
       },
       data: {
-        products: products.map((item) => toPublicListingCard(item, { listingType: 'product' })),
-        services: services.map((item) => toPublicListingCard(item, { listingType: 'service' })),
-        foods: foods.map((item) => toPublicListingCard(item, { listingType: 'food' })),
+        products: productCards,
+        services: serviceCards,
+        foods: foodCards,
       },
     });
   } catch (err) {

--- a/docs/MVP_BACKEND_API_AUDIT.md
+++ b/docs/MVP_BACKEND_API_AUDIT.md
@@ -257,7 +257,7 @@ Full list: [`models/`](../models/). No Prisma/SQL/Zod schema layer.
 | [#26](https://github.com/Techware-Hut/mosaic-backend/issues/26) | Backend MVP API audit | This document | N/A | N/A | — |
 | [#27](https://github.com/Techware-Hut/mosaic-backend/issues/27) | Backend MVP smoke proof pack | [production-smoke-checklist.md](production-smoke-checklist.md), [production-proof-pack-template.md](production-proof-pack-template.md) | Partial (deploy workflow health + CORS featured-products) | Full P0–P6 on production | No single consolidated proof pack filled for this release |
 | [#28](https://github.com/Techware-Hut/mosaic-backend/issues/28) | Marketplace data contract | Implemented in PR #37 — DTO layer + controller wiring | 20 marketplace tests ([TEST_MATRIX.md](TEST_MATRIX.md)) | Card/detail field audit vs frontend on prod | See [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md) |
-| [#29](https://github.com/Techware-Hut/mosaic-backend/issues/29) | Search/filter API readiness | `GET /api/public/search`, `GET /api/products/filters` | None | Query param smoke on prod | Location = **text regex** on address fields; **no ZIP/geolocation** |
+| [#29](https://github.com/Techware-Hut/mosaic-backend/issues/29) | Search/filter API readiness | `GET /api/public/search`, list endpoints, `GET /api/products/filters` | 15 search-filter tests ([TEST_MATRIX.md](TEST_MATRIX.md)) | Query param smoke on prod after merge | **ZIP exact** on `address.zipCode`; **no radius/geolocation**; tag + verified filters; see [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) |
 | [#30](https://github.com/Techware-Hut/mosaic-backend/issues/30) | Vendor onboarding + email | Full onboarding + `WellcomeMailer.js` | 6 vendor/admin tests | Payment webhook + approval email on prod | Submit validation reduced (business name only at server) |
 | [#31](https://github.com/Techware-Hut/mosaic-backend/issues/31) | Vendor profile/listings/orders | Business, product, order vendor routes | Field allowlist + business sync tests | End-to-end vendor flows | Listing tier limits documented in [tier-listing-limit-implementation.md](tier-listing-limit-implementation.md) — runtime enforcement unverified |
 | [#32](https://github.com/Techware-Hut/mosaic-backend/issues/32) | Stripe Connect checkout | Connect + 5 webhooks + order PI | Webhook routing/signature tests | Live PI + split payout on prod | `/stripe/*` routes **lack auth** — security risk |
@@ -282,7 +282,7 @@ Full list: [`models/`](../models/). No Prisma/SQL/Zod schema layer.
 - Reviews: list (public), upsert/delete (customer) for product, service, food
 - Admin: vendor pending queue, business approve, category CRUD, featured product toggle
 - Email utilities for OTP, welcome, order confirmation, listing approval, onboarding
-- **77 automated tests** (auth DTOs, vendor middleware, webhook wiring, admin guards, business sync, marketplace DTOs)
+- **92 automated tests** (auth DTOs, vendor middleware, webhook wiring, admin guards, business sync, marketplace DTOs, search filters)
 
 ---
 
@@ -311,13 +311,13 @@ Cannot be proven by CI alone (mocked MongoDB/Stripe/email):
 | Gap | Detail |
 |-----|--------|
 | No `/api/products/featured` | By design — use **`GET /api/featured-products`** |
-| No admin tags API | Tags on `Business.tags`; searchable in public search only |
+| No admin tags API | Tags on `Business.tags`; filterable via public search/list (#29 branch) |
 | No admin sales/revenue summary | Only raw `GET /api/orders/admin` |
-| No ZIP/geolocation filter | Location search is substring match on address/city/state/country |
+| No radius/geolocation filter | Location search is text regex; ZIP exact on `address.zipCode` (#29 branch); no lat/lng radius |
 | No review follow-up email | Post-purchase review prompt not found in mail utilities |
 | Unauthenticated routes | `GET /api/admin/categories`, `POST /stripe/*`, `POST /api/payments/create-payment-intent` |
 | Reduced submit validation | `validateStage1Payload` enforces business name only (most rules commented out) |
-| No automated tests | Marketplace DTOs, search filters, reviews, checkout, email content |
+| Partial automated tests | Search filters covered (#29 branch); reviews, checkout, email content still untested |
 | Unmounted CMS router | `routes/cms/cmsRoutes.js` dead code |
 
 ---
@@ -400,7 +400,7 @@ See [TEST_MATRIX.md](TEST_MATRIX.md) for manual smoke mapping.
 Aligned to issue dependencies (audit → implementation → smoke proof):
 
 1. ~~**#28 Marketplace data contract**~~ — **Done (PR #37):** null-safe DTOs for public listing/featured/detail; see [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md)
-2. **#29 Search/filter** — document supported query params; add tests for category/tag/location text filter; document ZIP gap explicitly (do not invent geolocation)
+2. ~~**#29 Search/filter**~~ — **Done (branch `sprint/backend-search-filter-readiness`):** shared filter module, ZIP exact, tag/verified, tests + [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md); geolocation explicitly unsupported
 3. **#30 Vendor onboarding email** — verify approval/rejection emails fire on finalize; tighten submit validation if product requires
 4. **#31 Vendor MVP APIs** — confirm listing tier limit enforcement; vendor order list smoke
 5. **#32 Stripe Connect runtime** — prod smoke for checkout + webhooks; remediate unauthenticated `/stripe/*` routes

--- a/docs/MVP_BACKEND_SEARCH_FILTER_READINESS.md
+++ b/docs/MVP_BACKEND_SEARCH_FILTER_READINESS.md
@@ -1,0 +1,153 @@
+# MVP Backend Search & Filter Readiness (Issue #29)
+
+**Branch:** `sprint/backend-search-filter-readiness`  
+**Status:** Implemented on branch — **not merged or deployed to production**
+
+## Purpose
+
+Document honest, test-backed search/filter behavior for public marketplace endpoints. Shared helpers live in `lib/listing/publicSearchFilters.js`.
+
+**Principle:** Do not invent geolocation, radius search, or fake `distanceMiles` fields. ZIP filtering is **exact match** on `address.zipCode` only.
+
+---
+
+## Endpoint matrix
+
+| Endpoint | Keyword | Category | Tag | City/State/Country | ZIP exact | Verified | Pagination | Notes |
+|----------|---------|----------|-----|-------------------|-----------|----------|------------|-------|
+| `GET /api/public/search` | yes (`keyword`, `search`) | yes (`categoryId`, `categorySlug`) | yes (`tag`, `tags`) | yes (`location` regex + `city`, `state`, `country`) | yes (`zip`) | yes (`verified=true`) | `page`, `limit` | `listingType=product\|service\|food\|all`; geo params listed in `filters.unsupported` |
+| `GET /api/products/list` | yes | yes | yes | yes (listing `address.*`) | yes | yes | `page`, `limit` | Visible-business gate; `businessId.tags` populated on cards |
+| `GET /api/products/filters` | same as list | same | same | same | same | same | yes | `totalPages` uses post-variant-filter count |
+| `GET /api/services/list` | yes | yes | yes | yes (business address join) | yes | yes | yes | `isPublished: true`; state/country via business scope |
+| `GET /api/food/list` | yes | yes | yes | yes | yes | yes | yes | Visible-business gate; `isPublished: true`; default price 0–200 unless `price=all` |
+| `GET /api/business/` | yes | `productCategory` | yes | exact match (unchanged) | yes | no | yes | Product vendors only |
+
+---
+
+## Query parameters
+
+### Unified public search (`GET /api/public/search`)
+
+| Param | Behavior |
+|-------|----------|
+| `keyword` / `search` | Text match on listing fields + business name/description/tags |
+| `location` | Flexible regex on business/vendor address fields (includes `address.zipCode` substring) |
+| `city`, `state`, `country` | Dedicated address filters (flexible regex) |
+| `zip` | Exact match on `Business.address.zipCode` and `VendorOnboardingStage1.address.zipCode` |
+| `tag` / `tags` | Exact case-insensitive match on `Business.tags` (comma-separated in `tags`) |
+| `verified=true` | Intersect with vendors where `VendorOnboardingStage1.status === 'verified'` |
+| `categoryId` / `categorySlug` | Filter by category per listing type |
+| `listingType` | `product`, `service`, `food`, or `all` (default `all`) |
+| `minorityType` | Existing minority filter (unchanged) |
+| `page`, `limit` | Offset pagination; limit clamped 1–50 |
+| `radius`, `lat`, `lng`, `nearMe` | **Unsupported** — ignored for query; echoed in `filters.unsupported` |
+
+### List endpoints (products, services, food)
+
+Optional additive params: `tag`, `tags`, `zip`, `verified=true`, plus existing filters.
+
+Food-only: `price=all` disables the default `price: 0–200` MVP filter.
+
+### Business browse (`GET /api/business/`)
+
+Optional: `tag`, `tags`, `zip` (exact on `address.zipCode`). City/state/country remain **exact match** (legacy behavior).
+
+---
+
+## Frontend usage examples
+
+```bash
+# Keyword + tag + verified vendors
+curl "https://api.mosaicbizhub.com/api/public/search?keyword=organic&tag=local&verified=true&limit=10"
+
+# ZIP exact (not radius)
+curl "https://api.mosaicbizhub.com/api/public/search?zip=90210&listingType=product"
+
+# Category slug + city
+curl "https://api.mosaicbizhub.com/api/public/search?categorySlug=handmade&city=Atlanta"
+
+# Products list with tag + zip
+curl "https://api.mosaicbizhub.com/api/products/list?tag=organic&zip=30301&page=1&limit=20"
+
+# Food without default price cap
+curl "https://api.mosaicbizhub.com/api/food/list?price=all&city=Chicago"
+
+# Rejected geolocation (still 200; params listed as unsupported)
+curl "https://api.mosaicbizhub.com/api/public/search?lat=33.7&lng=-84.4&radius=10"
+```
+
+Response excerpt for unsupported geo:
+
+```json
+{
+  "success": true,
+  "filters": {
+    "unsupported": [
+      { "param": "lat", "reason": "geolocation not implemented" },
+      { "param": "lng", "reason": "geolocation not implemented" },
+      { "param": "radius", "reason": "geolocation not implemented" }
+    ]
+  }
+}
+```
+
+---
+
+## ZIP vs geolocation
+
+| Capability | Status |
+|------------|--------|
+| ZIP exact on `address.zipCode` | **Implemented** |
+| ZIP substring via `location` text search | **Included** in location regex set |
+| Radius / lat/lng / near me | **Not implemented** |
+| `distanceMiles` in responses | **Never added** |
+
+Future phase requires a geocoding pipeline and indexed coordinates (Business GeoJSON or dedicated collection). Business `location` GeoJSON is commented out in schema today.
+
+---
+
+## Tags and verified behavior
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Tag filter | `Business.tags` only | Exact match; no listing-level tags invented |
+| Tags on cards | Populated from `businessId.tags` | Batch-loaded in list/search handlers |
+| Verified filter | `VendorOnboardingStage1.status === 'verified'` | Optional `verified=true` |
+| Verified on cards | Batch `loadVerifiedByBusinessIds` | `true` / `false` / `null` (unknown) |
+| DTO fix | `resolveVerified` | No longer treats Stripe `onboardingStatus` as verified |
+
+---
+
+## Known MVP gaps (documented, not hidden)
+
+| Gap | Detail |
+|-----|--------|
+| No radius / near-me search | By design until geo index + geocoding exist |
+| Food default price filter | `0–200` applied unless `price=all` |
+| Services `openNow` | Query param accepted elsewhere but not wired to hours logic |
+| Business browse location | City/state/country remain exact match (not flexible regex) |
+| Admin tags CRUD | Still no admin API; tags set on Business profile only |
+
+---
+
+## Tests
+
+| File | Count | Coverage |
+|------|------:|----------|
+| `tests/marketplace/public-search-filters.test.js` | 15 | Query parsing, tag/ZIP resolution, verified DTO fix, search handler empty/geo/listingType/shape |
+| Full suite | **92** | `npm test` |
+
+---
+
+## Backward compatibility
+
+- All new query params are **additive**; existing clients unchanged.
+- Response shapes unchanged; search adds optional `filters` metadata (including `unsupported`).
+- Services/food now require `isPublished: true` (aligns with products/public search).
+- Food list applies visible-business gate (aligns with products/services).
+
+---
+
+## Production deployment
+
+**Not deployed.** Changes exist only on branch `sprint/backend-search-filter-readiness`. Merge and EB deploy are out of scope for this issue pass.

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -2,7 +2,7 @@
 
 Maps backend features to automated tests (`npm test`), manual smoke checks, and proof-pack evidence.
 
-**Runner:** `npm test` → `node --test tests/**/*.test.js` (77 tests, Node built-in runner)
+**Runner:** `npm test` → `node --test tests/**/*.test.js` (92 tests, Node built-in runner)
 
 **Test style:** Unit/integration-style tests with mocked Mongoose models and module hooks. They prove **handler logic and wiring** — not full end-to-end flows against live MongoDB, Stripe, or AWS in CI.
 
@@ -14,7 +14,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 
 | Layer | Count | What it validates |
 |-------|-------|-------------------|
-| Automated (`tests/`) | **77** | DTOs, middleware, controller logic, webhook wiring (mocked) |
+| Automated (`tests/`) | **92** | DTOs, middleware, controller logic, webhook wiring, search filters (mocked) |
 | Manual smoke script | 1 | Live API + DB auth/check per role |
 | Production smoke tiers | P0–P6 | Post-deploy on `https://api.mosaicbizhub.com` |
 | Proof pack | Per release | Redacted evidence matrix |
@@ -206,6 +206,17 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 
 ---
 
+## Search/filter tests (issue #29)
+
+| Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
+| --- | --- | --- | --- | --- |
+| Public search filters | [`tests/marketplace/public-search-filters.test.js`](../tests/marketplace/public-search-filters.test.js) | Query parsing, tag/ZIP resolution, verified DTO fix, empty-result safety, unsupported geo echo, listingType scoping | Live MongoDB queries; radius search | Yes — P6.1–P6.2 after merge |
+| Shared filter module | same | `resolveBusinessIdsByTags`, `resolveBusinessIdsByZip`, intersection logic | VendorOnboarding + Business join against prod DB | Partial |
+
+**Readiness doc:** [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md)
+
+---
+
 ## Launch-critical area → coverage map
 
 | Launch-critical area | Automated | Manual smoke | Gap / honest limit |
@@ -219,6 +230,7 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 | Webhook wiring | Yes (9 tests) | P4.x | Event DB side-effects manual |
 | Business sync | Yes (5 tests) | Post-verify | Subscription dependency manual |
 | Marketplace card/detail DTO | Yes (20 tests) | P6.x | Live browse/detail E2E manual |
+| Public search/filter helpers | Yes (15 tests) | P6.1–P6.2 | No live ZIP/tag prod smoke |
 | Subscriptions (API) | **No** | P4.3 | Billing E2E manual |
 | CI/CD regression | **No** | `npm test` local pre-merge | No GitHub Actions |
 
@@ -227,7 +239,7 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 ## How to run
 
 ```bash
-# All automated tests (77)
+# All automated tests (92)
 npm test
 
 # Manual auth smoke (live API + DB)
@@ -243,7 +255,7 @@ node scripts/verify-auth-check-smoke.js
 
 | Evidence type | Source | Automated equivalent |
 | --- | --- | --- |
-| `npm test` 77/77 pass | Pre-merge local/CI | Yes — full suite |
+| `npm test` 92/92 pass | Pre-merge local/CI | Yes — full suite |
 | Auth smoke script output | `scripts/verify-auth-check-smoke.js` | Partial — live auth/check only |
 | Smoke matrix P0–P6 | [production-smoke-checklist.md](production-smoke-checklist.md) | No — human execution |
 | Webhook unsigned 400 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) curl | Partial — 9 tests cover handler logic |
@@ -272,4 +284,5 @@ node scripts/verify-auth-check-smoke.js
 | `tests/stripe/stripe-webhook-routing-signature.test.js` | 9 | Webhook routing + signatures |
 | `tests/marketplace/public-listing-dto.test.js` | 18 | Marketplace DTO normalization |
 | `tests/marketplace/featured-products-response.test.js` | 2 | Featured products wiring |
-| **Total** | **77** | |
+| `tests/marketplace/public-search-filters.test.js` | 15 | Search/filter helpers + handler |
+| **Total** | **92** | |

--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -183,8 +183,8 @@ function normalizeLocation(raw, businessSource) {
 
 function resolveVerified(raw, options = {}) {
   if (options.verified != null) return options.verified;
-  if (raw.onboardingStatus === 'verified') return true;
   if (raw.vendorDetails?.status === 'verified') return true;
+  if (raw.vendorDetails?.status && raw.vendorDetails.status !== 'verified') return false;
   return null;
 }
 

--- a/lib/listing/publicSearchFilters.js
+++ b/lib/listing/publicSearchFilters.js
@@ -1,0 +1,485 @@
+/**
+ * Public marketplace search/filter helpers.
+ * No geospatial radius, lat/lng, or fake distance fields — ZIP exact match only.
+ */
+const mongoose = require('mongoose');
+const Business = require('../../models/Business');
+const VendorOnboardingStage1 = require('../../models/VendorOnboardingStage1');
+const MinorityType = require('../../models/MinorityType');
+
+const GEO_UNSUPPORTED_KEYS = ['radius', 'lat', 'lng', 'nearMe', 'nearme', 'longitude', 'latitude'];
+
+function escapeRegex(value = '') {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildKeywordRegex(value = '') {
+  return new RegExp(escapeRegex(String(value).trim()), 'i');
+}
+
+function buildFlexibleMatchRegex(value = '') {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) return null;
+
+  const normalized = trimmed.replace(/[-_,]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const tokens = normalized.split(' ').filter(Boolean);
+
+  if (tokens.length > 1) {
+    return new RegExp(tokens.map(escapeRegex).join('[\\s,-]*'), 'i');
+  }
+
+  if (normalized.length >= 5) {
+    return new RegExp(normalized.split('').map(escapeRegex).join('[\\s,-]*'), 'i');
+  }
+
+  return new RegExp(escapeRegex(normalized), 'i');
+}
+
+function normalizeZip(value = '') {
+  return String(value || '').trim();
+}
+
+function parseTagList(tag, tags) {
+  const raw = String((tags && String(tags).trim()) || (tag && String(tag).trim()) || '').trim();
+  if (!raw) return [];
+  return raw.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function parsePublicSearchQuery(query = {}) {
+  const keyword = String(query.keyword || query.search || '').trim();
+  const page = Math.max(1, parseInt(query.page, 10) || 1);
+  const limit = Math.max(1, Math.min(50, parseInt(query.limit, 10) || 10));
+  const listingType = String(query.listingType || 'all').trim().toLowerCase();
+
+  return {
+    keyword,
+    location: String(query.location || '').trim(),
+    city: String(query.city || '').trim(),
+    state: String(query.state || '').trim(),
+    country: String(query.country || '').trim(),
+    zip: normalizeZip(query.zip),
+    minorityType: String(query.minorityType || '').trim(),
+    categoryId: query.categoryId ? String(query.categoryId).trim() : '',
+    categorySlug: String(query.categorySlug || '').trim(),
+    tag: String(query.tag || '').trim(),
+    tags: String(query.tags || '').trim(),
+    verified: String(query.verified || '').trim().toLowerCase() === 'true',
+    listingType: ['product', 'service', 'food', 'all'].includes(listingType) ? listingType : 'all',
+    page,
+    limit,
+  };
+}
+
+function detectUnsupportedGeoParams(query = {}) {
+  const unsupported = [];
+  for (const key of GEO_UNSUPPORTED_KEYS) {
+    if (query[key] != null && String(query[key]).trim() !== '') {
+      unsupported.push({
+        param: key,
+        reason: 'geolocation not implemented',
+      });
+    }
+  }
+  return unsupported;
+}
+
+function toObjectId(id) {
+  if (!id) return null;
+  if (id instanceof mongoose.Types.ObjectId) return id;
+  if (mongoose.Types.ObjectId.isValid(String(id))) {
+    return new mongoose.Types.ObjectId(String(id));
+  }
+  return null;
+}
+
+function intersectBusinessIdSets(...sets) {
+  const normalized = sets
+    .filter((set) => Array.isArray(set))
+    .map((set) => new Set(set.map((id) => String(id))));
+
+  if (!normalized.length) return null;
+  const [first, ...rest] = normalized;
+  const result = [...first].filter((id) => rest.every((set) => set.has(id)));
+  return result.map((id) => new mongoose.Types.ObjectId(id));
+}
+
+function shouldIncludeListingType(listingType, type) {
+  if (listingType === 'all') return true;
+  return listingType === type;
+}
+
+async function resolveBusinessIdsByKeyword(keyword) {
+  const keywordRegex = buildFlexibleMatchRegex(keyword);
+  if (!keywordRegex) return [];
+
+  const [businessMatches, vendorMatches] = await Promise.all([
+    Business.find({
+      isActive: true,
+      $or: [
+        { businessName: keywordRegex },
+        { description: keywordRegex },
+        { tags: keywordRegex },
+      ],
+    }).select('_id').lean(),
+    VendorOnboardingStage1.find({
+      businessId: { $exists: true, $ne: null },
+      $or: [
+        { businessName: keywordRegex },
+        { businessBio: keywordRegex },
+      ],
+    }).select('businessId').lean(),
+  ]);
+
+  return [...new Set([
+    ...businessMatches.map((item) => item._id.toString()),
+    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+  ])].map((id) => new mongoose.Types.ObjectId(id));
+}
+
+async function resolveBusinessIdsByTags(tag, tags) {
+  const tagList = parseTagList(tag, tags);
+  if (!tagList.length) return null;
+
+  const matches = await Business.find({
+    isActive: true,
+    $or: tagList.map((item) => ({ tags: new RegExp(`^${escapeRegex(item)}$`, 'i') })),
+  }).select('_id').lean();
+
+  return matches.map((business) => business._id);
+}
+
+async function resolveVerifiedBusinessIds() {
+  const rows = await VendorOnboardingStage1.find({
+    status: 'verified',
+    businessId: { $exists: true, $ne: null },
+  }).select('businessId').lean();
+
+  return [...new Set(rows.map((row) => row.businessId?.toString()).filter(Boolean))]
+    .map((id) => new mongoose.Types.ObjectId(id));
+}
+
+async function resolveBusinessIdsByZip(zip) {
+  const normalizedZip = normalizeZip(zip);
+  if (!normalizedZip) return null;
+
+  const zipRegex = new RegExp(`^${escapeRegex(normalizedZip)}$`, 'i');
+  const [businessMatches, vendorMatches] = await Promise.all([
+    Business.find({
+      isActive: true,
+      'address.zipCode': zipRegex,
+    }).select('_id').lean(),
+    VendorOnboardingStage1.find({
+      businessId: { $exists: true, $ne: null },
+      'address.zipCode': zipRegex,
+    }).select('businessId').lean(),
+  ]);
+
+  const ids = [...new Set([
+    ...businessMatches.map((item) => item._id.toString()),
+    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+  ])];
+
+  return ids.map((id) => new mongoose.Types.ObjectId(id));
+}
+
+async function resolveBusinessIdsByDedicatedLocation({ city, state, country }) {
+  const clauses = [];
+  if (city) clauses.push({ 'address.city': buildFlexibleMatchRegex(city) });
+  if (state) clauses.push({ 'address.state': buildFlexibleMatchRegex(state) });
+  if (country) clauses.push({ 'address.country': buildFlexibleMatchRegex(country) });
+
+  if (!clauses.length) return null;
+
+  const businessFilter = { isActive: true, $and: clauses };
+  const vendorFilter = {
+    businessId: { $exists: true, $ne: null },
+    $and: clauses.map((clause) => {
+      const key = Object.keys(clause)[0];
+      return { [key]: clause[key] };
+    }),
+  };
+
+  const [businessMatches, vendorMatches] = await Promise.all([
+    Business.find(businessFilter).select('_id').lean(),
+    VendorOnboardingStage1.find(vendorFilter).select('businessId').lean(),
+  ]);
+
+  const ids = [...new Set([
+    ...businessMatches.map((item) => item._id.toString()),
+    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+  ])];
+
+  return ids.map((id) => new mongoose.Types.ObjectId(id));
+}
+
+async function resolveBusinessIdsForMinorityType(minorityType) {
+  if (!minorityType) return null;
+
+  const normalizedMinority = minorityType.replace(/-/g, ' ').trim();
+  const minorityRegex = buildFlexibleMatchRegex(normalizedMinority);
+
+  let minorityTypeIds = [];
+  if (mongoose.Types.ObjectId.isValid(minorityType)) {
+    minorityTypeIds.push(new mongoose.Types.ObjectId(minorityType));
+  }
+
+  const minorityMatches = await MinorityType.find({
+    name: minorityRegex,
+    isActive: true,
+  }).select('_id').lean();
+
+  minorityTypeIds.push(...minorityMatches.map((item) => item._id));
+  minorityTypeIds = [...new Set(minorityTypeIds.map((id) => id.toString()))]
+    .map((id) => new mongoose.Types.ObjectId(id));
+
+  const [businessMinorityMatches, vendorMinorityMatches] = await Promise.all([
+    Business.find({
+      isActive: true,
+      ...(minorityTypeIds.length ? { minorityType: { $in: minorityTypeIds } } : { _id: null }),
+    }).select('_id').lean(),
+    VendorOnboardingStage1.find({
+      businessId: { $exists: true, $ne: null },
+      minorityCategories: { $elemMatch: { $regex: minorityRegex } },
+    }).select('businessId').lean(),
+  ]);
+
+  const ids = [...new Set([
+    ...businessMinorityMatches.map((item) => item._id.toString()),
+    ...vendorMinorityMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+  ])];
+
+  return ids.map((id) => new mongoose.Types.ObjectId(id));
+}
+
+async function resolveBusinessIdsByLocation({ location, city, state, country, zip }) {
+  const sets = [];
+
+  const zipIds = await resolveBusinessIdsByZip(zip);
+  if (zip != null && String(zip).trim() !== '') {
+    sets.push(zipIds || []);
+  }
+
+  const dedicatedIds = await resolveBusinessIdsByDedicatedLocation({ city, state, country });
+  if (dedicatedIds) sets.push(dedicatedIds);
+
+  const locationText = String(location || '').trim();
+  if (locationText) {
+    const locationRegex = buildFlexibleMatchRegex(locationText);
+    const [businessLocationMatches, vendorLocationMatches] = await Promise.all([
+      Business.find({
+        isActive: true,
+        $or: [
+          { businessName: locationRegex },
+          { 'address.street': locationRegex },
+          { 'address.city': locationRegex },
+          { 'address.state': locationRegex },
+          { 'address.country': locationRegex },
+          { 'address.zipCode': locationRegex },
+        ],
+      }).select('_id').lean(),
+      VendorOnboardingStage1.find({
+        businessId: { $exists: true, $ne: null },
+        $or: [
+          { businessName: locationRegex },
+          { 'address.street': locationRegex },
+          { 'address.city': locationRegex },
+          { 'address.state': locationRegex },
+          { 'address.country': locationRegex },
+          { 'address.zipCode': locationRegex },
+        ],
+      }).select('businessId').lean(),
+    ]);
+
+    sets.push([...new Set([
+      ...businessLocationMatches.map((item) => item._id.toString()),
+      ...vendorLocationMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+    ])].map((id) => new mongoose.Types.ObjectId(id)));
+  }
+
+  if (!sets.length) return null;
+  return intersectBusinessIdSets(...sets);
+}
+
+async function resolveCombinedBusinessFilters({
+  location,
+  city,
+  state,
+  country,
+  zip,
+  minorityType,
+  tag,
+  tags,
+  verified,
+}) {
+  const sets = [];
+
+  const locationIds = await resolveBusinessIdsByLocation({ location, city, state, country, zip });
+  if (locationIds) sets.push(locationIds);
+
+  const minorityIds = await resolveBusinessIdsForMinorityType(minorityType);
+  if (minorityIds) sets.push(minorityIds);
+
+  const tagIds = await resolveBusinessIdsByTags(tag, tags);
+  if (tagIds) sets.push(tagIds);
+
+  if (verified) {
+    sets.push(await resolveVerifiedBusinessIds());
+  }
+
+  if (!sets.length) return null;
+  return intersectBusinessIdSets(...sets);
+}
+
+async function loadVerifiedByBusinessIds(businessIds = []) {
+  const ids = [...new Set(businessIds.map((id) => String(id)).filter(Boolean))];
+  const map = new Map(ids.map((id) => [id, null]));
+  if (!ids.length) return map;
+
+  const objectIds = ids.map((id) => toObjectId(id)).filter(Boolean);
+  const rows = await VendorOnboardingStage1.find({
+    businessId: { $in: objectIds },
+  }).select('businessId status').lean();
+
+  for (const row of rows) {
+    const key = String(row.businessId);
+    if (!map.has(key)) continue;
+    map.set(key, row.status === 'verified');
+  }
+
+  return map;
+}
+
+async function loadTagsByBusinessIds(businessIds = []) {
+  const ids = [...new Set(businessIds.map((id) => String(id)).filter(Boolean))];
+  const map = new Map();
+  if (!ids.length) return map;
+
+  const objectIds = ids.map((id) => toObjectId(id)).filter(Boolean);
+  const rows = await Business.find({ _id: { $in: objectIds } }).select('_id tags').lean();
+  for (const row of rows) {
+    map.set(String(row._id), Array.isArray(row.tags) ? row.tags : []);
+  }
+  return map;
+}
+
+/**
+ * Apply optional tag/zip/verified/location filters against visible business IDs.
+ * Returns { empty: true } when intersection is empty, or { businessIds: string[] }.
+ */
+async function narrowVisibleBusinessIds(visibleBusinessIds, query = {}, options = {}) {
+  const includeLocation = options.includeLocation === true;
+  const {
+    tag,
+    tags,
+    zip,
+    verified,
+    city,
+    state,
+    country,
+  } = query;
+
+  const hasBusinessFilters = parseTagList(tag, tags).length
+    || normalizeZip(zip)
+    || String(verified || '').toLowerCase() === 'true'
+    || (includeLocation && (
+      String(city || '').trim()
+      || String(state || '').trim()
+      || String(country || '').trim()
+    ));
+
+  if (!hasBusinessFilters) {
+    return { businessIds: visibleBusinessIds, empty: false };
+  }
+
+  const filtered = await resolveCombinedBusinessFilters({
+    city: includeLocation ? city : '',
+    state: includeLocation ? state : '',
+    country: includeLocation ? country : '',
+    zip,
+    tag,
+    tags,
+    verified: String(verified || '').toLowerCase() === 'true',
+  });
+
+  if (Array.isArray(filtered) && !filtered.length) {
+    return { empty: true };
+  }
+
+  const visibleSet = new Set(visibleBusinessIds.map(String));
+  const targetSet = filtered
+    ? new Set(filtered.map((id) => String(id)))
+    : visibleSet;
+
+  const businessIds = [...visibleSet].filter((id) => targetSet.has(id));
+  if (!businessIds.length) return { empty: true };
+  return { businessIds, empty: false };
+}
+
+function mergeBusinessIdFilter(existingFilter, allowedBusinessIds) {
+  const allowedSet = new Set(allowedBusinessIds.map(String));
+
+  if (!allowedBusinessIds.length) {
+    return { empty: true };
+  }
+
+  if (existingFilter && typeof existingFilter === 'object' && existingFilter.$in) {
+    const narrowed = existingFilter.$in
+      .map(String)
+      .filter((id) => allowedSet.has(id));
+    if (!narrowed.length) return { empty: true };
+    return { filter: { $in: narrowed.map((id) => new mongoose.Types.ObjectId(id)) }, empty: false };
+  }
+
+  if (existingFilter) {
+    const id = String(existingFilter);
+    if (!allowedSet.has(id)) return { empty: true };
+    return { filter: existingFilter, empty: false };
+  }
+
+  return {
+    filter: { $in: allowedBusinessIds.map((id) => new mongoose.Types.ObjectId(id)) },
+    empty: false,
+  };
+}
+
+function attachBusinessMetadataToListings(items, { verifiedMap, tagsMap }) {
+  return items.map((item) => {
+    const plain = item && typeof item.toObject === 'function' ? item.toObject() : { ...item };
+    const businessId = plain.businessId?._id || plain.businessId;
+    const businessKey = businessId ? String(businessId) : null;
+
+    if (plain.businessId && typeof plain.businessId === 'object' && businessKey && tagsMap?.has(businessKey)) {
+      plain.businessId.tags = tagsMap.get(businessKey);
+    }
+
+    const cardOptions = { listingType: plain.listingType };
+    if (businessKey && verifiedMap?.has(businessKey)) {
+      cardOptions.verified = verifiedMap.get(businessKey);
+    }
+
+    return { plain, cardOptions };
+  });
+}
+
+module.exports = {
+  escapeRegex,
+  buildKeywordRegex,
+  buildFlexibleMatchRegex,
+  parseTagList,
+  parsePublicSearchQuery,
+  detectUnsupportedGeoParams,
+  intersectBusinessIdSets,
+  shouldIncludeListingType,
+  resolveBusinessIdsByKeyword,
+  resolveBusinessIdsByTags,
+  resolveVerifiedBusinessIds,
+  resolveBusinessIdsByZip,
+  resolveBusinessIdsByLocation,
+  resolveBusinessIdsForMinorityType,
+  resolveCombinedBusinessFilters,
+  loadVerifiedByBusinessIds,
+  loadTagsByBusinessIds,
+  narrowVisibleBusinessIds,
+  mergeBusinessIdFilter,
+  attachBusinessMetadataToListings,
+};

--- a/tests/marketplace/public-search-filters.test.js
+++ b/tests/marketplace/public-search-filters.test.js
@@ -1,0 +1,325 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const filtersPath = path.resolve(__dirname, '../../lib/listing/publicSearchFilters.js');
+const dtoPath = path.resolve(__dirname, '../../lib/listing/publicListingDto.js');
+const controllerPath = path.resolve(__dirname, '../../controllers/publicListing.js');
+
+const {
+  parsePublicSearchQuery,
+  detectUnsupportedGeoParams,
+  parseTagList,
+  intersectBusinessIdSets,
+  shouldIncludeListingType,
+  buildFlexibleMatchRegex,
+} = require(filtersPath);
+
+test('parsePublicSearchQuery normalizes search alias and clamps limit', () => {
+  const parsed = parsePublicSearchQuery({ search: ' hats ', limit: '999', page: '0' });
+  assert.equal(parsed.keyword, 'hats');
+  assert.equal(parsed.limit, 50);
+  assert.equal(parsed.page, 1);
+  assert.equal(parsed.listingType, 'all');
+});
+
+test('detectUnsupportedGeoParams flags geolocation params', () => {
+  const unsupported = detectUnsupportedGeoParams({ lat: '40.7', radius: '10' });
+  assert.ok(unsupported.some((item) => item.param === 'lat'));
+  assert.ok(unsupported.some((item) => item.param === 'radius'));
+  assert.equal(unsupported[0].reason, 'geolocation not implemented');
+});
+
+test('parseTagList supports comma-separated tags', () => {
+  assert.deepEqual(parseTagList('', 'organic, local'), ['organic', 'local']);
+});
+
+test('intersectBusinessIdSets returns shared business ids', () => {
+  const mongoose = require('mongoose');
+  const a = [new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId()];
+  const b = [a[0], new mongoose.Types.ObjectId()];
+  const result = intersectBusinessIdSets(a, b);
+  assert.equal(result.length, 1);
+  assert.equal(String(result[0]), String(a[0]));
+});
+
+test('shouldIncludeListingType respects listingType filter', () => {
+  assert.equal(shouldIncludeListingType('product', 'product'), true);
+  assert.equal(shouldIncludeListingType('product', 'service'), false);
+  assert.equal(shouldIncludeListingType('all', 'food'), true);
+});
+
+test('buildFlexibleMatchRegex matches flexible location tokens', () => {
+  const regex = buildFlexibleMatchRegex('New York');
+  assert.match('New-York', regex);
+});
+
+function buildFindChain(rows = []) {
+  const chain = {
+    populate() { return chain; },
+    select() { return chain; },
+    sort() { return chain; },
+    skip() { return chain; },
+    limit() { return chain; },
+    lean() { return Promise.resolve(rows); },
+  };
+  return chain;
+}
+
+function buildSelectLeanChain(rows = []) {
+  return buildFindChain(rows);
+}
+
+function wrapModelFind(model, fallbackRows = []) {
+  if (!model) {
+    return { find: () => buildSelectLeanChain(fallbackRows) };
+  }
+
+  const userFind = model.find;
+  return {
+    ...model,
+    find: (...args) => {
+      if (typeof userFind !== 'function') {
+        return buildSelectLeanChain(fallbackRows);
+      }
+
+      const result = userFind(...args);
+      if (result && typeof result.select === 'function') {
+        return result;
+      }
+
+      if (result && typeof result.then === 'function') {
+        return {
+          select() { return this; },
+          lean() { return result; },
+        };
+      }
+
+      return buildSelectLeanChain(Array.isArray(result) ? result : fallbackRows);
+    },
+  };
+}
+
+function loadFiltersWithMocks(mocks) {
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).includes('models/Business')) {
+      return wrapModelFind(mocks.Business);
+    }
+    if (String(request).includes('models/VendorOnboardingStage1')) {
+      return wrapModelFind(mocks.VendorOnboardingStage1);
+    }
+    if (String(request).includes('models/MinorityType')) return mocks.MinorityType;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[filtersPath];
+  const loaded = require(filtersPath);
+  Module._load = originalLoad;
+  return loaded;
+}
+
+function loadSearchController(mocks) {
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).includes('models/Product')) return { find: () => buildFindChain(mocks.products || []) };
+    if (String(request).includes('models/Service')) return { find: () => buildFindChain(mocks.services || []) };
+    if (String(request).includes('models/Food')) return { find: () => buildFindChain(mocks.foods || []) };
+    if (String(request).includes('models/Business')) return wrapModelFind(mocks.Business);
+    if (String(request).includes('models/VendorOnboardingStage1')) return wrapModelFind(mocks.VendorOnboardingStage1);
+    if (String(request).includes('models/MinorityType')) return mocks.MinorityType;
+    if (String(request).includes('models/ProductCategory')) return mocks.ProductCategory;
+    if (String(request).includes('models/ServiceCategory')) return mocks.ServiceCategory;
+    if (String(request).includes('models/FoodCategory')) return mocks.FoodCategory;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[controllerPath];
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+  return loaded;
+}
+
+test('resolveBusinessIdsByTags uses exact case-insensitive tag match', async () => {
+  const id = '507f1f77bcf86cd799439011';
+  const filters = loadFiltersWithMocks({
+    Business: {
+      find: async () => [{ _id: id }],
+    },
+    VendorOnboardingStage1: {},
+    MinorityType: {},
+  });
+
+  const result = await filters.resolveBusinessIdsByTags('Organic', '');
+  assert.equal(result.length, 1);
+  assert.equal(String(result[0]), id);
+});
+
+test('resolveBusinessIdsByZip matches address.zipCode exactly', async () => {
+  const id = '507f1f77bcf86cd799439012';
+  let capturedFilter = null;
+  const filters = loadFiltersWithMocks({
+    Business: {
+      find: async (filter) => {
+        capturedFilter = filter;
+        return [{ _id: id }];
+      },
+    },
+    VendorOnboardingStage1: {
+      find: async () => [],
+    },
+    MinorityType: {},
+  });
+
+  const result = await filters.resolveBusinessIdsByZip('90210');
+  assert.equal(result.length, 1);
+  assert.ok(capturedFilter['address.zipCode']);
+});
+
+test('resolveVerified ignores Stripe onboardingStatus field', () => {
+  delete require.cache[dtoPath];
+  const { toPublicListingCard } = require(dtoPath);
+  const card = toPublicListingCard({
+    _id: '507f1f77bcf86cd799439011',
+    title: 'Sample',
+    onboardingStatus: 'completed',
+  }, { listingType: 'product' });
+
+  assert.equal(card.verified, null);
+});
+
+test('resolveVerified uses explicit verified option', () => {
+  delete require.cache[dtoPath];
+  const { toPublicListingCard } = require(dtoPath);
+  const card = toPublicListingCard({
+    _id: '507f1f77bcf86cd799439011',
+    title: 'Sample',
+  }, { listingType: 'product', verified: true });
+
+  assert.equal(card.verified, true);
+});
+
+test('parseTagList uses tag when tags query is empty string', () => {
+  assert.deepEqual(parseTagList('Organic', ''), ['Organic']);
+});
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('searchPublicListings returns safe empty arrays when tag filter matches nothing', async () => {
+  const controller = loadSearchController({
+    Business: {
+      find: async () => [],
+    },
+    VendorOnboardingStage1: {
+      find: async () => [],
+    },
+    MinorityType: {},
+    ProductCategory: { findOne: async () => null },
+    ServiceCategory: { findOne: async () => null },
+    FoodCategory: { findOne: async () => null },
+  });
+
+  const res = mockResponse();
+  await controller.searchPublicListings({ query: { tag: 'missing-tag' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.deepEqual(res.body.data, { products: [], services: [], foods: [] });
+  assert.equal(res.body.totals.all, 0);
+});
+
+test('searchPublicListings reports unsupported geolocation params', async () => {
+  const controller = loadSearchController({
+    Business: { find: async () => [] },
+    VendorOnboardingStage1: { find: async () => [] },
+    MinorityType: {},
+    ProductCategory: { findOne: async () => null },
+    ServiceCategory: { findOne: async () => null },
+    FoodCategory: { findOne: async () => null },
+  });
+
+  const res = mockResponse();
+  await controller.searchPublicListings({ query: { nearMe: 'true', lat: '1', lng: '2' } }, res);
+
+  assert.ok(Array.isArray(res.body.filters.unsupported));
+  assert.ok(res.body.filters.unsupported.length >= 3);
+});
+
+test('searchPublicListings listingType product skips service and food queries', async () => {
+  let serviceFindCalled = false;
+
+  const controller = loadSearchController({
+    Business: { find: async () => [] },
+    VendorOnboardingStage1: { find: async () => [] },
+    MinorityType: {},
+    ProductCategory: { findOne: async () => null },
+    ServiceCategory: { findOne: async () => null },
+    FoodCategory: { findOne: async () => null },
+    products: [],
+    services: [],
+    foods: [],
+  });
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).includes('models/Service')) {
+      return {
+        find: () => {
+          serviceFindCalled = true;
+          return buildFindChain([]);
+        },
+      };
+    }
+    if (String(request).includes('models/Product')) return { find: () => buildFindChain([]) };
+    if (String(request).includes('models/Food')) return { find: () => buildFindChain([]) };
+    if (String(request).includes('models/Business')) return wrapModelFind({ find: async () => [] });
+    if (String(request).includes('models/VendorOnboardingStage1')) return wrapModelFind({ find: async () => [] });
+    if (String(request).includes('models/MinorityType')) return { find: async () => [] };
+    if (String(request).includes('models/ProductCategory')) return { findOne: async () => null };
+    if (String(request).includes('models/ServiceCategory')) return { findOne: async () => null };
+    if (String(request).includes('models/FoodCategory')) return { findOne: async () => null };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[controllerPath];
+  const reloaded = require(controllerPath);
+  Module._load = originalLoad;
+
+  const res = mockResponse();
+  await reloaded.searchPublicListings({ query: { listingType: 'product' } }, res);
+
+  assert.equal(serviceFindCalled, false);
+  assert.equal(res.body.filters.listingType, 'product');
+});
+
+test('searchPublicListings preserves backward compatible response shape', async () => {
+  const controller = loadSearchController({
+    Business: { find: async () => [] },
+    VendorOnboardingStage1: { find: async () => [] },
+    MinorityType: {},
+    ProductCategory: { findOne: async () => null },
+    ServiceCategory: { findOne: async () => null },
+    FoodCategory: { findOne: async () => null },
+  });
+
+  const res = mockResponse();
+  await controller.searchPublicListings({ query: { keyword: 'test' } }, res);
+
+  assert.ok('success' in res.body);
+  assert.ok('filters' in res.body);
+  assert.ok('totals' in res.body);
+  assert.ok('data' in res.body);
+  assert.ok(Array.isArray(res.body.data.products));
+  assert.ok(Array.isArray(res.body.data.services));
+  assert.ok(Array.isArray(res.body.data.foods));
+});


### PR DESCRIPTION
## Summary

- Adds shared filter module (lib/listing/publicSearchFilters.js) with keyword, location, ZIP exact, tag, verified, and intersection helpers — explicitly no geolocation/radius.
- Extends GET /api/public/search with categoryId/categorySlug, listingType, 	ag/	ags, city/state/country/zip, erified, page, and honest ilters.unsupported for geo params.
- Extends product/service/food list endpoints and business browse with 	ag, zip, erified; fixes services/food isPublished, food visible-business gate, services state/country via business scope, products/filters 	otalPages mismatch.
- Fixes esolveVerified DTO bug (Stripe onboardingStatus no longer treated as verified); batch-loads tags and verified status on cards.
- Adds 15 tests (	ests/marketplace/public-search-filters.test.js); **92/92** pass via 
pm test.

## Branch

sprint/backend-search-filter-readiness (from main @ c983ff4)

## Files changed

- lib/listing/publicSearchFilters.js (new)
- controllers/publicListing.js
- controllers/businessController.js
- lib/listing/publicListingDto.js
- 	ests/marketplace/public-search-filters.test.js (new)
- docs/MVP_BACKEND_SEARCH_FILTER_READINESS.md (new)
- docs/MVP_BACKEND_API_AUDIT.md
- docs/TEST_MATRIX.md

## Endpoints audited

| Endpoint | Filters confirmed/added |
|----------|-------------------------|
| GET /api/public/search | keyword, location, city/state/country, zip, tag, verified, category, listingType, page/limit |
| GET /api/products/list | + tag, zip, verified |
| GET /api/products/filters | + tag, zip, verified; totalPages fix |
| GET /api/services/list | + tag, zip, verified; isPublished; state/country |
| GET /api/food/list | + tag, zip, verified; isPublished; visible-business gate; price=all escape |
| GET /api/business/ | + tag, zip |

## Unsupported (honest contract)

- adius, lat, lng, 
earMe — echoed in ilters.unsupported; no fake distance fields

## ZIP / geolocation decision

- **ZIP exact** on Business + VendorOnboardingStage1 ddress.zipCode — implemented
- **Radius / near-me** — deferred (no geo index pipeline)

## Tag / verified decision

- Tags filter on Business.tags only; populated on DTO cards
- Verified filter via VendorOnboardingStage1.status === 'verified'

## Tests

- New: 15 search/filter tests
- Total: **92/92** (
pm test)
- Syntax: 
ode --check on filter module, publicListing controller, publicListingDto

## Backward compatibility

- Additive query params only; existing response keys unchanged
- Search adds optional ilters metadata

## Remaining blockers (post-merge)

- Radius / near-me search (future geocoding + indexed coordinates)
- Food default price 0–200 unless price=all
- Services openNow unused
- Admin tags CRUD still missing

## Production deployment status

**Not deployed** — branch/PR only; no merge, no EB deploy.

## Test plan

- [x] 
pm test — 92/92 pass
- [x] 
ode --check lib/listing/publicSearchFilters.js
- [x] 
ode --check controllers/publicListing.js
- [x] 
ode --check lib/listing/publicListingDto.js
- [ ] Post-merge prod smoke: GET /api/public/search?zip=...&tag=...&verified=true
- [ ] Post-merge prod smoke: geo params return ilters.unsupported

Made with [Cursor](https://cursor.com)