### PR TITLE
feat(observability): Sentry production error monitoring (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,21 @@ PUPPETEER_EXECUTABLE_PATH=
 
 LISTING_DEBUG=false
 
+
+
+# Sentry (optional — set SENTRY_DSN in EB only; never commit real DSN)
+
+# SENTRY_DSN=
+
+# SENTRY_ENVIRONMENT=production
+
+# SENTRY_RELEASE=mosaic-local
+
+# SENTRY_TRACES_SAMPLE_RATE=0
+
+# SENTRY_PROFILES_SAMPLE_RATE=0
+
+# SENTRY_ENABLED=true
+
+# ENABLE_SENTRY_DEBUG_ROUTE=false
+

--- a/app.js
+++ b/app.js
@@ -83,6 +83,8 @@ const enquiryRoutes = require('./routes/enquiryRoutes');
 
 const mongoSanitize = require('express-mongo-sanitize');
 const xss = require('xss-clean');
+const sentryHttpCapture = require('./middlewares/sentryHttpCapture');
+const { isSentryEnabled } = require('./instrument');
 
 const app = express();
 
@@ -102,6 +104,7 @@ const allowedOrigins = Array.from(
   ].filter(Boolean))
 );
 app.set('trust proxy', 1);
+app.use(sentryHttpCapture);
 app.use(cors({
   origin: function (origin, callback) {
     // Allow requests with no origin (like mobile apps or curl)
@@ -230,6 +233,17 @@ app.use('/api/enquiries', enquiryRoutes);
 app.get('/', (req, res) => {
   res.json({ message: 'Mosaic Biz Hub API is working 9 feb ' });
 });
+
+if (process.env.ENABLE_SENTRY_DEBUG_ROUTE === 'true' && isSentryEnabled()) {
+  app.get('/internal/sentry-debug', (_req, _res) => {
+    throw new Error('Sentry debug route test error');
+  });
+}
+
+if (isSentryEnabled()) {
+  const Sentry = require('./instrument');
+  Sentry.setupExpressErrorHandler(app);
+}
 
 // require('./jobs/cleanupImages');
 

--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -18,6 +18,7 @@ Operational guide for release owners: deployment verification, rollback confirma
 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) | Webhook smoke curl commands |
 | [hosted-staging-decision.md](hosted-staging-decision.md) | Why there is no staging host |
 | [launch-readiness-report.md](launch-readiness-report.md) | Open P0 blockers |
+| [production-env-checklist.md](production-env-checklist.md) § Observability | Sentry env var names |
 
 ---
 
@@ -210,6 +211,45 @@ Full tier detail: [production-smoke-checklist.md](production-smoke-checklist.md)
 ### Post-rollback sign-off
 
 Treat rollback deploy like a new release: deployment owner confirms SHA, release owner runs minimum smoke, proof pack updated.
+
+---
+
+## Observability — Sentry error monitoring
+
+Production error monitoring is **optional** until `SENTRY_DSN` is set on Elastic Beanstalk. Initialization is env-gated — local dev and CI run without Sentry when the DSN is unset.
+
+### Setup (infrastructure owner)
+
+1. Create a Sentry project for the backend (Node/Express).
+2. On EB, set env vars from [production-env-checklist.md](production-env-checklist.md) § Observability:
+   - `SENTRY_DSN` — from Sentry project settings (**never commit to git**)
+   - `SENTRY_ENVIRONMENT=production`
+   - `SENTRY_RELEASE=mosaic-<git-sha>` — align with EB version label from deploy workflow
+   - `SENTRY_TRACES_SAMPLE_RATE=0` (recommended for MVP — errors only)
+   - `SENTRY_ENABLED=true`
+3. Deploy the release that includes `instrument.js` and Sentry middleware.
+4. Restart or redeploy EB so env vars take effect.
+
+### What is captured
+
+| Signal | Mechanism |
+|--------|-----------|
+| Unhandled exceptions | Sentry Express error handler |
+| HTTP 5xx responses | Response `finish` hook (includes controller try/catch paths) |
+| Startup failures | Mongo connect failure in `index.js` |
+
+Sensitive fields (passwords, tokens, OTPs, Stripe secrets, cookies) are scrubbed in `beforeSend`. Request bodies are not logged by default.
+
+### Post-deploy verification
+
+1. Temporarily set `ENABLE_SENTRY_DEBUG_ROUTE=true` on EB.
+2. `GET https://api.mosaicbizhub.com/internal/sentry-debug` — expect HTTP 500.
+3. Confirm a new error event in the Sentry dashboard (environment `production`, release matches deploy SHA).
+4. Set `ENABLE_SENTRY_DEBUG_ROUTE=false` before launch sign-off.
+
+### Rollback notes
+
+If Sentry causes boot issues, set `SENTRY_ENABLED=false` or remove `SENTRY_DSN` on EB and restart — the app runs without monitoring.
 
 ---
 

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -2,7 +2,7 @@
 
 Maps backend features to automated tests (`npm test`), manual smoke checks, and proof-pack evidence.
 
-**Runner:** `npm test` → `node --test tests/**/*.test.js` (168 tests, Node built-in runner)
+**Runner:** `npm test` → `node --test tests/**/*.test.js` (173 tests, Node built-in runner)
 
 **Test style:** Unit/integration-style tests with mocked Mongoose models and module hooks. They prove **handler logic and wiring** — not full end-to-end flows against live MongoDB, Stripe, or AWS in CI.
 
@@ -14,7 +14,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 
 | Layer | Count | What it validates |
 |-------|-------|-------------------|
-| Automated (`tests/`) | **168** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked), **checkout approval gate + sanitized PI**, **email notification safety** |
+| Automated (`tests/`) | **173** | DTOs, middleware, controller logic, webhook wiring, search filters, vendor listing/order/stock, **Stripe Connect checkout guards** (mocked), **checkout approval gate + sanitized PI**, **email notification safety**, **Sentry env gating + PII scrub** |
 | Manual smoke script | 1 | Live API + DB auth/check per role |
 | Production smoke tiers | P0–P6 | Post-deploy on `https://api.mosaicbizhub.com` |
 | Proof pack | Per release | Redacted evidence matrix |
@@ -283,6 +283,14 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 
 ---
 
+## Observability tests (issue #18)
+
+| Area | Test File | What It Proves | What It Does Not Prove | Manual Smoke Needed? |
+| --- | --- | --- | --- | --- |
+| Sentry env gating + scrub | [`tests/sentry/instrument.test.js`](../tests/sentry/instrument.test.js) | `isSentryEnabled` gates on DSN; sensitive keys redacted in scrub helper | Live Sentry dashboard delivery | Yes — after EB `SENTRY_DSN` set |
+
+---
+
 ## Launch-critical area → coverage map
 
 | Launch-critical area | Automated | Manual smoke | Gap / honest limit |
@@ -306,7 +314,7 @@ Unsigned webhook POST → expect `400` on all five routes. Commands in [STRIPE_W
 ## How to run
 
 ```bash
-# All automated tests (168)
+# All automated tests (173)
 npm test
 
 # Manual auth smoke (live API + DB)
@@ -322,7 +330,7 @@ node scripts/verify-auth-check-smoke.js
 
 | Evidence type | Source | Automated equivalent |
 | --- | --- | --- |
-| `npm test` 168/168 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
+| `npm test` 173/173 pass | Pre-merge local/CI | Yes — full suite (see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for prod vs branch) |
 | Auth smoke script output | `scripts/verify-auth-check-smoke.js` | Partial — live auth/check only |
 | Smoke matrix P0–P6 | [production-smoke-checklist.md](production-smoke-checklist.md) | No — human execution |
 | Webhook unsigned 400 | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) curl | Partial — 9 tests cover handler logic |
@@ -366,4 +374,4 @@ node scripts/verify-auth-check-smoke.js
 | `tests/marketplace/public-listing-dto.test.js` | 18 | Marketplace DTO normalization |
 | `tests/marketplace/featured-products-response.test.js` | 2 | Featured products wiring |
 | `tests/marketplace/public-search-filters.test.js` | 15 | Search/filter helpers + handler |
-| **Total** | **168** | |
+| **Total** | **173** | |

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -104,3 +104,31 @@ Note: Backend code does **not** read `STRIPE_PUBLIC_KEY` (frontend uses `NEXT_PU
 | `JWT_SECRET` | Must match backend `JWT_SECRET` for middleware |
 
 See `mosaic-biz-frontend/.env.example` when present.
+
+---
+
+## Observability (Sentry)
+
+Optional production error monitoring. **Set `SENTRY_DSN` in EB only** — never commit the DSN to git.
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `SENTRY_DSN` | Yes (to enable) | From Sentry project settings |
+| `SENTRY_ENVIRONMENT` | Recommended | e.g. `production` |
+| `SENTRY_RELEASE` | Recommended | Match EB version label, e.g. `mosaic-<git-sha>` |
+| `SENTRY_TRACES_SAMPLE_RATE` | Optional | Default `0` (errors only) |
+| `SENTRY_PROFILES_SAMPLE_RATE` | Optional | Default `0` |
+| `SENTRY_ENABLED` | Optional | Set `false` to disable without removing DSN |
+| `ENABLE_SENTRY_DEBUG_ROUTE` | Optional | `true` only during verification; exposes `GET /internal/sentry-debug` |
+
+### Verification after enabling Sentry
+
+1. Set `SENTRY_DSN`, `SENTRY_ENVIRONMENT=production`, and `SENTRY_RELEASE=mosaic-<deployed-sha>` on EB.
+2. Redeploy or restart the EB environment.
+3. Temporarily set `ENABLE_SENTRY_DEBUG_ROUTE=true`.
+4. `GET https://api.mosaicbizhub.com/internal/sentry-debug` — expect 500; confirm event in Sentry dashboard.
+5. Set `ENABLE_SENTRY_DEBUG_ROUTE=false` before sign-off.
+
+See [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) § Observability.
+
+---

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ if (process.platform === 'win32') {
 }
 
 require('dotenv').config();
+require('./instrument');
+
 const app = require('./app');
 const connectDB = require('./config/Db');
 
@@ -20,6 +22,12 @@ const startServer = async () => {
     });
   } catch (err) {
     console.error('Server startup aborted because MongoDB is unavailable.');
+    const { isSentryEnabled } = require('./instrument');
+    if (isSentryEnabled()) {
+      const Sentry = require('./instrument');
+      Sentry.captureException(err);
+      await Sentry.flush(2000);
+    }
     process.exit(1);
   }
 };

