### PR TITLE
feat(docs/tests): launch-safe backend email notification audit (#33)

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -805,7 +805,7 @@ exports.initiateOrder = async (req, res) => {
         );
       }
     } catch (err) {
-      console.error("Email sending failed:", err);
+      console.error("Email sending failed:", err?.message || err);
     }
 
     return res.status(201).json({
@@ -980,7 +980,7 @@ exports.acceptOrder = async (req, res) => {
         await sendOrderStatusEmail(customerEmail, order._id.toString(), "accepted");
       }
     } catch (e) {
-      console.error("Failed to send acceptance email:", e);
+      console.error("Failed to send acceptance email:", e?.message || e);
     }
 
     res.json({
@@ -1058,7 +1058,7 @@ exports.rejectOrder = async (req, res) => {
         await sendOrderStatusEmail(customerEmail, order._id.toString(), "rejected");
       }
     } catch (e) {
-      console.error("Failed to send rejection email:", e);
+      console.error("Failed to send rejection email:", e?.message || e);
     }
 
     res.json({

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -102,7 +102,7 @@ exports.stripePaymentWebhook = async (req, res) => {
             vendorEmails: uniqueVendorEmails,
           });
         } catch (mailErr) {
-          console.error("✉️ Failed to send order-paid emails:", mailErr);
+          console.error("✉️ Failed to send order-paid emails:", mailErr?.message || mailErr);
         }
       }
 

--- a/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
+++ b/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
@@ -1,0 +1,174 @@
+# MVP Backend Email Notifications (Issue #33)
+
+**Branch:** `sprint/backend-email-notifications`  
+**Status:** Audit + tests + docs (pre-merge)  
+**Program hub:** [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md)
+
+**Related:** [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) (issue #30 onboarding emails)
+
+---
+
+## Purpose
+
+Audit and document launch-safe backend email notification behavior for vendor onboarding, order confirmation, and review follow-up readiness. Add tests proving graceful SMTP failure handling and logging safety without faking delivery.
+
+**Principle:** Do not fake email delivery. When SMTP is missing or send fails, core HTTP flows still succeed unless the existing contract intentionally requires failure (e.g. forgot-password).
+
+---
+
+## Scope boundaries
+
+| Topic | Owner issue | #33 action |
+| --- | --- | --- |
+| Vendor onboarding emails (#30) | #30 | Preserve + test submit path |
+| Order confirmation **timing** (pre-payment vs post-payment) | #43 | Document only — do not move emails |
+| Webhook email dedup on retry | #43 | Document only |
+| Post-purchase review follow-up | #35 | Document gap — not implemented |
+| Stripe/payment/webhook architecture | #32 / #43 | No changes |
+
+---
+
+## Audited files and routes
+
+### Mail utilities
+
+| File | Functions | Domain |
+| --- | --- | --- |
+| [`utils/mailer.js`](../utils/mailer.js) | `sendOtpEmail`, `sendPasswordResetOtpEmail`, `sendWelcomeEmail` | Auth |
+| [`utils/WellcomeMailer.js`](../utils/WellcomeMailer.js) | Onboarding submit/approve/reject/badge, admin alerts | Vendor onboarding |
+| [`utils/vendorOnboardingEmailDelivery.js`](../utils/vendorOnboardingEmailDelivery.js) | `deliverVendorOnboardingEmail(s)` | Graceful SMTP gate |
+| [`utils/OrderMail.js`](../utils/OrderMail.js) | `sendOrderPaidEmails` | Post-payment confirmation + PDF invoice |
+| [`utils/orderPhase.js`](../utils/orderPhase.js) | Placed, accept/reject, shipped, delivered | Order lifecycle |
+| [`utils/approvalMail.js`](../utils/approvalMail.js) | Business approved/blocked/deactivated | Business admin |
+| [`utils/bookingMailer.js`](../utils/bookingMailer.js) | Service booking lifecycle | Bookings |
+| [`utils/BuisnessprofileMail.js`](../utils/BuisnessprofileMail.js) | Business profile admin review | Legacy profile flow |
+
+### Controllers with email triggers (primary #33 focus)
+
+| Controller | Route / trigger | Email type |
+| --- | --- | --- |
+| [`vendorOnboarding.controller.js`](../controllers/vendorOnboarding.controller.js) | `POST /api/vendor-onboarding/submit` | Admin + vendor submission receipt |
+| [`admin/vendorOnboardVerifyStage1.js`](../controllers/admin/vendorOnboardVerifyStage1.js) | `POST /api/vendor-onboarding/:id/finalize` | Approve / reject / badge |
+| [`orderController.js`](../controllers/orderController.js) | `POST /api/orders/initiate`, accept/reject/ship/deliver | Order placed + lifecycle |
+| [`stripePaymentController.js`](../controllers/stripePaymentController.js) | `POST /api/stripe/payment/webhook` | Order paid + invoice |
+
+### Environment variables (names only — never commit values)
+
+| Variable | Used for |
+| --- | --- |
+| `MAIL_USER` | SMTP auth + from address |
+| `MAIL_PASSWORD` | SMTP auth (Gmail app password) |
+| `ADMIN_EMAIL` | Admin notification recipients |
+| `SUPPORT_EMAIL` | Order mail support line fallback |
+| `APP_NAME` | Order phase subject branding |
+| `APP_URL` | Order mail links |
+| `FRONTEND_URL` | Approval mail + template links |
+
+---
+
+## Supported email types
+
+| Category | Trigger | Template / helper | Failure behavior |
+| --- | --- | --- | --- |
+| Vendor submission receipt | `submitForReview` | `sendVendorSubmissionConfirmationEmail` | Non-blocking; `emailSent` / `emailSkipped` on response |
+| Admin submission alert | `submitForReview` | `sendAdminOnboardingSubmissionEmail` | Same delivery helper |
+| Vendor approved | `finalizeVerification` | `sendVendorApprovedEmail` | Non-blocking; HTTP 200 |
+| Vendor rejected | `finalizeVerification` | `sendVendorRejectionEmail` | Non-blocking; HTTP 200 |
+| Trust badge assigned | `finalizeVerification` | `sendVendorTrustBadgeAssignedEmail` | Non-blocking; HTTP 200 |
+| Order placed (customer) | `initiateOrder` | `sendCustomerOrderPlacedEmail` | try/catch; order + PI still created |
+| Order placed (vendor) | `initiateOrder` | `sendVendorNewOrderEmail` | try/catch; order + PI still created |
+| Order paid + invoice | `payment_intent.succeeded` webhook | `sendOrderPaidEmails` | try/catch per order; webhook 200 |
+| Order accepted/rejected | accept/reject handlers | `sendOrderStatusEmail` | try/catch; order update succeeds |
+| Order shipped/delivered | ship/deliver handlers | `sendOrderUpdateEmail` | try/catch; order update succeeds |
+
+### Vendor submission receipt copy (#33)
+
+> Thank you for applying to Mosaic Biz Hub. Your information is under review. We'll email next steps within **3–5 business days**.
+
+Application ID and support contact are included. Approve/reject/badge templates from #30 are unchanged.
+
+---
+
+## Unsupported / deferred email types
+
+| Type | Status | Tracked in |
+| --- | --- | --- |
+| Post-purchase review follow-up | **Not implemented** — Review CRUD exists (`reviewController.js`) but no mailer, scheduler, or post-order hook | #35 |
+| Move order confirmation to post-payment only | **Deferred** — emails still fire at `initiateOrder` (P0-6) | #43 |
+| Webhook email dedup on retry | **Deferred** | #43 |
+| Food booking emails | **Not implemented** | — |
+| Unified mail service / retry queue | **Not implemented** | — |
+
+---
+
+## Failure behavior matrix
+
+| Flow | Missing SMTP | Send throws | HTTP outcome |
+| --- | --- | --- | --- |
+| Vendor submit / finalize | Skip + warn | Log message only | **200** — state persisted |
+| `initiateOrder` emails | N/A (no gate) | Log `err.message` | **201** — order + PI created |
+| Post-payment webhook emails | N/A | Log `mailErr.message` | **200** — webhook ack |
+| Order accept/reject/ship/deliver | N/A | Log message | **200** — order updated |
+| Register OTP | N/A | Log; registration succeeds | **200/201** |
+| Forgot password OTP | N/A | Log; returns error | **500** — intentional contract |
+
+---
+
+## Logging safety
+
+- [`vendorOnboardingEmailDelivery.js`](../utils/vendorOnboardingEmailDelivery.js): logs label + `err.message` only; never OTP, credentials, or full payloads
+- Order email catch blocks (#33): log `err?.message` / `mailErr?.message` only
+- `mailer.js`: OTP values are not logged (verified by automated source audit)
+
+---
+
+## Tests
+
+| File | Tests | Coverage |
+| --- | ---: | --- |
+| [`tests/admin/vendor-onboarding-finalize.test.js`](../tests/admin/vendor-onboarding-finalize.test.js) | 5 | Approve/reject + SMTP skip/failure (#30) |
+| [`tests/vendor/vendor-onboarding-submit-email.test.js`](../tests/vendor/vendor-onboarding-submit-email.test.js) | 4 | Submit email flags, skip, failure, idempotent |
+| [`tests/utils/vendor-onboarding-email-delivery.test.js`](../tests/utils/vendor-onboarding-email-delivery.test.js) | 6 | Delivery helper unit tests |
+| [`tests/email/email-notification-safety.test.js`](../tests/email/email-notification-safety.test.js) | 4 | Review gap audit, OTP/logging source checks |
+| [`tests/stripe/order-email-safety.test.js`](../tests/stripe/order-email-safety.test.js) | 3 | Post-payment email call + safe failure |
+
+**Suite total after #33:** **155/155** (`npm test`)
+
+**Not proven by automation:** Live SMTP inbox delivery, template rendering in real clients, PDF invoice attachment in production.
+
+---
+
+## Smoke test plan (`SMOKE_TEST_*` accounts only)
+
+Live SMTP inbox proof requires **disposable dedicated smoke accounts** — not automated in CI.
+
+| Tier | Scenario | Accounts | Expected |
+| --- | --- | --- | --- |
+| C1 | Vendor submit → receipt email | `SMOKE_TEST_VENDOR_*` | Inbox: submission receipt (3–5 business day copy) |
+| C2 | Admin finalize approve | `SMOKE_TEST_ADMIN_*` + pending vendor app | Inbox: approval email; API `emailSent: true` |
+| C3 | Admin finalize reject | Same | Inbox: rejection email |
+| B1 | Checkout → order paid email | `SMOKE_TEST_CUSTOMER_*` + vendor listing | Inbox: payment confirmation + invoice PDF |
+| B2 | Order placed (pre-payment) | Same | Inbox: placed email (document P0-6 timing risk) |
+
+**Blockers:** `SMOKE_TEST_*` accounts not provisioned in repo — all live inbox proof **PENDING**.
+
+---
+
+## Remaining risks
+
+| Risk | Detail |
+| --- | --- |
+| Pre-payment order emails | Customer may receive "order placed" before payment succeeds — #43 |
+| No webhook email dedup | Retry may resend paid confirmation — #43 |
+| No review follow-up | Post-purchase review prompt not implemented — #35 |
+| Fragmented mailers | 8+ files each create own Nodemailer transport |
+| Live SMTP unverified | Production inbox proof not captured |
+
+---
+
+## Related documentation
+
+- [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md)
+- [TEST_MATRIX.md](TEST_MATRIX.md)
+- [deploy-verification.md](deploy-verification.md)
+- [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) §5 gaps

--- a/docs/MVP_BACKEND_PROGRAM_STATUS.md
+++ b/docs/MVP_BACKEND_PROGRAM_STATUS.md
@@ -1,6 +1,6 @@
 # MVP Backend Program Status
 
-**Last updated:** 2026-06-17 (post-#32 deploy)  
+**Last updated:** 2026-06-17 (issue #33 branch)  
 **Canonical hub** for backend MVP sprint (#26–#35): where Mosaic is today, what is live in production, what is in flight, and what comes next.
 
 For deep technical detail, follow links to issue-specific docs — do not duplicate them here.
@@ -17,7 +17,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | **EB version label** | `mosaic-7f7e2930f931968da6985519cc3fc948aab778ae` |
 | **`main` HEAD** | `7f7e293` |
 | **Open PR** | None |
-| **Automated tests** | **138/138** on `main` |
+| **Automated tests** | **155/155** on `sprint/backend-email-notifications` branch (138 on prod `main`) |
 | **Release model** | Controlled issue-by-issue merge → manual GHA EB deploy → tiered prod smoke → evidence in [deploy-verification.md](deploy-verification.md) |
 
 ---
@@ -33,7 +33,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | [#30](https://github.com/Techware-Hut/mosaic-backend/issues/30) | Vendor onboarding + email | **Merged** (PR #39) | **Live** (`6cdf587`) | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) |
 | [#31](https://github.com/Techware-Hut/mosaic-backend/issues/31) | Vendor self-service APIs | **Merged** (PR #40) | **Live** (`2134231`) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
 | [#32](https://github.com/Techware-Hut/mosaic-backend/issues/32) | Stripe Connect runtime | **Merged** (PR #47) | **Live** (`7f7e293` docs/tests) | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
-| [#33](https://github.com/Techware-Hut/mosaic-backend/issues/33) | Email notifications | **Not started** | N/A | Audit §10 |
+| [#33](https://github.com/Techware-Hut/mosaic-backend/issues/33) | Email notifications | **In progress** (branch) | N/A | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
 | [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) | Admin APIs | **Not started** | N/A | Audit §10 |
 | [#35](https://github.com/Techware-Hut/mosaic-backend/issues/35) | Reviews | **Not started** | N/A | Audit §10 |
 
@@ -49,7 +49,7 @@ Issue #32 complete (merged, deployed). Checkout live smoke **PENDING** `SMOKE_TE
 
 ### Next scheduled work
 
-- **#33** Email notifications — order/onboarding/review templates
+- **#33** Email notifications — audit + tests + docs (**in progress** on `sprint/backend-email-notifications`)
 - **#41** Payment route hardening (P0 security follow-up from #32 audit)
 - **#42** Checkout approval gate + safe `retrieveIntent` response
 
@@ -96,7 +96,7 @@ flowchart TD
 | Gap | Impact | Where tracked |
 | --- | --- | --- |
 | No dedicated `SMOKE_TEST_*` vendor/admin accounts | Submit/finalize and tier-limit prod smoke **PENDING** / **SKIP** | [#30 deploy verification](deploy-verification.md), vendor self-service doc |
-| Live SMTP inbox proof not captured | Email delivery unverified on production | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) |
+| Live SMTP inbox proof not captured | Email delivery unverified on production | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
 | `PATCH /business-profile` skips Business sync | PUT works; PATCH partial sync gap | [business-sync.md](business-sync.md), [DECISION_REGISTER.md](DECISION_REGISTER.md) |
 | `Business.usage` counters not wired | Tier limits use live product/variant counts (#31) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
 | Service/food/private-listing ownership | Not covered by #31 unit tests | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |

--- a/docs/MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md
+++ b/docs/MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md
@@ -93,7 +93,7 @@ Document checklist (EIN, license, minority proof) is validated at **admin finali
 | Trigger | Template helper | Recipient |
 |---------|-----------------|-----------|
 | Submit success | `sendAdminOnboardingSubmissionEmail` | `ADMIN_EMAIL` |
-| Submit success | `sendVendorSubmissionConfirmationEmail` | Vendor user email |
+| Submit success | `sendVendorSubmissionConfirmationEmail` | Vendor user email — 3–5 business day receipt copy |
 | Finalize approve | `sendVendorApprovedEmail` | Vendor user email |
 | Finalize approve + badge | `sendVendorTrustBadgeAssignedEmail` | Vendor user email |
 | Finalize reject | `sendVendorRejectionEmail` | Vendor user email |
@@ -136,6 +136,7 @@ Secrets and full payloads are never logged.
 |------|------:|----------|
 | [`tests/vendor/vendor-onboarding-validation.test.js`](../tests/vendor/vendor-onboarding-validation.test.js) | 10 | Submit validation rules |
 | [`tests/admin/vendor-onboarding-finalize.test.js`](../tests/admin/vendor-onboarding-finalize.test.js) | 5 | Approve/reject, email graceful failure |
+| [`tests/vendor/vendor-onboarding-submit-email.test.js`](../tests/vendor/vendor-onboarding-submit-email.test.js) | 4 | Submit email flags + graceful failure |
 | Existing vendor/admin tests | 16 | Resubmit, pending queue, middleware |
 
 Full suite at **#30 merge:** **107/107** (`npm test` on production lineage `6cdf587`).  

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
 | [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md) | Issue #28 public listing/featured/detail DTO contract |
 | [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) | Issue #29 search/filter API readiness |
 | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) | Issue #30 vendor onboarding validation + email flow |
+| [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) | Issue #33 email notification audit + tests |
 | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) | Issue #31 vendor profile, listings, orders, stock |
 | [deploy-verification.md](deploy-verification.md) | Chronological MVP deploy verification log |
 

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -2,7 +2,7 @@
 
 Maps backend features to automated tests (`npm test`), manual smoke checks, and proof-pack evidence.
 
-**Runner:** `npm test` → `node --test tests/**/*.test.js` (138 tests, Node built-in runner)
+**Runner:** `npm test` → `node --test tests/**/*.test.js` (155 tests, Node built-in runner)
 
 **Test style:** Unit/integration-style tests with mocked Mongoose models and module hooks. They prove **handler logic and wiring** — not full end-to-end flows against live MongoDB, Stripe, or AWS in CI.
 
@@ -14,7 +14,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 
 | Layer | Count | What it validates |
 |-------|-------|-------------------|
-| Automated (`tests/`) | **138** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked) |
+| Automated (`tests/`) | **155** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked), **email notification safety** |
 | Manual smoke script | 1 | Live API + DB auth/check per role |
 | Production smoke tiers | P0–P6 | Post-deploy on `https://api.mosaicbizhub.com` |
 | Proof pack | Per release | Redacted evidence matrix |
@@ -208,7 +208,7 @@ These launch-critical areas have **no** meaningful automated coverage. They requ
 | **Connect onboarding** | No Connect tests | P5.1 | Connect status in Dashboard |
 | **Subscription billing E2E** | Webhook logic mocked | P4.3 | Invoice payment delivery |
 | **Order checkout E2E** | Order controller not tested | P5.2–P5.5 | Test order `paymentStatus: paid` |
-| **Admin finalize + emails** | Controller not tested | P3.4 | Approval/rejection email received |
+| **Admin finalize + emails** | Yes (5 finalize tests) | P3.4 | Live approval/rejection email received |
 | **Frontend integration** | Backend tests only | Script + P6 | `verify-auth-check-smoke.js` page loads |
 | **Cross-domain cookies** | Cookie helper unit-tested only | P1.4 | Browser session on `app.mosaicbizhub.com` |
 | **Open P0 blockers** | Documented gaps, not tested | Launch review | [launch-readiness-report.md](launch-readiness-report.md) §9 |
@@ -249,6 +249,19 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 
 ---
 
+## Email notification tests (issue #33)
+
+| Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
+| --- | --- | --- | --- | --- |
+| Submit email flags | [`tests/vendor/vendor-onboarding-submit-email.test.js`](../tests/vendor/vendor-onboarding-submit-email.test.js) | `emailSent`/`emailSkipped`, SMTP skip/failure, idempotent resubmit | Live SMTP delivery | Yes — Tier C |
+| Delivery helper | [`tests/utils/vendor-onboarding-email-delivery.test.js`](../tests/utils/vendor-onboarding-email-delivery.test.js) | Config gate, aggregation, message-only logging | Nodemailer transport | No |
+| Logging + review gap | [`tests/email/email-notification-safety.test.js`](../tests/email/email-notification-safety.test.js) | No review follow-up mailer; OTP not logged | Runtime log capture | No |
+| Order email safety | [`tests/stripe/order-email-safety.test.js`](../tests/stripe/order-email-safety.test.js) | Post-payment email call; webhook ack on mail failure | Live inbox | Yes — Tier B |
+
+**Readiness doc:** [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md)
+
+---
+
 ## Vendor onboarding email tests (issue #30)
 
 | Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
@@ -283,7 +296,7 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 ## How to run
 
 ```bash
-# All automated tests (123)
+# All automated tests (155)
 npm test
 
 # Manual auth smoke (live API + DB)
@@ -299,7 +312,7 @@ node scripts/verify-auth-check-smoke.js
 
 | Evidence type | Source | Automated equivalent |
 | --- | --- | --- |
-| `npm test` 138/138 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
+| `npm test` 155/155 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
 | Auth smoke script output | `scripts/verify-auth-check-smoke.js` | Partial — live auth/check only |
 | Smoke matrix P0–P6 | [production-smoke-checklist.md](production-smoke-checklist.md) | No — human execution |
 | Webhook unsigned 400 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) curl | Partial — 9 tests cover handler logic |
@@ -331,10 +344,14 @@ node scripts/verify-auth-check-smoke.js
 | `tests/vendor/vendor-listing-ownership.test.js` | 2 | Product update ownership |
 | `tests/vendor/vendor-variant-stock.test.js` | 5 | Variant stock PATCH |
 | `tests/vendor/vendor-orders.test.js` | 4 | Vendor order filter + accept guards |
+| `tests/vendor/vendor-onboarding-submit-email.test.js` | 4 | Submit email flags + graceful failure |
+| `tests/utils/vendor-onboarding-email-delivery.test.js` | 6 | Onboarding email delivery helper |
+| `tests/email/email-notification-safety.test.js` | 4 | Logging safety + review gap audit |
+| `tests/stripe/order-email-safety.test.js` | 3 | Post-payment email safe failure |
 | `tests/stripe/stripe-webhook-routing-signature.test.js` | 9 | Webhook routing + signatures |
 | `tests/stripe/order-initiate-connect.test.js` | 10 | Connect checkout guards + PI params |
 | `tests/stripe/order-webhook-handlers.test.js` | 5 | Order payment webhook handlers |
 | `tests/marketplace/public-listing-dto.test.js` | 18 | Marketplace DTO normalization |
 | `tests/marketplace/featured-products-response.test.js` | 2 | Featured products wiring |
 | `tests/marketplace/public-search-filters.test.js` | 15 | Search/filter helpers + handler |
-| **Total** | **138** | |
+| **Total** | **155** | |

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -344,3 +344,28 @@ Workflow post-deploy probes: root **200**, unauth auth/check **401**.
 ### Conclusion
 
 **Deploy Go** for issue #32 on `7f7e293`. Audit and test coverage merged; payment runtime unchanged (docs/tests only in deploy package). Live checkout proof **PENDING** smoke accounts. Follow-ups: #41, #42, #43, expanded #27.
+
+---
+
+## Planned — Issue #33 email notification audit (pre-deploy)
+
+**Branch:** `sprint/backend-email-notifications` (not yet merged/deployed)
+
+| Field | Value |
+|-------|-------|
+| Scope | Email audit, vendor submission receipt copy, logging hardening, tests, docs |
+| Runtime changes | Vendor submission email copy; order email failure logs message-only |
+| Stripe/payment | **No changes** |
+| Automated tests | **155/155** (138 baseline + 17 new) |
+| Evidence doc | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
+
+### Planned smoke (post-merge deploy)
+
+| Area | Expected | Status |
+|------|----------|--------|
+| Vendor submit receipt email | `SMOKE_TEST_VENDOR_*` inbox | **PENDING** |
+| Admin finalize approve/reject emails | `SMOKE_TEST_ADMIN_*` + pending app | **PENDING** |
+| Order paid confirmation email | `SMOKE_TEST_CUSTOMER_*` checkout | **PENDING** |
+| Live SMTP inbox proof | Disposable smoke accounts only | **PENDING** |
+
+**Conclusion:** Pre-merge only. No deploy claim until PR merged and EB deploy completed.

--- a/tests/email/email-notification-safety.test.js
+++ b/tests/email/email-notification-safety.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const utilsDir = path.resolve(__dirname, '../../utils');
+const mailerPath = path.resolve(utilsDir, 'mailer.js');
+const deliveryPath = path.resolve(utilsDir, 'vendorOnboardingEmailDelivery.js');
+
+function readUtilsSources() {
+  return fs.readdirSync(utilsDir)
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => ({
+      name,
+      source: fs.readFileSync(path.join(utilsDir, name), 'utf8'),
+    }));
+}
+
+test('no post-purchase review follow-up mailer exists in utils', () => {
+  const sources = readUtilsSources();
+  const reviewFollowUpPatterns = [
+    /sendReviewFollowUp/i,
+    /reviewFollowUp/i,
+    /postPurchaseReview/i,
+    /sendPostPurchaseReview/i,
+  ];
+
+  for (const { name, source } of sources) {
+    for (const pattern of reviewFollowUpPatterns) {
+      assert.equal(
+        pattern.test(source),
+        false,
+        `Unexpected review follow-up pattern in utils/${name}`
+      );
+    }
+  }
+});
+
+test('mailer.js does not log OTP values', () => {
+  const source = fs.readFileSync(mailerPath, 'utf8');
+  assert.ok(!source.includes('console.log') || !/console\.log\([^)]*otp/i.test(source));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*\botp\b/i));
+});
+
+test('vendorOnboardingEmailDelivery logs error message only', () => {
+  const source = fs.readFileSync(deliveryPath, 'utf8');
+  assert.ok(source.includes('err.message'));
+  assert.ok(source.includes('never logs secrets'));
+  assert.ok(!source.includes('console.error(`Vendor onboarding email failed (${label}):`, err)'));
+});
+
+test('vendorOnboardingEmailDelivery source avoids logging credential values', () => {
+  const source = fs.readFileSync(deliveryPath, 'utf8');
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_PASSWORD/));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_USER/));
+});

--- a/tests/stripe/order-email-safety.test.js
+++ b/tests/stripe/order-email-safety.test.js
@@ -1,0 +1,180 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const stripePaymentControllerPath = path.resolve(
+  __dirname,
+  '../../controllers/stripePaymentController.js'
+);
+const orderControllerPath = path.resolve(__dirname, '../../controllers/orderController.js');
+
+const ORDER_ID = '507f1f77bcf86cd799439020';
+const PAYMENT_ID = 'pi_test_email_safety';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function createStripeModule(stripeMock) {
+  return function StripeClient() {
+    return stripeMock;
+  };
+}
+
+function buildOrderForPostPayment() {
+  return {
+    _id: ORDER_ID,
+    paymentId: PAYMENT_ID,
+    paymentStatus: 'pending',
+    status: 'created',
+    statusHistory: [{ status: 'created' }],
+    items: [{ chargeId: null, transferId: null, applicationFeeId: null }],
+    userId: { email: 'customer@example.com' },
+    vendorId: { email: 'vendor@example.com' },
+    businessId: {
+      email: 'biz@example.com',
+      owner: { email: 'owner@example.com' },
+    },
+    markModified() {},
+    save: async function save() {
+      return this;
+    },
+  };
+}
+
+function loadPostPaymentWebhook({ orders = [], mailShouldFail = false } = {}) {
+  let emailSendCount = 0;
+
+  const stripeMock = {
+    webhooks: {
+      constructEvent: () => ({
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: PAYMENT_ID,
+            latest_charge: 'ch_test_001',
+            currency: 'usd',
+          },
+        },
+      }),
+    },
+    charges: {
+      retrieve: async () => ({
+        transfer: 'tr_test_001',
+        application_fee: 'fee_test_001',
+      }),
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return createStripeModule(stripeMock);
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        find: () => ({
+          populate: async () => orders,
+        }),
+      };
+    }
+    if (request.endsWith('utils/OrderMail')) {
+      return {
+        sendOrderPaidEmails: async () => {
+          emailSendCount += 1;
+          if (mailShouldFail) {
+            throw new Error('SMTP unavailable');
+          }
+        },
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[stripePaymentControllerPath];
+  const { stripePaymentWebhook } = require(stripePaymentControllerPath);
+  Module._load = originalLoad;
+
+  return {
+    stripePaymentWebhook,
+    getEmailSendCount: () => emailSendCount,
+  };
+}
+
+test('post-payment webhook calls sendOrderPaidEmails on success', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment();
+  const { stripePaymentWebhook, getEmailSendCount } = loadPostPaymentWebhook({ orders: [order] });
+  const res = mockResponse();
+
+  await stripePaymentWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.ok(res.body.received);
+  assert.equal(getEmailSendCount(), 1);
+});
+
+test('post-payment webhook still returns received when email send fails', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment();
+  const errorLogs = [];
+  const originalError = console.error;
+  console.error = (...args) => errorLogs.push(args.join(' '));
+
+  const { stripePaymentWebhook, getEmailSendCount } = loadPostPaymentWebhook({
+    orders: [order],
+    mailShouldFail: true,
+  });
+  const res = mockResponse();
+
+  await stripePaymentWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  console.error = originalError;
+
+  assert.ok(res.body.received);
+  assert.equal(getEmailSendCount(), 1);
+  assert.ok(errorLogs.some((line) => line.includes('SMTP unavailable')));
+  assert.ok(!errorLogs.some((line) => line.includes('whsec_')));
+});
+
+test('initiateOrder catches pre-payment email failures without rethrowing', () => {
+  const source = fs.readFileSync(orderControllerPath, 'utf8');
+  const initiateBlock = source.slice(
+    source.indexOf('// 📧 EMAILS (CUSTOMER + VENDOR)'),
+    source.indexOf('return res.status(201).json({', source.indexOf('// 📧 EMAILS (CUSTOMER + VENDOR)'))
+  );
+
+  assert.ok(initiateBlock.includes('try {'));
+  assert.ok(initiateBlock.includes('sendCustomerOrderPlacedEmail'));
+  assert.ok(initiateBlock.includes('sendVendorNewOrderEmail'));
+  assert.ok(initiateBlock.includes('catch (err)'));
+  assert.ok(initiateBlock.includes('err?.message'));
+});

--- a/tests/utils/vendor-onboarding-email-delivery.test.js
+++ b/tests/utils/vendor-onboarding-email-delivery.test.js
@@ -1,0 +1,135 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  isVendorEmailConfigured,
+  deliverVendorOnboardingEmail,
+  deliverVendorOnboardingEmails,
+} = require('../../utils/vendorOnboardingEmailDelivery');
+
+const originalMailUser = process.env.MAIL_USER;
+const originalMailPassword = process.env.MAIL_PASSWORD;
+
+function restoreMailEnv() {
+  if (originalMailUser === undefined) {
+    delete process.env.MAIL_USER;
+  } else {
+    process.env.MAIL_USER = originalMailUser;
+  }
+  if (originalMailPassword === undefined) {
+    delete process.env.MAIL_PASSWORD;
+  } else {
+    process.env.MAIL_PASSWORD = originalMailPassword;
+  }
+}
+
+test('isVendorEmailConfigured returns false when MAIL_USER or MAIL_PASSWORD missing', () => {
+  process.env.MAIL_USER = '';
+  process.env.MAIL_PASSWORD = 'secret';
+  assert.equal(isVendorEmailConfigured(), false);
+
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = '';
+  assert.equal(isVendorEmailConfigured(), false);
+
+  restoreMailEnv();
+});
+
+test('isVendorEmailConfigured returns true when both env vars are set', () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+  assert.equal(isVendorEmailConfigured(), true);
+  restoreMailEnv();
+});
+
+test('deliverVendorOnboardingEmail skips when SMTP not configured', async () => {
+  process.env.MAIL_USER = '';
+  process.env.MAIL_PASSWORD = '';
+
+  const warnLogs = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnLogs.push(args.join(' '));
+
+  const result = await deliverVendorOnboardingEmail({
+    label: 'test_skip',
+    send: async () => {
+      throw new Error('should not run');
+    },
+  });
+
+  console.warn = originalWarn;
+  restoreMailEnv();
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, 'email_not_configured');
+  assert.ok(warnLogs.some((line) => line.includes('test_skip')));
+});
+
+test('deliverVendorOnboardingEmail returns sent on success', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+
+  const result = await deliverVendorOnboardingEmail({
+    label: 'test_success',
+    send: async () => {},
+  });
+
+  restoreMailEnv();
+
+  assert.equal(result.sent, true);
+  assert.equal(result.skipped, false);
+});
+
+test('deliverVendorOnboardingEmail logs message only on failure', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+
+  const errorLogs = [];
+  const originalError = console.error;
+  console.error = (...args) => errorLogs.push(args.join(' '));
+
+  const result = await deliverVendorOnboardingEmail({
+    label: 'test_fail',
+    send: async () => {
+      throw new Error('SMTP timeout');
+    },
+  });
+
+  console.error = originalError;
+  restoreMailEnv();
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, false);
+  assert.equal(result.error, 'SMTP timeout');
+  assert.ok(errorLogs.some((line) => line.includes('test_fail')));
+  assert.ok(!errorLogs.some((line) => line.includes('app-password')));
+});
+
+test('deliverVendorOnboardingEmails aggregates partial success', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+
+  const delivery = await deliverVendorOnboardingEmails([
+    {
+      label: 'first',
+      send: async () => {},
+    },
+    {
+      label: 'second',
+      send: async () => {
+        throw new Error('second failed');
+      },
+    },
+  ]);
+
+  restoreMailEnv();
+
+  assert.equal(delivery.emailSent, true);
+  assert.equal(delivery.emailSkipped, false);
+  assert.equal(delivery.emailFailed, false);
+  assert.equal(delivery.results.length, 2);
+  assert.equal(delivery.results[0].sent, true);
+  assert.equal(delivery.results[1].sent, false);
+});

--- a/tests/vendor/vendor-onboarding-submit-email.test.js
+++ b/tests/vendor/vendor-onboarding-submit-email.test.js
@@ -1,0 +1,208 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/vendorOnboarding.controller.js'
+);
+const emailDeliveryPath = path.resolve(
+  __dirname,
+  '../../utils/vendorOnboardingEmailDelivery.js'
+);
+
+const userId = '507f1f77bcf86cd799439011';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOnboarding(overrides = {}) {
+  return {
+    userId,
+    applicationId: 'MBH-APP-SUBMIT-001',
+    businessName: 'Test Business LLC',
+    businessType: 'product',
+    primaryContactName: 'Jane Vendor',
+    address: {
+      city: 'Atlanta',
+      state: 'GA',
+      country: 'USA',
+      zipCode: '30301',
+    },
+    acceptedTerms: true,
+    declarationAccepted: true,
+    isMinorityOwned: false,
+    status: 'draft',
+    verificationPayment: { status: 'paid' },
+    toObject() {
+      return { ...this };
+    },
+    save: async function save() {
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function loadController({
+  onboarding,
+  mailerCalls = {},
+  emailConfigured = true,
+  mailerOverrides = {},
+}) {
+  process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+  process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+  process.env.MAIL_USER = emailConfigured ? 'mail@example.com' : '';
+  process.env.MAIL_PASSWORD = emailConfigured ? 'app-password' : '';
+
+  const vendorOnboardingMock = {
+    findOne: async () => onboarding,
+  };
+
+  const userMock = {
+    findById: () => ({
+      select: async () => ({ name: 'Vendor User', email: 'vendor@example.com' }),
+    }),
+  };
+
+  const mailerMock = {
+    sendAdminOnboardingSubmissionEmail:
+      mailerOverrides.sendAdminOnboardingSubmissionEmail
+      || (async (payload) => {
+        mailerCalls.admin = payload;
+      }),
+    sendVendorSubmissionConfirmationEmail:
+      mailerOverrides.sendVendorSubmissionConfirmationEmail
+      || (async (payload) => {
+        mailerCalls.vendor = payload;
+      }),
+    sendAdminVendorProfileCompletedEmail: async () => {},
+  };
+
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return () => ({
+        paymentIntents: { create: async () => ({ id: 'pi_test' }) },
+      });
+    }
+    if (request === '../models/VendorOnboardingStage1') {
+      return vendorOnboardingMock;
+    }
+    if (request === '../models/User') {
+      return userMock;
+    }
+    if (request === '../utils/WellcomeMailer') {
+      return mailerMock;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  delete require.cache[emailDeliveryPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+
+  return { controller, mailerCalls };
+}
+
+test('submitForReview sends admin and vendor emails when SMTP configured', async () => {
+  const onboarding = buildOnboarding();
+  const { controller, mailerCalls } = loadController({ onboarding });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(onboarding.status, 'submitted');
+  assert.equal(res.body.emailSent, true);
+  assert.equal(res.body.emailSkipped, false);
+  assert.ok(mailerCalls.admin);
+  assert.ok(mailerCalls.vendor);
+  assert.equal(mailerCalls.vendor.to, 'vendor@example.com');
+});
+
+test('submitForReview skips emails when SMTP not configured', async () => {
+  const onboarding = buildOnboarding();
+  const mailerCalls = {};
+  const { controller } = loadController({
+    onboarding,
+    mailerCalls,
+    emailConfigured: false,
+  });
+  const res = mockResponse();
+
+  const warnLogs = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnLogs.push(args.join(' '));
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  console.warn = originalWarn;
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(onboarding.status, 'submitted');
+  assert.equal(res.body.emailSent, false);
+  assert.equal(res.body.emailSkipped, true);
+  assert.equal(mailerCalls.admin, undefined);
+  assert.equal(mailerCalls.vendor, undefined);
+  assert.ok(warnLogs.some((line) => line.includes('not configured')));
+});
+
+test('submitForReview succeeds when email send fails', async () => {
+  const onboarding = buildOnboarding();
+  const errorLogs = [];
+  const originalError = console.error;
+  console.error = (...args) => errorLogs.push(args.join(' '));
+
+  const { controller } = loadController({
+    onboarding,
+    mailerOverrides: {
+      sendAdminOnboardingSubmissionEmail: async () => {
+        throw new Error('SMTP connection refused');
+      },
+      sendVendorSubmissionConfirmationEmail: async () => {
+        throw new Error('SMTP connection refused');
+      },
+    },
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  console.error = originalError;
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(onboarding.status, 'submitted');
+  assert.equal(res.body.emailSent, false);
+  assert.ok(errorLogs.some((line) => line.includes('admin_submission')));
+  assert.ok(!errorLogs.some((line) => line.includes('app-password')));
+});
+
+test('submitForReview idempotent when already submitted does not resend emails', async () => {
+  const onboarding = buildOnboarding({ status: 'submitted' });
+  const mailerCalls = {};
+  const { controller } = loadController({ onboarding, mailerCalls });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(mailerCalls.admin, undefined);
+  assert.equal(mailerCalls.vendor, undefined);
+});

--- a/utils/WellcomeMailer.js
+++ b/utils/WellcomeMailer.js
@@ -107,22 +107,17 @@ exports.sendVendorSubmissionConfirmationEmail = async ({
   const mailOptions = {
     from: `"Mosaic Biz Hub" <${process.env.MAIL_USER}>`,
     to,
-    subject: "Your Business Verification Is Under Review",
+    subject: "Your Mosaic Biz Hub Application Is Under Review",
     html: `
       <div style="font-family: Arial, sans-serif; background:#f9f9f9; padding:20px;">
         <h2 style="color:#333;">Hi ${vendorName},</h2>
 
         <p>
-          Thank you for submitting your business details to Mosaic Biz Hub.
-          Your application is currently under review.
+          Thank you for applying to Mosaic Biz Hub. Your information is under review.
+          We’ll email next steps within <strong>3–5 business days</strong>.
         </p>
 
         <p><strong>Application ID:</strong> ${applicationId}</p>
-
-        <p>
-          Our team typically completes verification within <strong>48 hours</strong>.
-          You’ll receive an email once the review is complete.
-        </p>
 
         <p style="margin-top:20px;">
           If you have questions, contact us at


### PR DESCRIPTION
## Summary
- Audit and document launch-safe backend email notifications (vendor onboarding, order confirmation, deferred review follow-up).
- Align vendor application receipt copy to 3-5 business day SLA wording.
- Add 17 tests for submit email flags, delivery helper, order email safe failure, and logging safety.
- Preserve #30 finalize approve/reject behavior.

## Scope boundaries
- Order confirmation timing and webhook email dedup -> #43
- Post-purchase review follow-up emails -> #35 (documented gap)

## Test plan
- [x] npm test (138 -> 155)
- [x] Vendor submit: emailSent/emailSkipped when SMTP configured/missing
- [x] Finalize approve/reject: existing 5 tests still pass
- [x] Post-payment webhook: mail failure does not break 200 ack
- [ ] Manual smoke PENDING SMOKE_TEST_* accounts

Made with [Cursor](https://cursor.com)