### PR TITLE
docs(tests): Stripe Connect checkout split payout runtime verification (#32)

### DIFF
--- a/docs/MVP_BACKEND_PROGRAM_STATUS.md
+++ b/docs/MVP_BACKEND_PROGRAM_STATUS.md
@@ -17,7 +17,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | **EB version label** | `mosaic-213423163964db9f32505ecb500d034b40fc583e` |
 | **`main` HEAD** | `6aa71ee` — post-#31 verification docs; **app runtime on EB matches `2134231`** |
 | **Open PR** | None for #31 — merged and deployed |
-| **Automated tests** | **123/123** on `main` / production |
+| **Automated tests** | **138/138** on audit branch (`123` baseline on prod runtime `2134231`) |
 | **Release model** | Controlled issue-by-issue merge → manual GHA EB deploy → tiered prod smoke → evidence in [deploy-verification.md](deploy-verification.md) |
 
 ---
@@ -32,7 +32,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | [#29](https://github.com/Techware-Hut/mosaic-backend/issues/29) | Search/filter readiness | **Merged** (PR #38) | **Live** (`9f66c07`+) | [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) |
 | [#30](https://github.com/Techware-Hut/mosaic-backend/issues/30) | Vendor onboarding + email | **Merged** (PR #39) | **Live** (`6cdf587`) | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) |
 | [#31](https://github.com/Techware-Hut/mosaic-backend/issues/31) | Vendor self-service APIs | **Merged** (PR #40) | **Live** (`2134231`) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
-| [#32](https://github.com/Techware-Hut/mosaic-backend/issues/32) | Stripe Connect runtime | **Not started** | N/A | [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) §10 |
+| [#32](https://github.com/Techware-Hut/mosaic-backend/issues/32) | Stripe Connect runtime | **In progress** (audit branch) | N/A (not deployed) | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
 | [#33](https://github.com/Techware-Hut/mosaic-backend/issues/33) | Email notifications | **Not started** | N/A | Audit §10 |
 | [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) | Admin APIs | **Not started** | N/A | Audit §10 |
 | [#35](https://github.com/Techware-Hut/mosaic-backend/issues/35) | Reviews | **Not started** | N/A | Audit §10 |
@@ -49,7 +49,7 @@ Issue #31 complete (merged, deployed, partial smoke). Tier-limit and vendor-orde
 
 ### Next scheduled work
 
-- **#32 Stripe Connect runtime** — prod smoke for checkout + webhooks; remediate unauthenticated `/stripe/*` routes. **Do not start until scheduled.**
+- **#32 Stripe Connect runtime** — audit complete on branch `sprint/backend-stripe-connect-runtime-verification` (docs + 15 tests); prod checkout smoke **PENDING** smoke accounts + live-charge gate. See [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md).
 
 ### Parallel / later
 

--- a/docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md
+++ b/docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md
@@ -1,0 +1,285 @@
+# MVP Backend Stripe Connect Runtime Verification (Issue #32)
+
+> **Status:** Audit complete on branch `sprint/backend-stripe-connect-runtime-verification` (docs + tests only; **not deployed**). Program snapshot: [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md).
+
+**Related:** [PAYMENT_FLOW.md](PAYMENT_FLOW.md), [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md), [TEST_MATRIX.md](TEST_MATRIX.md), [production-smoke-checklist.md](production-smoke-checklist.md)
+
+---
+
+## Purpose
+
+Audit and verify existing Stripe Connect checkout split-payout behavior without changing payment architecture, deploying, or running live charges. Confirm the backend can safely initiate Connect destination charges, calculate platform/vendor amounts, and transition order payment state via webhooks.
+
+**Out of scope:** Payment architecture refactor, deploy workflow edits, auth hardening on `/stripe/*`, changes to `GET /api/featured-products`, live production charges without written approval.
+
+---
+
+## Stripe Connect pattern
+
+| Aspect | Choice |
+|--------|--------|
+| Connect account type | **Express** |
+| Marketplace charge model | **Destination charges** on platform PaymentIntent |
+| Platform fee | Flat `PLATFORM_FEE_CENTS` → `application_fee_amount` |
+| Vendor payout | Stripe auto-transfers `amount - application_fee` via `transfer_data.destination` |
+| Currency | Hardcoded `usd` / `USD` |
+| Rounding | `Math.round(totalAmount * 100)` for PI cents |
+| PI idempotency | `idempotencyKey: pi:{orderId}` |
+| Refunds | `reverse_transfer: true`, `refund_application_fee: true` in order controller |
+
+**Not used:** separate charges + manual transfers, `on_behalf_of`, direct charges on connected account.
+
+### Split payout calculation
+
+```
+totalCents     = Math.round((subtotalInclTax + shipping) * 100)
+platformCents  = parseInt(PLATFORM_FEE_CENTS || "0", 10)
+vendorNetCents = totalCents - platformCents   // enforced by Stripe on destination transfer
+```
+
+Platform fee is a **flat per-order cent amount**, not a percentage. Default is `0` when env unset.
+
+---
+
+## Files audited
+
+### Controllers
+
+| File | Role |
+|------|------|
+| [`controllers/orderController.js`](../controllers/orderController.js) | `initiateOrder` — Connect PI creation; refund handlers |
+| [`controllers/stripePaymentController.js`](../controllers/stripePaymentController.js) | Post-payment webhook; `retrieveIntent` |
+| [`controllers/webhookController.js`](../controllers/webhookController.js) | Order status webhook (`payment_intent.*`, `charge.refunded`) |
+| [`controllers/connectController.js`](../controllers/connectController.js) | Connect onboarding Account Links + status sync |
+| [`controllers/stripe.controller.js`](../controllers/stripe.controller.js) | Embedded Connect dashboard helpers (**unauthenticated**) |
+| [`controllers/paymentController.js`](../controllers/paymentController.js) | Legacy PI path (no Connect split) |
+| [`controllers/stripeController.js`](../controllers/stripeController.js) | Subscription Checkout Session + `account.updated` |
+
+### Routes
+
+| File | Endpoints |
+|------|-----------|
+| [`routes/orderRoutes.js`](../routes/orderRoutes.js) | `POST /initiate`, `GET /retrieve-intent/:id` |
+| [`routes/webhookRoutes.js`](../routes/webhookRoutes.js) | `POST /api/webhooks/stripe` |
+| [`routes/stripeRoutes.js`](../routes/stripeRoutes.js) | `POST /api/stripe/webhook`, `POST /api/stripe/payment/webhook`, `POST /api/stripe/create-checkout-session` |
+| [`routes/connectRoutes.js`](../routes/connectRoutes.js) | `POST /api/connect/:businessId/account-link`, `GET .../status` |
+| [`routes/paymentRoutes.js`](../routes/paymentRoutes.js) | `POST /api/payments/create-payment-intent` (legacy) |
+| [`routes/stripe.routes.js`](../routes/stripe.routes.js) | `/stripe/*` (no `/api` prefix) |
+| [`app.js`](../app.js) | Webhook raw-body mounts before `express.json()` |
+
+### Models
+
+| File | Stripe fields |
+|------|---------------|
+| [`models/Business.js`](../models/Business.js) | `stripeConnectAccountId`, `chargesEnabled`, `payoutsEnabled`, `onboardingStatus`, `capabilities` |
+| [`models/Order.js`](../models/Order.js) | `paymentId`, `paymentStatus`, `items[].chargeId/transferId/applicationFeeId` |
+
+### Tests (existing + added)
+
+| File | Coverage |
+|------|----------|
+| [`tests/stripe/stripe-webhook-routing-signature.test.js`](../tests/stripe/stripe-webhook-routing-signature.test.js) | 5 webhook routes, signatures, mount order |
+| [`tests/stripe/order-initiate-connect.test.js`](../tests/stripe/order-initiate-connect.test.js) | **New** — Connect guards, fee params, rounding, safe errors |
+| [`tests/stripe/order-webhook-handlers.test.js`](../tests/stripe/order-webhook-handlers.test.js) | **New** — order status + post-payment webhook logic |
+
+---
+
+## Endpoints audited
+
+| Method | Route | Auth | Handler | Changed in #32 |
+|--------|-------|------|---------|----------------|
+| POST | `/api/orders/initiate` | Customer JWT | `initiateOrder` | No |
+| GET | `/api/orders/retrieve-intent/:id` | Customer JWT | `retrieveIntent` | No |
+| POST | `/api/webhooks/stripe` | Stripe signature | `handleStripeWebhook` | No |
+| POST | `/api/stripe/payment/webhook` | Stripe signature | `stripePaymentWebhook` | No |
+| POST | `/api/connect/:businessId/account-link` | Business owner | `createAccountLink` | No |
+| GET | `/api/connect/:businessId/status` | Business owner | `getStatus` | No |
+| POST | `/api/payments/create-payment-intent` | None (rate-limited) | `createPaymentIntent` | No |
+| POST/GET | `/stripe/*` | **None** | Connect dashboard helpers | No |
+| GET | `/api/featured-products` | Public | `getFeaturedProducts` | **No — preserved** |
+
+---
+
+## Required environment variables (names only)
+
+| Variable | Purpose |
+|----------|---------|
+| `STRIPE_SECRET_KEY` | All Stripe SDK calls; mode = `sk_test_*` or `sk_live_*` prefix |
+| `STRIPE_ORDER_WEBHOOK_SECRET` | Order status webhook signing |
+| `STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET` | Post-payment webhook signing |
+| `STRIPE_BUSINESS_DRAFT_WEBHOOK_SECRET` | Draft checkout + `account.updated` |
+| `STRIPE_SUBSCRIPTION_WEBHOOK_SECRET` | Subscription billing |
+| `STRIPE_VENDOR_VERIFICATION_WEBHOOK_SECRET` | Vendor $24.99 verification fee |
+| `PLATFORM_FEE_CENTS` | Flat platform fee per order (default `0`) |
+| `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL` | Connect onboarding redirects |
+| `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH` | Path fallbacks with `FRONTEND_URL` |
+| `FRONTEND_URL` | Connect return/refresh base |
+| `BILLING_PORTAL_RETURN_URL` | Billing portal return |
+
+Full list: [`.env.example`](../.env.example), [production-env-checklist.md](production-env-checklist.md)
+
+---
+
+## Checkout / order lifecycle
+
+```mermaid
+sequenceDiagram
+  participant FE as Frontend
+  participant API as POST_orders_initiate
+  participant DB as MongoDB
+  participant Stripe
+  participant WH1 as webhooks_stripe
+  participant WH2 as stripe_payment_webhook
+
+  FE->>API: items + shippingAddress (Bearer)
+  API->>DB: Validate variants, stock, prices
+  API->>Stripe: accounts.retrieve (Connect readiness)
+  API->>DB: Create Order pending/created
+  API->>Stripe: paymentIntents.create (destination + app fee)
+  API->>DB: Save paymentId
+  API-->>FE: clientSecret + totals
+  Note over API,FE: Pre-payment emails sent here (known P0-6)
+  FE->>Stripe: Confirm PI (Stripe.js)
+  Stripe->>WH1: payment_intent.succeeded
+  WH1->>DB: paymentStatus=paid, status=ordered
+  Stripe->>WH2: payment_intent.succeeded
+  WH2->>DB: charge/transfer/fee IDs on items
+  WH2->>FE: Paid confirmation emails
+```
+
+### Preconditions enforced in `initiateOrder`
+
+1. Valid cart items, shipping address, single vendor
+2. Server-derived prices (±$0.01 tolerance vs client `price`)
+3. Stock available (unless backorder allowed)
+4. `Business.stripeConnectAccountId` present
+5. Live Stripe account: `charges_enabled` + active `transfers` capability
+
+### Not enforced at checkout (documented gaps)
+
+- `Business.isApproved` / admin approval gate
+- Vendor onboarding `verified` status
+- Active subscription tier (listing gate only)
+
+---
+
+## Runtime safety review
+
+| Check | Result |
+|-------|--------|
+| Test vs live mode | Driven by `STRIPE_SECRET_KEY` prefix only |
+| Secret keys logged | **No** — logs use IDs, not keys |
+| Webhook secrets exposed | **No** — signature verification required |
+| Client responses safe | `initiateOrder` returns `clientSecret` only (expected for Stripe.js) |
+| Stripe errors to client | Generic `500` or mapped `400`; no secret leakage |
+| PI idempotency | `pi:{orderId}` on create |
+| Order double-create on retry | Order persisted before PI; retry creates new order (no cart-level idempotency) |
+| Webhook idempotency | Status updates idempotent; post-payment may resend emails on Stripe retry |
+
+---
+
+## Unsupported or unsafe scenarios
+
+| Scenario | Behavior | Safe? |
+|----------|----------|-------|
+| Vendor missing Connect account | 400 `"Vendor is not connected to Stripe."` | Yes — blocks checkout |
+| Connect onboarding incomplete | 400 `"Vendor Stripe onboarding incomplete."` | Yes |
+| Multi-vendor cart | 400 single-vendor message | Yes |
+| Price tampering | 400 price mismatch | Yes |
+| Legacy `/api/payments/create-payment-intent` | Plain PI, no Connect split, no auth | **Bypass risk** — document only |
+| Unauthenticated `/stripe/*` | Anyone with account ID can request sessions | **Unsafe** — track separately |
+| `retrieveIntent` full PI dump | Returns raw Stripe PaymentIntent object | **Review** — may expose internal fields |
+| `PLATFORM_FEE_CENTS >= total` | Stripe rejects PI after order saved | Low — orphan pending order |
+| Pre-payment order emails | Sent in `initiateOrder` before pay succeeds | Known product issue (P0-6) |
+| Prod live charge without approval | **STOP** — see gate below | N/A |
+
+---
+
+## Test coverage summary
+
+| Area | Automated | Manual / prod |
+|------|-----------|---------------|
+| Webhook routing + signatures | Yes (9 tests) | P4.1, P4.5 |
+| Connect checkout guards | Yes (10 tests) | P5.2 |
+| Platform fee on PI | Yes (mocked) | P5.3 + Dashboard |
+| Webhook order status | Yes (5 tests) | P4.4, P5.3 |
+| Full E2E pay + split payout | **No** | P5.3 (test mode) |
+| Live prod charge | **No** | **BLOCKED** |
+
+**Automated count:** 123 → **138** (`npm test`)
+
+New files:
+- `tests/stripe/order-initiate-connect.test.js` (10 tests)
+- `tests/stripe/order-webhook-handlers.test.js` (5 tests)
+
+---
+
+## Production smoke plan
+
+### Tier A — Safe, no charges (can run anytime)
+
+| Step | Action | Expected |
+|------|--------|----------|
+| A1 | `GET /health` | 200 |
+| A2 | Unsigned `POST /api/webhooks/stripe` | 400 missing signature |
+| A3 | `GET /api/connect/:businessId/status` (owner JWT) | Connect flags JSON |
+| A4 | Stripe Dashboard → Webhooks → delivery log | Recent 200s for 5 endpoints |
+
+### Tier B — Test-mode E2E (local/staging `sk_test_*` only)
+
+**Requires:** `SMOKE_TEST_CUSTOMER_*`, `SMOKE_TEST_VENDOR_*` with completed Connect test account and published listing.
+
+| Step | Action | Record |
+|------|--------|--------|
+| B1 | Login as smoke customer | JWT (do not commit) |
+| B2 | `POST /api/orders/initiate` — single vendor item | `orderId`, `clientSecret`, `totals.totalAmount` |
+| B3 | Confirm PI with Stripe test card `4242424242424242` | PI status `succeeded` |
+| B4 | Poll `GET /api/orders/retrieve-intent/:piId` | `paymentStatus: paid` |
+| B5 | Vendor `GET /api/orders/vendor` | Order visible |
+| B6 | Stripe Dashboard (test mode) | Charge shows `application_fee`, transfer to `acct_*` |
+| B7 | **Rollback** | Refund via vendor reject flow or Dashboard refund |
+
+### Tier C — Production API live charge
+
+## LIVE-CHARGE APPROVAL GATE — STOP
+
+**Do not run Tier C without ALL of:**
+
+1. Written approval from release owner
+2. Dedicated `SMOKE_TEST_*` accounts (not real customers/vendors)
+3. Smoke vendor with verified Connect account in production Stripe
+4. Pre-documented: product/listing ID, exact amount, expected `PLATFORM_FEE_CENTS`, refund owner
+5. Confirmation `STRIPE_SECRET_KEY` mode matches test intent (`sk_live_*` on prod EB per [production-env-checklist.md](production-env-checklist.md))
+
+**Current status:** **BLOCKED** — no `SMOKE_TEST_*` accounts provisioned; production uses live Stripe keys.
+
+### Rollback / refund considerations
+
+- **Test mode:** Stripe Dashboard refund or `orderController` reject/cancel refund path (`reverse_transfer: true`, `refund_application_fee: true`)
+- **Live approved smoke:** Same refund paths; record PI/charge IDs in proof pack; verify transfer reversal in Connect Dashboard
+- **Failed PI (never confirmed):** Order remains `pending`/`created`; no charge to refund
+
+---
+
+## Files changed in #32
+
+| File | Change |
+|------|--------|
+| `docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md` | **Created** |
+| `docs/TEST_MATRIX.md` | Stripe Connect checkout section |
+| `docs/deploy-verification.md` | #32 audit entry |
+| `docs/MVP_BACKEND_PROGRAM_STATUS.md` | #32 status update |
+| `tests/stripe/order-initiate-connect.test.js` | **Created** |
+| `tests/stripe/order-webhook-handlers.test.js` | **Created** |
+
+**Not changed:** Payment controllers, routes, deploy workflows, `GET /api/featured-products`.
+
+---
+
+## Confirmations
+
+- [x] No secrets committed
+- [x] No deployment workflow changed
+- [x] No unrelated marketplace/frontend endpoint changed
+- [x] Live runtime testing blocked pending approval + smoke accounts
+- [x] `GET /api/featured-products` preserved (canonical)

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -2,7 +2,7 @@
 
 Maps backend features to automated tests (`npm test`), manual smoke checks, and proof-pack evidence.
 
-**Runner:** `npm test` → `node --test tests/**/*.test.js` (123 tests, Node built-in runner)
+**Runner:** `npm test` → `node --test tests/**/*.test.js` (138 tests, Node built-in runner)
 
 **Test style:** Unit/integration-style tests with mocked Mongoose models and module hooks. They prove **handler logic and wiring** — not full end-to-end flows against live MongoDB, Stripe, or AWS in CI.
 
@@ -14,7 +14,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 
 | Layer | Count | What it validates |
 |-------|-------|-------------------|
-| Automated (`tests/`) | **123** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock (mocked) |
+| Automated (`tests/`) | **138** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked) |
 | Manual smoke script | 1 | Live API + DB auth/check per role |
 | Production smoke tiers | P0–P6 | Post-deploy on `https://api.mosaicbizhub.com` |
 | Proof pack | Per release | Redacted evidence matrix |
@@ -116,6 +116,25 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 | Signed Dashboard delivery | — | *(no automated test)* | Stripe → EB HTTP 200 end-to-end | Yes — P4.1 |
 
 See [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) for route ownership and curl smoke commands.
+
+---
+
+## Stripe Connect checkout tests (#32)
+
+| Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
+| --- | --- | --- | --- | --- |
+| Missing Connect account | [`tests/stripe/order-initiate-connect.test.js`](../tests/stripe/order-initiate-connect.test.js) | 400 when `stripeConnectAccountId` absent; no PI create | Live Stripe account state on prod | Yes — P5.2 |
+| Incomplete Connect onboarding | same | 400 when `charges_enabled` false or transfers inactive | Dashboard onboarding UX | Yes — P5.1 |
+| Connect PI params | same | `transfer_data.destination`, `application_fee_amount`, metadata, idempotency key | Actual split payout on Stripe | Yes — P5.3 Dashboard |
+| Platform fee env | same | `PLATFORM_FEE_CENTS` maps to `application_fee_amount` | EB env value in prod | Yes — infra review |
+| Cent rounding | same | `Math.round(total * 100)` for PI amount | All tax/shipping edge cases | Partial |
+| Price / vendor guards | same | Price mismatch 400; single-vendor only | Live cart E2E | Yes — P5.2 |
+| Safe error responses | same | No `sk_`/`whsec_` in JSON; generic 500 on Stripe API errors | All error paths | Partial |
+| Order status webhook | [`tests/stripe/order-webhook-handlers.test.js`](../tests/stripe/order-webhook-handlers.test.js) | `payment_intent.succeeded` → paid/ordered; failed → cancelled | Signed Dashboard delivery | Yes — P4.4, P5.3 |
+| Post-payment webhook | same | Stores charge/transfer/fee IDs; duplicate succeed idempotent | Email dedup on retry | Yes — P5.3 |
+| Full checkout E2E | — | *(no automated test)* | Client Stripe.js confirm + live webhooks | Yes — P5.2–P5.5 (test mode) |
+
+See [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md).
 
 ---
 
@@ -280,7 +299,7 @@ node scripts/verify-auth-check-smoke.js
 
 | Evidence type | Source | Automated equivalent |
 | --- | --- | --- |
-| `npm test` 123/123 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
+| `npm test` 138/138 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
 | Auth smoke script output | `scripts/verify-auth-check-smoke.js` | Partial — live auth/check only |
 | Smoke matrix P0–P6 | [production-smoke-checklist.md](production-smoke-checklist.md) | No — human execution |
 | Webhook unsigned 400 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) curl | Partial — 9 tests cover handler logic |
@@ -313,7 +332,9 @@ node scripts/verify-auth-check-smoke.js
 | `tests/vendor/vendor-variant-stock.test.js` | 5 | Variant stock PATCH |
 | `tests/vendor/vendor-orders.test.js` | 4 | Vendor order filter + accept guards |
 | `tests/stripe/stripe-webhook-routing-signature.test.js` | 9 | Webhook routing + signatures |
+| `tests/stripe/order-initiate-connect.test.js` | 10 | Connect checkout guards + PI params |
+| `tests/stripe/order-webhook-handlers.test.js` | 5 | Order payment webhook handlers |
 | `tests/marketplace/public-listing-dto.test.js` | 18 | Marketplace DTO normalization |
 | `tests/marketplace/featured-products-response.test.js` | 2 | Featured products wiring |
 | `tests/marketplace/public-search-filters.test.js` | 15 | Search/filter helpers + handler |
-| **Total** | **123** | |
+| **Total** | **138** | |

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -310,3 +310,34 @@ Full matrix: [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_S
 ### Conclusion
 
 **Deploy Go** for issue #31 vendor self-service APIs on `2134231`. Auth boundaries and search canary **PASS**. Tier-limit, stock, and vendor-order flows **PENDING** until dedicated `SMOKE_TEST_*` accounts exist. **Next scheduled issue:** #32 Stripe Connect runtime — do not start until scheduled. Program snapshot: [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md).
+
+---
+
+## Issue #32 — Stripe Connect runtime verification (audit branch)
+
+**Branch:** `sprint/backend-stripe-connect-runtime-verification`  
+**Scope:** Audit + docs + mocked tests only — **no deploy**, **no live charges**
+
+### Audit record
+
+| Field | Value |
+|-------|-------|
+| Base commit | `76713f2` (docs-only `main` after #31 deploy) |
+| EB production runtime | `2134231` (unchanged) |
+| Connect pattern | Express + destination charges + `application_fee_amount` |
+| Automated tests | **138/138** pass (`123` → `138`, +15 Connect/webhook handler tests) |
+| Evidence doc | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
+
+### Smoke summary
+
+| Area | Result |
+|------|--------|
+| Static code audit (Connect checkout, webhooks, guards) | **PASS** |
+| Mocked unit tests (initiateOrder, webhook handlers) | **PASS** — 138/138 |
+| Tier A prod smoke (unsigned webhook, health) | **Not run** — optional read-only |
+| Tier B test-mode E2E checkout + split payout | **BLOCKED** — requires `sk_test_*` env + smoke accounts |
+| Tier C prod live charge | **BLOCKED** — requires written approval + `SMOKE_TEST_*` accounts |
+
+### Conclusion
+
+**Audit Go** for issue #32 on branch `sprint/backend-stripe-connect-runtime-verification`. Connect destination-charge implementation verified in code and tests. Production runtime checkout proof **PENDING** until `SMOKE_TEST_*` accounts exist and Tier B/C gates are cleared. No deployment in this issue.

--- a/tests/stripe/order-initiate-connect.test.js
+++ b/tests/stripe/order-initiate-connect.test.js
@@ -1,0 +1,432 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const orderControllerPath = path.resolve(__dirname, '../../controllers/orderController.js');
+
+const vendorId = '507f1f77bcf86cd799439011';
+const businessId = '507f1f77bcf86cd799439012';
+const productId = '507f1f77bcf86cd799439013';
+const variantId = '507f1f77bcf86cd799439014';
+const userId = '507f1f77bcf86cd799439015';
+const connectAccountId = 'acct_test_connect_001';
+
+const defaultShipping = {
+  deliverySpeed: 'standard',
+  amount: 5,
+  method: 'flat_rate',
+  freeShippingApplied: false,
+  freeShippingThreshold: null,
+  matchedTier: null,
+};
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildVariant(overrides = {}) {
+  const owner = overrides.ownerId || vendorId;
+  const biz = overrides.businessId || businessId;
+  return {
+    _id: variantId,
+    ownerId: { toString: () => owner },
+    businessId: biz,
+    sku: 'SKU-TEST',
+    allowBackorder: false,
+    sizes: [
+      {
+        size: 'M',
+        stock: 10,
+        price: overrides.price ?? 25,
+        salePrice: null,
+        sku: 'SKU-M',
+      },
+    ],
+    productId: {
+      _id: { toString: () => productId },
+      title: 'Test Product',
+      ...(overrides.productId || {}),
+    },
+    ...overrides.variantExtra,
+  };
+}
+
+function buildBusiness(overrides = {}) {
+  return {
+    _id: businessId,
+    email: 'vendor@example.com',
+    stripeConnectAccountId: overrides.stripeConnectAccountId ?? connectAccountId,
+    taxSettings: {},
+    shippingSettings: { method: 'flat_rate', flatRate: { standard: 5 } },
+    save: async function save() {
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function buildStripeAccount(overrides = {}) {
+  return {
+    charges_enabled: overrides.charges_enabled ?? true,
+    payouts_enabled: overrides.payouts_enabled ?? true,
+    capabilities: {
+      card_payments: 'active',
+      transfers: overrides.transfers ?? 'active',
+    },
+  };
+}
+
+function loadInitiateOrder({
+  business = buildBusiness(),
+  stripeAccount = buildStripeAccount(),
+  variants = [buildVariant()],
+  variantById = null,
+  piCreateError = null,
+  shippingResult = defaultShipping,
+  taxPricing = { priceExclTax: 25, priceInclTax: 25 },
+} = {}) {
+  const piCreateCalls = [];
+  const accountRetrieveCalls = [];
+
+  const stripeMock = {
+    accounts: {
+      retrieve: async (accountId) => {
+        accountRetrieveCalls.push(accountId);
+        return stripeAccount;
+      },
+    },
+    paymentIntents: {
+      create: async (params, options) => {
+        if (piCreateError) {
+          throw piCreateError;
+        }
+        piCreateCalls.push({ params, options });
+        return {
+          id: 'pi_test_001',
+          client_secret: 'pi_test_001_secret_test',
+        };
+      },
+    },
+  };
+
+  let savedOrderPayload = null;
+  let orderIdCounter = 0;
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe' || (request.includes('node_modules') && request.replace(/\\/g, '/').includes('/stripe/'))) {
+      return class Stripe {
+        constructor() {
+          return stripeMock;
+        }
+      };
+    }
+    if (request === 'uuid') {
+      return { v4: () => 'group-order-test-uuid' };
+    }
+    if (request.endsWith('models/Order')) {
+      return class Order {
+        constructor(payload) {
+          Object.assign(this, payload);
+          this._id = { toString: () => `order_${++orderIdCounter}` };
+        }
+        async save() {
+          savedOrderPayload = { ...this };
+          return this;
+        }
+      };
+    }
+    if (request.endsWith('models/ProductVariant')) {
+      return {
+        findById: (id) => ({
+          populate: async () => {
+            if (variantById) {
+              return variantById(id);
+            }
+            const match = variants.find((v) => v._id === id) || variants[0];
+            return match;
+          },
+        }),
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findById: async () => business,
+      };
+    }
+    if (request.endsWith('models/User')) {
+      return {
+        findById: () => ({
+          select: () => ({
+            email: 'customer@example.com',
+          }),
+        }),
+      };
+    }
+    if (request.endsWith('utils/orderPhase')) {
+      return {
+        sendOrderStatusEmail: async () => {},
+        sendOrderUpdateEmail: async () => {},
+        sendVendorNewOrderEmail: async () => {},
+        sendCustomerOrderPlacedEmail: async () => {},
+      };
+    }
+    if (request.endsWith('utils/vendorShipping')) {
+      return {
+        calculateShippingForVendor: () => shippingResult,
+        normalizeDeliverySpeed: (value) => value || 'standard',
+      };
+    }
+    if (request.endsWith('utils/vendorTax')) {
+      return {
+        getResolvedTaxCategory: () => null,
+        getTaxRateForCategory: () => 0,
+        buildTaxAwareAmounts: () => taxPricing,
+        extractTaxFromInclusiveAmount: ({ inclusiveAmount }) => ({
+          amountExclTax: inclusiveAmount,
+          taxAmount: 0,
+          amountInclTax: inclusiveAmount,
+        }),
+        roundCurrency: (value) => Math.round(Number(value) * 100) / 100,
+      };
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[orderControllerPath];
+  const controller = require(orderControllerPath);
+  Module._load = originalLoad;
+
+  return {
+    initiateOrder: controller.initiateOrder,
+    getPiCreateCalls: () => piCreateCalls,
+    getAccountRetrieveCalls: () => accountRetrieveCalls,
+    getSavedOrderPayload: () => savedOrderPayload,
+  };
+}
+
+function baseRequest(overrides = {}) {
+  return {
+    user: { id: userId },
+    body: {
+      items: [
+        {
+          productId,
+          variantId,
+          size: 'M',
+          quantity: 1,
+          price: overrides.price ?? 25,
+        },
+      ],
+      shippingAddress: {
+        fullName: 'Test Customer',
+        phone: '+15551234567',
+        addressLine1: '123 Main St',
+      },
+      ...overrides.bodyExtra,
+    },
+  };
+}
+
+test('initiateOrder blocks checkout when vendor has no stripeConnectAccountId', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    business: buildBusiness({ stripeConnectAccountId: null }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /not connected to Stripe/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder blocks checkout when Connect charges_enabled is false', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    stripeAccount: buildStripeAccount({ charges_enabled: false, transfers: 'active' }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /onboarding incomplete/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder blocks checkout when transfers capability is inactive', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    stripeAccount: buildStripeAccount({ transfers: 'inactive' }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /onboarding incomplete/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder rejects multi-vendor cart', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const otherVendor = '507f1f77bcf86cd799439099';
+  const otherProductId = '507f1f77bcf86cd799439098';
+  const otherVariantId = '507f1f77bcf86cd799439099';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    variantById: (id) => {
+      if (id === variantId) {
+        return buildVariant();
+      }
+      return buildVariant({
+        ownerId: otherVendor,
+        productId: {
+          _id: { toString: () => otherProductId },
+          title: 'Other Product',
+        },
+        variantExtra: { _id: otherVariantId },
+      });
+    },
+  });
+  const res = mockResponse();
+
+  await initiateOrder(
+    {
+      user: { id: userId },
+      body: {
+        items: [
+          { productId, variantId, size: 'M', quantity: 1, price: 25 },
+          {
+            productId: otherProductId,
+            variantId: otherVariantId,
+            size: 'M',
+            quantity: 1,
+            price: 25,
+          },
+        ],
+        shippingAddress: {
+          fullName: 'Test Customer',
+          phone: '+15551234567',
+          addressLine1: '123 Main St',
+        },
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Single-vendor checkout only/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder rejects price mismatch', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({});
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest({ price: 99.99 }), res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Price mismatch/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder creates Connect destination PI with platform fee and idempotency key', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.PLATFORM_FEE_CENTS = '100';
+  const { initiateOrder, getPiCreateCalls, getAccountRetrieveCalls } = loadInitiateOrder({});
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.clientSecret, 'pi_test_001_secret_test');
+  assert.equal(getAccountRetrieveCalls()[0], connectAccountId);
+
+  const [{ params, options }] = getPiCreateCalls();
+  assert.equal(params.currency, 'usd');
+  assert.equal(params.amount, 3000);
+  assert.equal(params.application_fee_amount, 100);
+  assert.equal(params.transfer_data.destination, connectAccountId);
+  assert.ok(params.metadata.orderId);
+  assert.equal(params.metadata.groupOrderId, 'group-order-test-uuid');
+  assert.match(options.idempotencyKey, /^pi:order_/);
+});
+
+test('initiateOrder rounds total amount to nearest cent for Stripe', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.PLATFORM_FEE_CENTS = '0';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    shippingResult: {
+      ...defaultShipping,
+      amount: 5.015,
+    },
+    taxPricing: { priceExclTax: 10.01, priceInclTax: 10.01 },
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest({ price: 10.01 }), res);
+
+  assert.equal(res.statusCode, 201);
+  const [{ params }] = getPiCreateCalls();
+  assert.equal(params.amount, Math.round((10.01 + 5.015) * 100));
+});
+
+test('initiateOrder maps insufficient_capabilities_for_transfer to safe client message', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const stripeError = new Error('Transfer capability missing');
+  stripeError.code = 'insufficient_capabilities_for_transfer';
+  const { initiateOrder } = loadInitiateOrder({ piCreateError: stripeError });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /onboarding incomplete/i);
+  assert.doesNotMatch(JSON.stringify(res.body), /sk_test|whsec_/);
+});
+
+test('initiateOrder response exposes clientSecret but not secret keys', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.PLATFORM_FEE_CENTS = '0';
+  const { initiateOrder } = loadInitiateOrder({});
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.ok(res.body.clientSecret);
+  const serialized = JSON.stringify(res.body);
+  assert.doesNotMatch(serialized, /sk_test_mock/);
+  assert.doesNotMatch(serialized, /whsec_/);
+});
+
+test('initiateOrder returns generic 500 on unexpected Stripe errors', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const stripeError = new Error('Internal stripe failure');
+  stripeError.type = 'StripeAPIError';
+  const { initiateOrder } = loadInitiateOrder({ piCreateError: stripeError });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.message, 'Server error');
+  assert.doesNotMatch(JSON.stringify(res.body), /Internal stripe failure/);
+});

--- a/tests/stripe/order-webhook-handlers.test.js
+++ b/tests/stripe/order-webhook-handlers.test.js
@@ -1,0 +1,336 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const webhookControllerPath = path.resolve(__dirname, '../../controllers/webhookController.js');
+const stripePaymentControllerPath = path.resolve(__dirname, '../../controllers/stripePaymentController.js');
+
+const ORDER_ID = '507f1f77bcf86cd799439020';
+const PAYMENT_ID = 'pi_test_webhook_001';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function createStripeModule(stripeMock) {
+  return function StripeClient() {
+    return stripeMock;
+  };
+}
+
+function loadOrderStatusWebhook({ orderDoc, findByIdAndUpdateImpl } = {}) {
+  const updates = [];
+  const defaultOrder = orderDoc || {
+    _id: ORDER_ID,
+    paymentStatus: 'pending',
+    status: 'created',
+  };
+
+  const stripeMock = {
+    webhooks: {
+      constructEvent: () => ({
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: PAYMENT_ID,
+            metadata: { orderId: ORDER_ID },
+          },
+        },
+      }),
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return createStripeModule(stripeMock);
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        findByIdAndUpdate: async (id, update, opts) => {
+          updates.push({ id, update, opts });
+          if (findByIdAndUpdateImpl) {
+            return findByIdAndUpdateImpl(id, update, opts);
+          }
+          return {
+            ...defaultOrder,
+            ...update,
+            _id: id,
+          };
+        },
+      };
+    }
+    if (request.endsWith('models/Subscription')) {
+      return {};
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[webhookControllerPath];
+  const { handleStripeWebhook } = require(webhookControllerPath);
+  Module._load = originalLoad;
+
+  return { handleStripeWebhook, getUpdates: () => updates };
+}
+
+function loadFailedPaymentWebhook() {
+  const updates = [];
+  const stripeMock = {
+    webhooks: {
+      constructEvent: () => ({
+        type: 'payment_intent.payment_failed',
+        data: {
+          object: {
+            id: PAYMENT_ID,
+            metadata: { orderId: ORDER_ID },
+          },
+        },
+      }),
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return createStripeModule(stripeMock);
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        findByIdAndUpdate: async (id, update) => {
+          updates.push({ id, update });
+          return { _id: id, ...update };
+        },
+      };
+    }
+    if (request.endsWith('models/Subscription')) {
+      return {};
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[webhookControllerPath];
+  const { handleStripeWebhook } = require(webhookControllerPath);
+  Module._load = originalLoad;
+
+  return { handleStripeWebhook, getUpdates: () => updates };
+}
+
+function buildOrderForPostPayment(overrides = {}) {
+  const items = [
+    {
+      chargeId: null,
+      transferId: null,
+      applicationFeeId: null,
+    },
+  ];
+  return {
+    _id: ORDER_ID,
+    paymentId: PAYMENT_ID,
+    paymentStatus: overrides.paymentStatus || 'pending',
+    status: overrides.status || 'created',
+    statusHistory: overrides.statusHistory || [{ status: 'created' }],
+    items,
+    userId: { email: 'customer@example.com' },
+    vendorId: { email: 'vendor@example.com' },
+    businessId: {
+      email: 'biz@example.com',
+      owner: { email: 'owner@example.com' },
+    },
+    markModified() {},
+    save: async function save() {
+      this.saveCount = (this.saveCount || 0) + 1;
+      return this;
+    },
+  };
+}
+
+function loadPostPaymentWebhook({ orders = [], charge = {} } = {}) {
+  let emailSendCount = 0;
+  const defaultCharge = {
+    transfer: 'tr_test_001',
+    application_fee: 'fee_test_001',
+    ...charge,
+  };
+
+  const stripeMock = {
+    webhooks: {
+      constructEvent: () => ({
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: PAYMENT_ID,
+            latest_charge: 'ch_test_001',
+            currency: 'usd',
+          },
+        },
+      }),
+    },
+    charges: {
+      retrieve: async () => defaultCharge,
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return createStripeModule(stripeMock);
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        find: () => ({
+          populate: async () => orders,
+        }),
+      };
+    }
+    if (request.endsWith('utils/OrderMail')) {
+      return {
+        sendOrderPaidEmails: async () => {
+          emailSendCount += 1;
+        },
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[stripePaymentControllerPath];
+  const { stripePaymentWebhook } = require(stripePaymentControllerPath);
+  Module._load = originalLoad;
+
+  return {
+    stripePaymentWebhook,
+    getEmailSendCount: () => emailSendCount,
+  };
+}
+
+test('order status webhook marks order paid and ordered on payment_intent.succeeded', async () => {
+  process.env.STRIPE_ORDER_WEBHOOK_SECRET = 'whsec_order_test';
+  const { handleStripeWebhook, getUpdates } = loadOrderStatusWebhook();
+  const res = mockResponse();
+
+  await handleStripeWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(getUpdates().length, 1);
+  assert.equal(getUpdates()[0].update.paymentStatus, 'paid');
+  assert.equal(getUpdates()[0].update.status, 'ordered');
+});
+
+test('order status webhook duplicate succeed is idempotent', async () => {
+  process.env.STRIPE_ORDER_WEBHOOK_SECRET = 'whsec_order_test';
+  const { handleStripeWebhook, getUpdates } = loadOrderStatusWebhook({
+    findByIdAndUpdateImpl: async (id, update) => ({
+      _id: id,
+      paymentStatus: 'paid',
+      status: 'ordered',
+      ...update,
+    }),
+  });
+  const req = {
+    headers: { 'stripe-signature': 'sig_test' },
+    body: Buffer.from('{}'),
+  };
+
+  const res1 = mockResponse();
+  await handleStripeWebhook(req, res1);
+  const res2 = mockResponse();
+  await handleStripeWebhook(req, res2);
+
+  assert.equal(res1.statusCode, 200);
+  assert.equal(res2.statusCode, 200);
+  assert.equal(getUpdates().length, 2);
+  assert.equal(getUpdates()[0].update.paymentStatus, 'paid');
+  assert.equal(getUpdates()[1].update.paymentStatus, 'paid');
+});
+
+test('order status webhook marks failed payment as cancelled', async () => {
+  process.env.STRIPE_ORDER_WEBHOOK_SECRET = 'whsec_order_test';
+  const { handleStripeWebhook, getUpdates } = loadFailedPaymentWebhook();
+  const res = mockResponse();
+
+  await handleStripeWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(getUpdates()[0].update.paymentStatus, 'failed');
+  assert.equal(getUpdates()[0].update.status, 'cancelled');
+});
+
+test('post-payment webhook stores charge transfer and application fee IDs', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment();
+  const { stripePaymentWebhook } = loadPostPaymentWebhook({ orders: [order] });
+  const res = mockResponse();
+
+  await stripePaymentWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.ok(res.body.received);
+  assert.equal(order.paymentStatus, 'paid');
+  assert.equal(order.status, 'ordered');
+  assert.equal(order.items[0].chargeId, 'ch_test_001');
+  assert.equal(order.items[0].transferId, 'tr_test_001');
+  assert.equal(order.items[0].applicationFeeId, 'fee_test_001');
+});
+
+test('post-payment webhook duplicate succeed keeps paid status without corruption', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment({
+    paymentStatus: 'paid',
+    status: 'ordered',
+    statusHistory: [{ status: 'created' }, { status: 'ordered' }],
+  });
+  order.items[0].chargeId = 'ch_existing';
+  order.items[0].transferId = 'tr_existing';
+  order.items[0].applicationFeeId = 'fee_existing';
+
+  const { stripePaymentWebhook } = loadPostPaymentWebhook({ orders: [order] });
+  const req = {
+    headers: { 'stripe-signature': 'sig_test' },
+    body: Buffer.from('{}'),
+  };
+
+  const res1 = mockResponse();
+  await stripePaymentWebhook(req, res1);
+  const res2 = mockResponse();
+  await stripePaymentWebhook(req, res2);
+
+  assert.ok(res1.body.received);
+  assert.ok(res2.body.received);
+  assert.equal(order.paymentStatus, 'paid');
+  assert.equal(order.status, 'ordered');
+  assert.equal(order.items[0].chargeId, 'ch_test_001');
+  assert.equal(order.items[0].transferId, 'tr_test_001');
+  assert.equal(order.items[0].applicationFeeId, 'fee_test_001');
+});


### PR DESCRIPTION
## Summary
- Audit existing Connect destination-charge checkout (`POST /api/orders/initiate`).
- Add 15 mocked tests for Connect guards, fee params, rounding, webhook idempotency, and safe error responses.
- Document runtime verification, smoke tiers (A/B/C), and live-charge approval gate.

## Connect pattern
Express Connect + destination charges with `application_fee_amount` from `PLATFORM_FEE_CENTS`.

## Test plan
- [x] npm test (123 → 138, all pass)
- [x] No changes to GET /api/featured-products
- [ ] Prod live charge: NOT RUN (blocked — see `docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md`)

## Out of scope
- Payment architecture refactor
- Deploy / workflow changes
- Auth hardening on `/stripe/*` routes
- Legacy payment route remediation
- Business approval checkout gate fix
- PaymentIntent response sanitization
- Webhook/email timing changes

## Documented risks / follow-up issues needed
- Legacy `POST /api/payments/create-payment-intent` bypasses Connect and has no auth.
- `/stripe/*` routes are unauthenticated.
- No `Business.isApproved` gate at checkout.
- `retrieveIntent` returns full PaymentIntent object.
- `initiateOrder` sends pre-payment emails.
- Webhook retries may resend emails.