--- a/instrument.js
+++ b/instrument.js
@@ -1,0 +1,82 @@
+const Sentry = require('@sentry/node');
+
+const SENSITIVE_KEYS = [
+  'password',
+  'otp',
+  'token',
+  'authorization',
+  'cookie',
+  'jwt',
+  'secret',
+  'whsec_',
+  'sk_live_',
+  'sk_test_',
+];
+
+function scrubValue(key, value) {
+  if (value == null) return value;
+  const lowerKey = String(key).toLowerCase();
+  if (SENSITIVE_KEYS.some((part) => lowerKey.includes(part))) {
+    return '[Filtered]';
+  }
+  if (typeof value === 'string' && value.length > 256) {
+    return `${value.slice(0, 32)}…[truncated]`;
+  }
+  return value;
+}
+
+function scrubObject(input) {
+  if (!input || typeof input !== 'object') return input;
+  if (Array.isArray(input)) {
+    return input.map((item) => scrubObject(item));
+  }
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [
+      key,
+      typeof value === 'object' ? scrubObject(value) : scrubValue(key, value),
+    ])
+  );
+}
+
+function parseSampleRate(envVal, fallback) {
+  if (envVal === undefined || envVal === '') return fallback;
+  const parsed = Number.parseFloat(envVal);
+  if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) return fallback;
+  return parsed;
+}
+
+function isSentryEnabled() {
+  const dsn = process.env.SENTRY_DSN;
+  if (!dsn) return false;
+  const enabled = process.env.SENTRY_ENABLED;
+  if (enabled === 'false' || enabled === '0') return false;
+  return true;
+}
+
+if (isSentryEnabled()) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
+    release: process.env.SENTRY_RELEASE,
+    enabled: true,
+    sendDefaultPii: false,
+    tracesSampleRate: parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0),
+    profilesSampleRate: parseSampleRate(process.env.SENTRY_PROFILES_SAMPLE_RATE, 0),
+    beforeSend(event) {
+      if (event.request?.headers) {
+        event.request.headers = scrubObject(event.request.headers);
+      }
+      if (event.request?.data) {
+        event.request.data = scrubObject(event.request.data);
+      }
+      if (event.extra) {
+        event.extra = scrubObject(event.extra);
+      }
+      return event;
+    },
+  });
+}
+
+module.exports = Sentry;
+module.exports.isSentryEnabled = isSentryEnabled;
+module.exports.scrubObject = scrubObject;

