### PR TITLE
fix(checkout): enforce business approval and sanitize PaymentIntent response (#42)

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -96,6 +96,7 @@ const Order = require("../models/Order");
 const User = require("../models/User");
 const ProductVariant = require("../models/ProductVariant")  ;
 const Business = require("../models/Business");
+const { getBusinessCheckoutBlock } = require("../utils/checkoutGuards");
 const { sendOrderStatusEmail, sendOrderUpdateEmail, sendVendorNewOrderEmail, sendCustomerOrderPlacedEmail } = require("../utils/orderPhase");
 const {
   calculateShippingForVendor,
@@ -573,10 +574,11 @@ exports.initiateOrder = async (req, res) => {
     const business = await Business.findById(businessId);
     const user = await User.findById(userId).select("email");
 
-    if (!business || !business.stripeConnectAccountId) {
-      return res.status(400).json({
+    const checkoutBlock = getBusinessCheckoutBlock(business);
+    if (checkoutBlock) {
+      return res.status(checkoutBlock.status).json({
         success: false,
-        message: "Vendor is not connected to Stripe.",
+        message: checkoutBlock.message,
       });
     }
 

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -1,6 +1,10 @@
 const Stripe = require("stripe");
 const Order = require("../models/Order");
 const { sendOrderPaidEmails } = require("../utils/OrderMail");
+const {
+  sanitizePaymentIntentForClient,
+  sanitizeOrderForPaymentPoll,
+} = require("../utils/paymentIntentResponse");
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 exports.stripePaymentWebhook = async (req, res) => {
@@ -117,17 +121,18 @@ exports.stripePaymentWebhook = async (req, res) => {
   }
 };
 
-// ✅ Retrieve payment intent details
+// ✅ Retrieve payment intent details (sanitized for frontend)
 exports.retrieveIntent = async (req, res) => {
   const { id } = req.params;
+  const customerId = req.user?.id || req.user?._id;
 
   try {
-    const paymentIntent = await stripe.paymentIntents.retrieve(id);
-
-    const orders = await Order.find({ paymentId: id }).populate({
-      path: "items.productId",
-      select: "title coverImage", // optional, you can add more fields
-    });
+    const orders = await Order.find({ paymentId: id })
+      .select('userId groupOrderId status paymentStatus totalAmount currency items')
+      .populate({
+        path: "items.productId",
+        select: "title",
+      });
 
     if (!orders || orders.length === 0) {
       return res
@@ -135,17 +140,29 @@ exports.retrieveIntent = async (req, res) => {
         .json({ success: false, message: "No orders found for this payment" });
     }
 
+    const ownsAllOrders = orders.every(
+      (order) => order.userId?.toString() === String(customerId)
+    );
+
+    if (!ownsAllOrders) {
+      return res.status(403).json({
+        success: false,
+        message: "Not allowed to view this payment.",
+      });
+    }
+
+    const paymentIntent = await stripe.paymentIntents.retrieve(id);
+
     return res.status(200).json({
       success: true,
-      paymentIntent,
-      orders,
+      paymentIntent: sanitizePaymentIntentForClient(paymentIntent),
+      orders: orders.map(sanitizeOrderForPaymentPoll),
     });
   } catch (error) {
     console.error("❌ Failed to retrieve payment intent:", error.message);
     return res.status(500).json({
       success: false,
       message: "Failed to fetch payment information",
-      error: error.message,
     });
   }
 };

--- a/docs/MVP_BACKEND_PROGRAM_STATUS.md
+++ b/docs/MVP_BACKEND_PROGRAM_STATUS.md
@@ -1,6 +1,6 @@
 # MVP Backend Program Status
 
-**Last updated:** 2026-06-17 (post-#32 deploy)  
+**Last updated:** 2026-06-17 (issue #42 branch)  
 **Canonical hub** for backend MVP sprint (#26–#35): where Mosaic is today, what is live in production, what is in flight, and what comes next.
 
 For deep technical detail, follow links to issue-specific docs — do not duplicate them here.
@@ -17,7 +17,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | **EB version label** | `mosaic-7f7e2930f931968da6985519cc3fc948aab778ae` |
 | **`main` HEAD** | `7f7e293` |
 | **Open PR** | None |
-| **Automated tests** | **138/138** on `main` |
+| **Automated tests** | **151/151** on `sprint/backend-checkout-approval-paymentintent-safety` (138 on prod `main`) |
 | **Release model** | Controlled issue-by-issue merge → manual GHA EB deploy → tiered prod smoke → evidence in [deploy-verification.md](deploy-verification.md) |
 
 ---
@@ -36,6 +36,7 @@ For deep technical detail, follow links to issue-specific docs — do not duplic
 | [#33](https://github.com/Techware-Hut/mosaic-backend/issues/33) | Email notifications | **Not started** | N/A | Audit §10 |
 | [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) | Admin APIs | **Not started** | N/A | Audit §10 |
 | [#35](https://github.com/Techware-Hut/mosaic-backend/issues/35) | Reviews | **Not started** | N/A | Audit §10 |
+| [#42](https://github.com/Techware-Hut/mosaic-backend/issues/42) | Checkout approval + safe PI | **In progress** (branch) | N/A | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) §#42 |
 
 **Deploy log:** chronological merge/deploy/smoke records → [deploy-verification.md](deploy-verification.md)
 
@@ -51,7 +52,7 @@ Issue #32 complete (merged, deployed). Checkout live smoke **PENDING** `SMOKE_TE
 
 - **#33** Email notifications — order/onboarding/review templates
 - **#41** Payment route hardening (P0 security follow-up from #32 audit)
-- **#42** Checkout approval gate + safe `retrieveIntent` response
+- **#42** Checkout approval gate + safe `retrieveIntent` — **in progress** on `sprint/backend-checkout-approval-paymentintent-safety`
 
 ### Parallel / later
 

--- a/docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md
+++ b/docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md
@@ -152,25 +152,82 @@ sequenceDiagram
 1. Valid cart items, shipping address, single vendor
 2. Server-derived prices (±$0.01 tolerance vs client `price`)
 3. Stock available (unless backorder allowed)
-4. `Business.stripeConnectAccountId` present
-5. Live Stripe account: `charges_enabled` + active `transfers` capability
+4. **`Business.isApproved === true`** (#42)
+5. **`Business.isActive === true`** (#42)
+6. `Business.stripeConnectAccountId` present
+7. Live Stripe account: `charges_enabled` + active `transfers` capability
 
 ### Not enforced at checkout (documented gaps)
 
-- `Business.isApproved` / admin approval gate
-- Vendor onboarding `verified` status
+- Vendor onboarding `verified` status (separate from `Business.isApproved`)
 - Active subscription tier (listing gate only)
 
 ---
 
-## Runtime safety review
+## Checkout approval gate (#42)
+
+**Helper:** [`utils/checkoutGuards.js`](../utils/checkoutGuards.js) — `getBusinessCheckoutBlock(business)`
+
+| Business state | HTTP | Message |
+| --- | --- | --- |
+| Missing | 404 | Vendor business not found. |
+| `isApproved === false` | 403 | This vendor is not approved for checkout. |
+| `isActive === false` | 403 | This vendor is temporarily unavailable for checkout. |
+| No `stripeConnectAccountId` | 400 | Vendor is not connected to Stripe. |
+| Approved + active + Connect ready | — | Proceeds to PI creation |
+
+Admin block flow sets `isApproved: false` and `isActive: false` together ([`business.Controller.js`](../controllers/admin/business.Controller.js)).
+
+---
+
+## Sanitized PaymentIntent response (#42)
+
+**Endpoint:** `GET /api/orders/retrieve-intent/:id` (customer JWT required)
+
+**Helper:** [`utils/paymentIntentResponse.js`](../utils/paymentIntentResponse.js)
+
+### Ownership
+
+- Loads orders by `paymentId` first
+- Returns **403** if any order `userId` does not match authenticated customer
+
+### `paymentIntent` safe fields
+
+| Field | Included |
+| --- | --- |
+| `id` | Yes |
+| `status` | Yes |
+| `amount` | Yes |
+| `currency` | Yes |
+| `created` | Yes |
+| `metadata.orderId` / `metadata.groupOrderId` | Yes (when present) |
+| `client_secret` | **No** |
+| `charges` | **No** |
+| `payment_method` | **No** |
+| `transfer_data` | **No** |
+| `customer` | **No** |
+| `last_payment_error` | **No** |
+
+### `orders` poll shape
+
+Returns per-order: `id`, `groupOrderId`, `status`, `paymentStatus`, `totalAmount`, `currency`, and item `title`/`quantity`/`price`/`size` only. Omits `userId`, vendor references, and internal Stripe IDs.
+
+### Error mapping
+
+- Stripe retrieve failures → **500** with generic message only (no `error.message` in body)
+- Missing orders → **404**
+- Wrong customer → **403**
+
+---
+
+## Runtime safety review (updated #42)
 
 | Check | Result |
 |-------|--------|
 | Test vs live mode | Driven by `STRIPE_SECRET_KEY` prefix only |
 | Secret keys logged | **No** — logs use IDs, not keys |
 | Webhook secrets exposed | **No** — signature verification required |
-| Client responses safe | `initiateOrder` returns `clientSecret` only (expected for Stripe.js) |
+| Client responses safe | `initiateOrder` returns `clientSecret` only; `retrieveIntent` returns sanitized PI (#42) |
 | Stripe errors to client | Generic `500` or mapped `400`; no secret leakage |
 | PI idempotency | `pi:{orderId}` on create |
 | Order double-create on retry | Order persisted before PI; retry creates new order (no cart-level idempotency) |
@@ -186,9 +243,10 @@ sequenceDiagram
 | Connect onboarding incomplete | 400 `"Vendor Stripe onboarding incomplete."` | Yes |
 | Multi-vendor cart | 400 single-vendor message | Yes |
 | Price tampering | 400 price mismatch | Yes |
-| Legacy `/api/payments/create-payment-intent` | Plain PI, no Connect split, no auth | **Bypass risk** — document only |
-| Unauthenticated `/stripe/*` | Anyone with account ID can request sessions | **Unsafe** — track separately |
-| `retrieveIntent` full PI dump | Returns raw Stripe PaymentIntent object | **Review** — may expose internal fields |
+| Unapproved / deactivated vendor | 403 blocked at checkout (#42) | Yes |
+| Legacy `/api/payments/create-payment-intent` | Plain PI, no Connect split, no auth | **Bypass risk** — track #41 |
+| Unauthenticated `/stripe/*` | Anyone with account ID can request sessions | **Unsafe** — track #41 |
+| `retrieveIntent` over-exposure | Sanitized PI + order poll (#42) | **Mitigated** |
 | `PLATFORM_FEE_CENTS >= total` | Stripe rejects PI after order saved | Low — orphan pending order |
 | Pre-payment order emails | Sent in `initiateOrder` before pay succeeds | Known product issue (P0-6) |
 | Prod live charge without approval | **STOP** — see gate below | N/A |
@@ -258,6 +316,25 @@ New files:
 - **Test mode:** Stripe Dashboard refund or `orderController` reject/cancel refund path (`reverse_transfer: true`, `refund_application_fee: true`)
 - **Live approved smoke:** Same refund paths; record PI/charge IDs in proof pack; verify transfer reversal in Connect Dashboard
 - **Failed PI (never confirmed):** Order remains `pending`/`created`; no charge to refund
+
+---
+
+## Files changed in #42
+
+| File | Change |
+|------|--------|
+| `utils/checkoutGuards.js` | **Created** — business approval/active gate |
+| `utils/paymentIntentResponse.js` | **Created** — sanitized PI + order poll |
+| `controllers/orderController.js` | Approval gate before Connect checks |
+| `controllers/stripePaymentController.js` | Sanitized `retrieveIntent` + ownership |
+| `tests/stripe/order-initiate-connect.test.js` | +5 approval gate tests |
+| `tests/stripe/checkout-approval-paymentintent-safety.test.js` | **Created** — retrieve-intent safety |
+| `tests/utils/checkout-paymentintent-response.test.js` | **Created** — util unit tests |
+| `docs/MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md` | #42 sections |
+| `docs/TEST_MATRIX.md` | #42 test index |
+| `docs/MVP_BACKEND_PROGRAM_STATUS.md` | #42 status |
+
+**Not changed:** Connect destination-charge architecture, webhook handlers, deploy workflows, `GET /api/featured-products`.
 
 ---
 

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -2,7 +2,7 @@
 
 Maps backend features to automated tests (`npm test`), manual smoke checks, and proof-pack evidence.
 
-**Runner:** `npm test` → `node --test tests/**/*.test.js` (138 tests, Node built-in runner)
+**Runner:** `npm test` → `node --test tests/**/*.test.js` (151 tests, Node built-in runner)
 
 **Test style:** Unit/integration-style tests with mocked Mongoose models and module hooks. They prove **handler logic and wiring** — not full end-to-end flows against live MongoDB, Stripe, or AWS in CI.
 
@@ -14,7 +14,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 
 | Layer | Count | What it validates |
 |-------|-------|-------------------|
-| Automated (`tests/`) | **138** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked) |
+| Automated (`tests/`) | **151** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked), **checkout approval gate + sanitized PI** |
 | Manual smoke script | 1 | Live API + DB auth/check per role |
 | Production smoke tiers | P0–P6 | Post-deploy on `https://api.mosaicbizhub.com` |
 | Proof pack | Per release | Redacted evidence matrix |
@@ -135,6 +135,16 @@ See [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) for route ownership and curl smoke 
 | Full checkout E2E | — | *(no automated test)* | Client Stripe.js confirm + live webhooks | Yes — P5.2–P5.5 (test mode) |
 
 See [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md).
+
+---
+
+## Checkout approval + PaymentIntent safety tests (#42)
+
+| Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
+| --- | --- | --- | --- | --- |
+| Business approval gate | [`tests/stripe/order-initiate-connect.test.js`](../tests/stripe/order-initiate-connect.test.js) | Blocks unapproved/inactive/missing business; allows approved+active | Live MongoDB business states | Yes — Tier B |
+| Retrieve-intent safety | [`tests/stripe/checkout-approval-paymentintent-safety.test.js`](../tests/stripe/checkout-approval-paymentintent-safety.test.js) | Sanitized PI, ownership 403, safe Stripe error mapping | Live Stripe retrieve | Yes — Tier B |
+| Response helpers | [`tests/utils/checkout-paymentintent-response.test.js`](../tests/utils/checkout-paymentintent-response.test.js) | Guard + sanitizer unit contracts | HTTP integration | No |
 
 ---
 
@@ -283,7 +293,7 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 ## How to run
 
 ```bash
-# All automated tests (123)
+# All automated tests (151)
 npm test
 
 # Manual auth smoke (live API + DB)
@@ -299,7 +309,7 @@ node scripts/verify-auth-check-smoke.js
 
 | Evidence type | Source | Automated equivalent |
 | --- | --- | --- |
-| `npm test` 138/138 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
+| `npm test` 151/151 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
 | Auth smoke script output | `scripts/verify-auth-check-smoke.js` | Partial — live auth/check only |
 | Smoke matrix P0–P6 | [production-smoke-checklist.md](production-smoke-checklist.md) | No — human execution |
 | Webhook unsigned 400 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) curl | Partial — 9 tests cover handler logic |
@@ -332,9 +342,11 @@ node scripts/verify-auth-check-smoke.js
 | `tests/vendor/vendor-variant-stock.test.js` | 5 | Variant stock PATCH |
 | `tests/vendor/vendor-orders.test.js` | 4 | Vendor order filter + accept guards |
 | `tests/stripe/stripe-webhook-routing-signature.test.js` | 9 | Webhook routing + signatures |
-| `tests/stripe/order-initiate-connect.test.js` | 10 | Connect checkout guards + PI params |
+| `tests/stripe/order-initiate-connect.test.js` | 15 | Connect checkout guards + approval gate |
+| `tests/stripe/checkout-approval-paymentintent-safety.test.js` | 4 | Sanitized retrieve-intent + canonical route |
+| `tests/utils/checkout-paymentintent-response.test.js` | 4 | Checkout guard + PI sanitizer units |
 | `tests/stripe/order-webhook-handlers.test.js` | 5 | Order payment webhook handlers |
 | `tests/marketplace/public-listing-dto.test.js` | 18 | Marketplace DTO normalization |
 | `tests/marketplace/featured-products-response.test.js` | 2 | Featured products wiring |
 | `tests/marketplace/public-search-filters.test.js` | 15 | Search/filter helpers + handler |
-| **Total** | **138** | |
+| **Total** | **151** | |

--- a/docs/deploy-verification.md
+++ b/docs/deploy-verification.md
@@ -344,3 +344,27 @@ Workflow post-deploy probes: root **200**, unauth auth/check **401**.
 ### Conclusion
 
 **Deploy Go** for issue #32 on `7f7e293`. Audit and test coverage merged; payment runtime unchanged (docs/tests only in deploy package). Live checkout proof **PENDING** smoke accounts. Follow-ups: #41, #42, #43, expanded #27.
+
+---
+
+## Planned — Issue #42 checkout approval gate + safe PaymentIntent response (pre-deploy)
+
+**Branch:** `sprint/backend-checkout-approval-paymentintent-safety` (not yet merged/deployed)
+
+| Field | Value |
+|-------|-------|
+| Scope | `Business.isApproved`/`isActive` checkout gate; sanitized `retrieveIntent` |
+| Connect architecture | **Unchanged** — destination charges preserved |
+| Webhooks | **Unchanged** |
+| Automated tests | **151/151** (138 baseline + 13 new) |
+
+### Planned smoke (post-merge deploy, `SMOKE_TEST_*` only)
+
+| Area | Expected | Status |
+|------|----------|--------|
+| Approved vendor checkout | `POST /api/orders/initiate` → 201 + `clientSecret` | **PENDING** |
+| Unapproved vendor checkout | 403 blocked | **PENDING** |
+| `GET /api/orders/retrieve-intent/:id` | Sanitized PI only; 403 for wrong customer | **PENDING** |
+| Tier C live charge | Written approval still required | **BLOCKED** |
+
+**Conclusion:** Pre-merge only. No deploy claim until PR merged and EB deploy completed.

--- a/tests/stripe/checkout-approval-paymentintent-safety.test.js
+++ b/tests/stripe/checkout-approval-paymentintent-safety.test.js
@@ -1,0 +1,184 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+const fs = require('node:fs');
+
+const stripePaymentControllerPath = path.resolve(
+  __dirname,
+  '../../controllers/stripePaymentController.js'
+);
+const appPath = path.resolve(__dirname, '../../app.js');
+
+const userId = '507f1f77bcf86cd799439015';
+const otherUserId = '507f1f77bcf86cd799439016';
+const productId = '507f1f77bcf86cd799439013';
+const paymentId = 'pi_test_retrieve_001';
+const orderId = '507f1f77bcf86cd799439020';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function loadRetrieveIntent({ orders = [], stripeError = null } = {}) {
+  const stripeMock = {
+    paymentIntents: {
+      retrieve: async () => {
+        if (stripeError) {
+          throw stripeError;
+        }
+        return {
+          id: paymentId,
+          status: 'succeeded',
+          amount: 3000,
+          currency: 'usd',
+          created: 1710000000,
+          client_secret: 'pi_secret_should_not_leak',
+          charges: { data: [{ id: 'ch_secret' }] },
+          payment_method: 'pm_secret',
+          transfer_data: { destination: 'acct_secret' },
+          metadata: { orderId, internalNote: 'private' },
+          customer: 'cus_secret',
+          last_payment_error: { message: 'card declined' },
+        };
+      },
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe' || (request.includes('node_modules') && request.replace(/\\/g, '/').includes('/stripe/'))) {
+      return class Stripe {
+        constructor() {
+          return stripeMock;
+        }
+      };
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        find: () => ({
+          select: () => ({
+            populate: async () => orders,
+          }),
+        }),
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[stripePaymentControllerPath];
+  const { retrieveIntent } = require(stripePaymentControllerPath);
+  Module._load = originalLoad;
+
+  return { retrieveIntent };
+}
+
+test('retrieveIntent returns sanitized paymentIntent without Stripe internals', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const orders = [{
+    _id: orderId,
+    userId: { toString: () => userId },
+    groupOrderId: 'grp-001',
+    status: 'ordered',
+    paymentStatus: 'paid',
+    totalAmount: 30,
+    currency: 'USD',
+    items: [{
+      productId: { _id: productId, title: 'Test Product' },
+      quantity: 1,
+      price: 25,
+      size: 'M',
+    }],
+  }];
+
+  const { retrieveIntent } = loadRetrieveIntent({ orders });
+  const res = mockResponse();
+
+  await retrieveIntent({ params: { id: paymentId }, user: { id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.paymentIntent.id, paymentId);
+  assert.equal(res.body.paymentIntent.status, 'succeeded');
+  assert.equal(res.body.paymentIntent.metadata.orderId, orderId);
+  assert.equal(res.body.paymentIntent.charges, undefined);
+  assert.equal(res.body.paymentIntent.payment_method, undefined);
+  assert.equal(res.body.paymentIntent.transfer_data, undefined);
+  assert.equal(res.body.paymentIntent.client_secret, undefined);
+  assert.equal(res.body.paymentIntent.customer, undefined);
+  assert.ok(Array.isArray(res.body.orders));
+  assert.equal(res.body.orders[0].status, 'ordered');
+  assert.equal(res.body.orders[0].items[0].title, 'Test Product');
+  assert.equal(res.body.orders[0].userId, undefined);
+});
+
+test('retrieveIntent blocks access when order belongs to different customer', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const orders = [{
+    _id: orderId,
+    userId: { toString: () => otherUserId },
+    groupOrderId: 'grp-001',
+    status: 'ordered',
+    paymentStatus: 'paid',
+    totalAmount: 30,
+    currency: 'USD',
+    items: [],
+  }];
+
+  const { retrieveIntent } = loadRetrieveIntent({ orders });
+  const res = mockResponse();
+
+  await retrieveIntent({ params: { id: paymentId }, user: { id: userId } }, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /not allowed/i);
+});
+
+test('retrieveIntent maps Stripe errors without leaking internals', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const orders = [{
+    _id: orderId,
+    userId: { toString: () => userId },
+    groupOrderId: 'grp-001',
+    status: 'created',
+    paymentStatus: 'pending',
+    totalAmount: 30,
+    currency: 'USD',
+    items: [],
+  }];
+
+  const { retrieveIntent } = loadRetrieveIntent({
+    orders,
+    stripeError: new Error('No such payment_intent: pi_test_retrieve_001'),
+  });
+  const res = mockResponse();
+
+  await retrieveIntent({ params: { id: paymentId }, user: { id: userId } }, res);
+
+  assert.equal(res.statusCode, 500);
+  assert.equal(res.body.message, 'Failed to fetch payment information');
+  assert.equal(res.body.error, undefined);
+  assert.equal(JSON.stringify(res.body).includes('sk_'), false);
+});
+
+test('featured-products route remains canonical', () => {
+  const routesSource = fs.readFileSync(
+    path.resolve(__dirname, '../../routes/featuredProductRoutes.js'),
+    'utf8'
+  );
+  const appSource = fs.readFileSync(appPath, 'utf8');
+
+  assert.ok(routesSource.includes('/featured-products'));
+  assert.ok(!routesSource.includes('/products/featured'));
+  assert.ok(!appSource.includes('/api/products/featured'));
+});

--- a/tests/stripe/order-initiate-connect.test.js
+++ b/tests/stripe/order-initiate-connect.test.js
@@ -67,6 +67,8 @@ function buildBusiness(overrides = {}) {
   return {
     _id: businessId,
     email: 'vendor@example.com',
+    isApproved: overrides.isApproved ?? true,
+    isActive: overrides.isActive ?? true,
     stripeConnectAccountId: overrides.stripeConnectAccountId ?? connectAccountId,
     taxSettings: {},
     shippingSettings: { method: 'flat_rate', flatRate: { standard: 5 } },
@@ -429,4 +431,75 @@ test('initiateOrder returns generic 500 on unexpected Stripe errors', async () =
   assert.equal(res.statusCode, 500);
   assert.equal(res.body.message, 'Server error');
   assert.doesNotMatch(JSON.stringify(res.body), /Internal stripe failure/);
+});
+
+test('initiateOrder allows checkout for approved active business with Connect account', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    business: buildBusiness({ isApproved: true, isActive: true }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.ok(res.body.clientSecret);
+  assert.equal(getPiCreateCalls().length, 1);
+});
+
+test('initiateOrder blocks checkout when business is not approved', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    business: buildBusiness({ isApproved: false }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /not approved/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder blocks checkout when business is deactivated', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    business: buildBusiness({ isActive: false }),
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /unavailable/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder blocks checkout when business is missing', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    business: null,
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 404);
+  assert.match(res.body.message, /not found/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder blocks checkout when product variant is missing', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    variants: [],
+  });
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 404);
+  assert.match(res.body.message, /not found/i);
+  assert.equal(getPiCreateCalls().length, 0);
 });

--- a/tests/utils/checkout-paymentintent-response.test.js
+++ b/tests/utils/checkout-paymentintent-response.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  getBusinessCheckoutBlock,
+} = require('../../utils/checkoutGuards');
+const {
+  sanitizePaymentIntentForClient,
+  sanitizeOrderForPaymentPoll,
+} = require('../../utils/paymentIntentResponse');
+
+test('getBusinessCheckoutBlock returns null for approved active connected business', () => {
+  assert.equal(
+    getBusinessCheckoutBlock({
+      isApproved: true,
+      isActive: true,
+      stripeConnectAccountId: 'acct_test',
+    }),
+    null
+  );
+});
+
+test('getBusinessCheckoutBlock blocks unapproved business', () => {
+  const block = getBusinessCheckoutBlock({
+    isApproved: false,
+    isActive: true,
+    stripeConnectAccountId: 'acct_test',
+  });
+  assert.equal(block.status, 403);
+});
+
+test('sanitizePaymentIntentForClient strips sensitive Stripe fields', () => {
+  const sanitized = sanitizePaymentIntentForClient({
+    id: 'pi_test',
+    status: 'succeeded',
+    amount: 2500,
+    currency: 'usd',
+    created: 1710000000,
+    client_secret: 'secret',
+    charges: { data: [] },
+    payment_method: 'pm_test',
+    transfer_data: { destination: 'acct_test' },
+    metadata: { orderId: '507f1f77bcf86cd799439020' },
+    customer: 'cus_test',
+  });
+
+  assert.deepEqual(sanitized, {
+    id: 'pi_test',
+    status: 'succeeded',
+    amount: 2500,
+    currency: 'usd',
+    created: 1710000000,
+    metadata: { orderId: '507f1f77bcf86cd799439020' },
+  });
+});
+
+test('sanitizeOrderForPaymentPoll omits user and vendor references', () => {
+  const sanitized = sanitizeOrderForPaymentPoll({
+    _id: '507f1f77bcf86cd799439020',
+    userId: '507f1f77bcf86cd799439015',
+    vendorId: '507f1f77bcf86cd799439011',
+    groupOrderId: 'grp-001',
+    status: 'ordered',
+    paymentStatus: 'paid',
+    totalAmount: 30,
+    currency: 'USD',
+    items: [{
+      productId: { _id: '507f1f77bcf86cd799439013', title: 'Widget' },
+      quantity: 1,
+      price: 25,
+      size: 'M',
+    }],
+  });
+
+  assert.equal(sanitized.id, '507f1f77bcf86cd799439020');
+  assert.equal(sanitized.userId, undefined);
+  assert.equal(sanitized.vendorId, undefined);
+  assert.equal(sanitized.items[0].title, 'Widget');
+});

--- a/utils/checkoutGuards.js
+++ b/utils/checkoutGuards.js
@@ -1,0 +1,39 @@
+/**
+ * Business eligibility checks for customer checkout (Connect destination charge).
+ */
+
+function getBusinessCheckoutBlock(business) {
+  if (!business) {
+    return {
+      status: 404,
+      message: 'Vendor business not found.',
+    };
+  }
+
+  if (business.isApproved === false) {
+    return {
+      status: 403,
+      message: 'This vendor is not approved for checkout.',
+    };
+  }
+
+  if (business.isActive === false) {
+    return {
+      status: 403,
+      message: 'This vendor is temporarily unavailable for checkout.',
+    };
+  }
+
+  if (!business.stripeConnectAccountId) {
+    return {
+      status: 400,
+      message: 'Vendor is not connected to Stripe.',
+    };
+  }
+
+  return null;
+}
+
+module.exports = {
+  getBusinessCheckoutBlock,
+};

--- a/utils/paymentIntentResponse.js
+++ b/utils/paymentIntentResponse.js
@@ -1,0 +1,59 @@
+/**
+ * Frontend-safe PaymentIntent and order poll shapes for retrieve-intent.
+ */
+
+function sanitizePaymentIntentForClient(paymentIntent) {
+  if (!paymentIntent) {
+    return null;
+  }
+
+  const metadata = paymentIntent.metadata || {};
+  const safeMetadata = {};
+
+  if (metadata.orderId) {
+    safeMetadata.orderId = String(metadata.orderId);
+  }
+  if (metadata.groupOrderId) {
+    safeMetadata.groupOrderId = String(metadata.groupOrderId);
+  }
+
+  return {
+    id: paymentIntent.id,
+    status: paymentIntent.status,
+    amount: paymentIntent.amount,
+    currency: paymentIntent.currency,
+    created: paymentIntent.created,
+    ...(Object.keys(safeMetadata).length > 0 ? { metadata: safeMetadata } : {}),
+  };
+}
+
+function sanitizeOrderForPaymentPoll(order) {
+  if (!order) {
+    return null;
+  }
+
+  const plain = typeof order.toObject === 'function' ? order.toObject() : order;
+
+  return {
+    id: plain._id?.toString?.() || plain._id,
+    groupOrderId: plain.groupOrderId,
+    status: plain.status,
+    paymentStatus: plain.paymentStatus,
+    totalAmount: plain.totalAmount,
+    currency: plain.currency,
+    items: Array.isArray(plain.items)
+      ? plain.items.map((item) => ({
+          productId: item.productId?._id?.toString?.() || item.productId,
+          title: item.productId?.title || item.title || null,
+          quantity: item.quantity,
+          price: item.price,
+          size: item.size,
+        }))
+      : [],
+  };
+}
+
+module.exports = {
+  sanitizePaymentIntentForClient,
+  sanitizeOrderForPaymentPoll,
+};


### PR DESCRIPTION
## Summary
- Block checkout for unapproved, deactivated, or missing vendor businesses.
- Sanitize GET /api/orders/retrieve-intent/:id to return frontend-safe PI fields only.
- Enforce order ownership before returning payment status.

## Unchanged
- Connect destination-charge architecture
- Webhook handlers and signature verification
- GET /api/featured-products canonical route

## Test plan
- [x] npm test (138 -> 151)
- [x] Unapproved/inactive business blocked at initiate
- [x] retrieveIntent returns sanitized PI without charges/payment_method/transfer_data
- [x] Wrong customer gets 403 on retrieve-intent
- [ ] Manual smoke PENDING SMOKE_TEST_* accounts

Made with [Cursor](https://cursor.com)