--- a/middlewares/sentryHttpCapture.js
+++ b/middlewares/sentryHttpCapture.js
@@ -1,0 +1,29 @@
+const Sentry = require('../instrument');
+const { isSentryEnabled } = require('../instrument');
+
+/**
+ * Reports HTTP 5xx responses to Sentry when controllers return errors
+ * without calling next(err). Unhandled throws are covered by setupExpressErrorHandler.
+ */
+function sentryHttpCapture(req, res, next) {
+  if (!isSentryEnabled()) {
+    return next();
+  }
+
+  res.on('finish', () => {
+    if (res.statusCode >= 500) {
+      Sentry.captureMessage(`HTTP ${res.statusCode} ${req.method} ${req.originalUrl}`, {
+        level: 'error',
+        tags: {
+          method: req.method,
+          path: req.originalUrl,
+          status_code: String(res.statusCode),
+        },
+      });
+    }
+  });
+
+  next();
+}
+
+module.exports = sentryHttpCapture;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.850.0",
         "@aws-sdk/s3-request-presigner": "^3.850.0",
+        "@sentry/node": "^10.58.0",
         "axios": "^1.10.0",
         "bcryptjs": "^3.0.2",
         "cloudinary": "^2.6.1",
@@ -980,6 +981,101 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.10.8",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.8.tgz",
@@ -996,6 +1092,108 @@
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.58.0.tgz",
+      "integrity": "sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.58.0.tgz",
+      "integrity": "sha512-KICgacBS+I/eWzFlAembutSwFwy0WVSrGp8UMV9n1XZqqu4EBTlALRsbLNlDSv61UgH85L9L3vk91tgq6nJXAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry/core": "10.58.0",
+        "@sentry/node-core": "10.58.0",
+        "@sentry/opentelemetry": "10.58.0",
+        "@sentry/server-utils": "10.58.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.58.0.tgz",
+      "integrity": "sha512-7dTbYuoaSwSmF2GWDl7KK+sXQL8iqaZeZ2I/aFm+SvPZLckZF3OGFb2VsluWsSXQLnxtxPX9QP93viyK+VZsuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0",
+        "@sentry/opentelemetry": "10.58.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.58.0.tgz",
+      "integrity": "sha512-qKOGVmt02wDaq7E70VekG8Z9XM641trJPoTHSeVUfGaXVcmGc46ZldTNtfWbxJq/8f/fge2pap60gn066ido2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.58.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.58.0.tgz",
+      "integrity": "sha512-PywIl2jvl+tO5R4j+n72Lcf3ItanHcaMN/oL1U9ZHE8icaT2zpo2W4uOaslpQeQvqPC24HGZ3BW2etzsCFQbag==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.58.0"
       },
       "engines": {
         "node": ">=18"
@@ -1802,6 +2000,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2229,6 +2448,12 @@
         "devtools-protocol": "*"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2482,8 +2707,7 @@
       "version": "0.0.1475386",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -2700,7 +2924,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3041,6 +3264,7 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -3055,6 +3279,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3068,6 +3293,7 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -3084,6 +3310,7 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -3098,6 +3325,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3118,14 +3346,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3133,6 +3363,7 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3469,6 +3700,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz",
+      "integrity": "sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3566,6 +3812,7 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -3848,6 +4095,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/mongodb": {
       "version": "6.16.0",
@@ -4586,6 +4839,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4813,7 +5079,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.850.0",
     "@aws-sdk/s3-request-presigner": "^3.850.0",
+    "@sentry/node": "^10.58.0",
     "axios": "^1.10.0",
     "bcryptjs": "^3.0.2",
     "cloudinary": "^2.6.1",

--- a/tests/sentry/instrument.test.js
+++ b/tests/sentry/instrument.test.js
@@ -1,0 +1,89 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const instrumentPath = path.resolve(__dirname, '../../instrument.js');
+
+function loadInstrumentWithEnv(envOverrides = {}) {
+  const saved = {};
+  for (const key of [
+    'SENTRY_DSN',
+    'SENTRY_ENABLED',
+    'SENTRY_ENVIRONMENT',
+    'SENTRY_RELEASE',
+    'SENTRY_TRACES_SAMPLE_RATE',
+    'SENTRY_PROFILES_SAMPLE_RATE',
+  ]) {
+    saved[key] = process.env[key];
+  }
+
+  delete process.env.SENTRY_DSN;
+  delete process.env.SENTRY_ENABLED;
+  Object.assign(process.env, envOverrides);
+
+  delete require.cache[instrumentPath];
+  const mod = require(instrumentPath);
+
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  delete require.cache[instrumentPath];
+  return mod;
+}
+
+test('isSentryEnabled returns false when SENTRY_DSN is unset', () => {
+  const { isSentryEnabled } = loadInstrumentWithEnv();
+  assert.equal(isSentryEnabled(), false);
+});
+
+test('isSentryEnabled returns false when SENTRY_ENABLED is false', () => {
+  const { isSentryEnabled } = loadInstrumentWithEnv({
+    SENTRY_DSN: 'https://example@sentry.io/1',
+    SENTRY_ENABLED: 'false',
+  });
+  assert.equal(isSentryEnabled(), false);
+});
+
+test('isSentryEnabled returns true when DSN is set and not disabled', () => {
+  const savedDsn = process.env.SENTRY_DSN;
+  const savedEnabled = process.env.SENTRY_ENABLED;
+  process.env.SENTRY_DSN = 'https://example@sentry.io/1';
+  process.env.SENTRY_ENABLED = 'true';
+  delete require.cache[instrumentPath];
+  const { isSentryEnabled } = require(instrumentPath);
+  assert.equal(isSentryEnabled(), true);
+  if (savedDsn === undefined) delete process.env.SENTRY_DSN;
+  else process.env.SENTRY_DSN = savedDsn;
+  if (savedEnabled === undefined) delete process.env.SENTRY_ENABLED;
+  else process.env.SENTRY_ENABLED = savedEnabled;
+  delete require.cache[instrumentPath];
+});
+
+test('scrubObject redacts sensitive keys', () => {
+  const { scrubObject } = loadInstrumentWithEnv();
+  const scrubbed = scrubObject({
+    email: 'user@example.com',
+    password: 'secret123',
+    authorization: 'Bearer token',
+    nested: { otp: '123456', note: 'ok' },
+  });
+
+  assert.equal(scrubbed.email, 'user@example.com');
+  assert.equal(scrubbed.password, '[Filtered]');
+  assert.equal(scrubbed.authorization, '[Filtered]');
+  assert.equal(scrubbed.nested.otp, '[Filtered]');
+  assert.equal(scrubbed.nested.note, 'ok');
+});
+
+test('scrubObject truncates long string values', () => {
+  const { scrubObject } = loadInstrumentWithEnv();
+  const longValue = 'x'.repeat(300);
+  const scrubbed = scrubObject({ description: longValue });
+  assert.match(scrubbed.description, /\[truncated\]$/);
+  assert.ok(scrubbed.description.length < longValue.length);
+});


### PR DESCRIPTION
﻿## Summary

Closes #18 by adding optional, env-gated Sentry error monitoring for production.

- `instrument.js` initializes `@sentry/node` when `SENTRY_DSN` is set (disabled locally/CI by default)
- Unhandled exceptions via `Sentry.setupExpressErrorHandler`
- HTTP 5xx responses via `middlewares/sentryHttpCapture` finish hook
- Mongo startup failures captured in `index.js`
- PII scrubbing in `beforeSend` (passwords, tokens, OTPs, Stripe secrets)
- Production runbook + env checklist updated with setup/verification steps

## Files changed

- `instrument.js` (new)
- `middlewares/sentryHttpCapture.js` (new)
- `index.js`, `app.js`
- `package.json`, `package-lock.json`
- `.env.example` (commented placeholders only)
- `docs/PRODUCTION_RUNBOOK.md` (Observability section)
- `docs/production-env-checklist.md` (Sentry env vars)
- `docs/TEST_MATRIX.md`
- `tests/sentry/instrument.test.js` (new)

## Tests run

```
npm test
# 173/173 pass
```

## Screenshots / terminal proof

```
npm test
ℹ tests 173
ℹ pass 173
ℹ fail 0
```

## Risk notes

- Sentry is **opt-in** — no behavior change when `SENTRY_DSN` is unset
- HTTP 5xx capture may create duplicate Sentry events when both `captureException` and finish hook fire on the same request (acceptable for MVP)
- `ENABLE_SENTRY_DEBUG_ROUTE=true` exposes a test route that throws — must be disabled after verification

## Rollback notes

- Set `SENTRY_ENABLED=false` or remove `SENTRY_DSN` on EB and restart
- Revert this PR if Sentry SDK causes boot issues

## Confirmations

- [x] No secrets committed (DSN placeholders commented in `.env.example` only)
- [x] `GET /api/featured-products` remains canonical — no route changes to featured products
- [x] No deployment workflow changes
- [x] No merge / no deploy performed

## Test plan

- [x] `npm test` 173/173
- [ ] After merge + EB deploy: set `SENTRY_DSN`, `SENTRY_RELEASE=mosaic-<sha>`, verify `/internal/sentry-debug` (with `ENABLE_SENTRY_DEBUG_ROUTE=true`)
- [ ] Disable debug route before production sign-off
