### PR TITLE
fix: backend stability and launch blockers (#41 #43 #69)

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,6 +140,8 @@ app.use('/api/subscription/webhook',
   handleSubscriptionWebhook
 );
 app.use(express.json());
+app.use(mongoSanitize());
+app.use(xss());
 
 
 app.use('/api/product', productRoutes);

--- a/app.js
+++ b/app.js
@@ -73,6 +73,7 @@ const apiRoutes = require('./routes/api.routes');
 const googlePlace = require('./routes/googlePlace');
 const featuredProductRoutes = require('./routes/featuredProductRoutes');
 const contactInquiryRoutes = require('./routes/contactInquiryRoutes');
+const healthRoutes = require('./routes/healthRoutes');
 
 const authRoutes = require('./routes/authRoutes');
 const enquiryRoutes = require('./routes/enquiryRoutes');
@@ -142,6 +143,8 @@ app.use('/api/subscription/webhook',
 app.use(express.json());
 app.use(mongoSanitize());
 app.use(xss());
+
+app.use('/api', healthRoutes);
 
 
 app.use('/api/product', productRoutes);

--- a/controllers/featuredProducts.controller.js
+++ b/controllers/featuredProducts.controller.js
@@ -1,24 +1,51 @@
 const Product = require('../models/Product');
+const Business = require('../models/Business');
 const { toPublicListingCard } = require('../lib/listing/publicListingDto');
+
+const FEATURED_MAX_LIMIT = 50;
+
+async function getVisibleBusinessIds() {
+  const businesses = await Business.find({ isActive: true }).select('_id').lean();
+  return businesses.map((business) => business._id);
+}
 
 // Get featured products (public API)
 exports.getFeaturedProducts = async (req, res) => {
   try {
-    const { page = 1, limit = 12 } = req.query;
-    const skip = (page - 1) * limit;
+    const pageN = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limitN = Math.max(
+      1,
+      Math.min(FEATURED_MAX_LIMIT, parseInt(req.query.limit, 10) || 12)
+    );
+    const skip = (pageN - 1) * limitN;
 
-    const products = await Product.find({
+    const visibleBusinessIds = await getVisibleBusinessIds();
+    if (!visibleBusinessIds.length) {
+      return res.status(200).json({
+        products: [],
+        pagination: {
+          currentPage: pageN,
+          totalPages: 0,
+          totalProducts: 0,
+        },
+      });
+    }
+
+    const query = {
       isFeatured: true,
       isPublished: true,
-      isDeleted: false
-    })
-    .populate('categoryId', 'name')
-    .populate('subcategoryId', 'name')
-    .populate('businessId', 'businessName location')
-    .select('title slug description coverImage minorityType price createdAt categoryId subcategoryId businessId')
-    .sort({ createdAt: -1 })
-    .skip(skip)
-    .limit(parseInt(limit));
+      isDeleted: false,
+      businessId: { $in: visibleBusinessIds },
+    };
+
+    const products = await Product.find(query)
+      .populate('categoryId', 'name')
+      .populate('subcategoryId', 'name')
+      .populate('businessId', 'businessName location')
+      .select('title slug description coverImage minorityType price createdAt categoryId subcategoryId businessId')
+      .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limitN);
 
     const transformedProducts = products.map((product) => {
       const productObj = product.toObject();
@@ -33,19 +60,15 @@ exports.getFeaturedProducts = async (req, res) => {
       );
     });
 
-    const total = await Product.countDocuments({
-      isFeatured: true,
-      isPublished: true,
-      isDeleted: false
-    });
+    const total = await Product.countDocuments(query);
 
     res.status(200).json({
       products: transformedProducts,
       pagination: {
-        currentPage: parseInt(page),
-        totalPages: Math.ceil(total / limit),
-        totalProducts: total
-      }
+        currentPage: pageN,
+        totalPages: Math.ceil(total / limitN),
+        totalProducts: total,
+      },
     });
   } catch (error) {
     console.error('Error fetching featured products:', error);

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -97,7 +97,7 @@ const User = require("../models/User");
 const ProductVariant = require("../models/ProductVariant")  ;
 const Business = require("../models/Business");
 const { getBusinessCheckoutBlock } = require("../utils/checkoutGuards");
-const { sendOrderStatusEmail, sendOrderUpdateEmail, sendVendorNewOrderEmail, sendCustomerOrderPlacedEmail } = require("../utils/orderPhase");
+const { sendOrderStatusEmail, sendOrderUpdateEmail } = require("../utils/orderPhase");
 const {
   calculateShippingForVendor,
   normalizeDeliverySpeed,
@@ -782,33 +782,6 @@ exports.initiateOrder = async (req, res) => {
 
     order.paymentId = paymentIntent.id;
     await order.save();
-
-    // =========================
-    // 📧 EMAILS (CUSTOMER + VENDOR)
-    // =========================
-    try {
-      const orderUrlCustomer =
-        "https://app.mosaicbizhub.com/customer/order";
-
-      const orderUrlVendor =
-        "https://app.mosaicbizhub.com/partners/orders";
-
-      // 👤 CUSTOMER EMAIL
-      if (user?.email) {
-        await sendCustomerOrderPlacedEmail(user.email, order, orderUrlCustomer);
-      }
-
-      // 👨‍💼 VENDOR EMAIL
-      if (business?.email) {
-        await sendVendorNewOrderEmail(
-          business.email,
-          order,
-          orderUrlVendor
-        );
-      }
-    } catch (err) {
-      console.error("Email sending failed:", err?.message || err);
-    }
 
     return res.status(201).json({
       success: true,

--- a/controllers/paymentController.js
+++ b/controllers/paymentController.js
@@ -30,6 +30,15 @@ const createPaymentIntent = async (req, res) => {
       return res.status(404).json({ message: 'Order not found.' });
     }
 
+    const requestUserId = String(req.user?.id || req.user?._id || '');
+    if (!requestUserId || order.userId.toString() !== requestUserId) {
+      return res.status(403).json({ message: 'Not allowed to pay for this order.' });
+    }
+
+    if (order.paymentStatus === 'paid') {
+      return res.status(400).json({ message: 'Order is already paid.' });
+    }
+
     const derivedAmount = toStripeAmount(order.totalAmount);
     if (!derivedAmount) {
       return res.status(400).json({ message: 'Order total is invalid.' });

--- a/controllers/productListingController.js
+++ b/controllers/productListingController.js
@@ -46,6 +46,7 @@ async function listProductsRanked(req, res) {
     if (!businessType && !location && !minority) {
       const products = await Product.find({
         isDeleted: false,
+        isPublished: true,
         businessId: { $in: visibleBusinessIds },
       })
         .populate('businessId', 'businessName')
@@ -57,6 +58,7 @@ async function listProductsRanked(req, res) {
 
       const total = await Product.countDocuments({
         isDeleted: false,
+        isPublished: true,
         businessId: { $in: visibleBusinessIds },
       });
 
@@ -89,6 +91,7 @@ async function listProductsRanked(req, res) {
       {
         $match: {
           isDeleted: false,
+          isPublished: true,
           businessId: { $in: visibleBusinessIds },
         }
       }

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -37,6 +37,17 @@ const getVisibleBusinessIds = async () => {
   return businesses.map((business) => business._id.toString());
 };
 
+const PUBLIC_LIST_MAX_LIMIT = 50;
+
+function clipListPagination(page, limit, defaultLimit = 10) {
+  const pageN = Math.max(1, parseInt(page, 10) || 1);
+  const limitN = Math.max(
+    1,
+    Math.min(PUBLIC_LIST_MAX_LIMIT, parseInt(limit, 10) || defaultLimit)
+  );
+  return { page: pageN, limit: limitN, skip: (pageN - 1) * limitN };
+};
+
 const emptyListResponse = (page = 1) => ({
   success: true,
   total: 0,
@@ -255,13 +266,13 @@ exports.getAllServices = async (req, res) => {
     if (sort === 'rating') sortOption = { averageRating: -1 };
     if (sort === 'reviews') sortOption = { totalReviews: -1 };
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     let services = await Service.find(filters)
       .select('title services averageRating totalReviews slug description contact.address coverImage location price businessId')
       .sort(sortOption)
       .skip(skip)
-      .limit(parseInt(limit))
+      .limit(limitN)
       .lean();
 
     const serviceBusinessIds = [...new Set(
@@ -328,8 +339,8 @@ exports.getAllServices = async (req, res) => {
     res.json({
       success: true,
       total,
-      page: parseInt(page),
-      totalPages: Math.ceil(total / limit),
+      page: pageN,
+      totalPages: Math.ceil(total / limitN),
       data: services,
     });
   } catch (err) {
@@ -655,7 +666,7 @@ exports.getAllFood = async (req, res) => {
     if (sort === 'price_desc') sortOption = { price: -1 };
     if (sort === 'rating') sortOption = { averageRating: -1 };
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     // Fetch foods with business info
 const foodItems = await Food.find(filters)
@@ -666,7 +677,7 @@ const foodItems = await Food.find(filters)
   })
   .sort(sortOption)
   .skip(skip)
-  .limit(parseInt(limit))
+  .limit(limitN)
   .lean();
 
     const total = await Food.countDocuments(filters);
@@ -674,8 +685,8 @@ const foodItems = await Food.find(filters)
     res.json({
       success: true,
       total,
-      page: parseInt(page),
-      totalPages: Math.ceil(total / limit),
+      page: pageN,
+      totalPages: Math.ceil(total / limitN),
       data: foodItems.map((food) => toPublicListingCard(food, { listingType: 'food' })),
     });
 
@@ -1134,25 +1145,25 @@ if (price) {
     if (sort === 'price_desc') sortOption = { price: -1 };
     if (sort === 'rating') sortOption = { averageRating: -1 };
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     let products = await Product.find(filters)
       .select('title description coverImage slug brand categoryId subcategoryId price businessId')
       .populate('businessId', 'businessName logo badge address tags')
       .sort(sortOption)
       .skip(skip)
-      .limit(parseInt(limit))
+      .limit(limitN)
       .lean();
 
     products = await mapProductsWithBusinessMeta(products, 'product');
 
     const total = await Product.countDocuments(filters);
-    const totalPages = Math.ceil(total / limit);
+    const totalPages = Math.ceil(total / limitN);
 
     res.json({
       success: true,
       total,
-      page: parseInt(page),
+      page: pageN,
       totalPages,
       data: products,
     });
@@ -1252,14 +1263,14 @@ exports.getProductsByFilters = async (req, res) => {
     if (sort === 'price_desc') sortOption = { price: -1 };
     if (sort === 'rating') sortOption = { averageRating: -1 };
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     // First get products without populating variants to avoid ObjectId errors
     let products = await Product.find(filters)
       .select('title description coverImage variants slug')
       .sort(sortOption)
       .skip(skip)
-      .limit(parseInt(limit))
+      .limit(limitN)
       .lean();
 
     // Manually fetch variants for each product
@@ -1317,8 +1328,8 @@ exports.getProductsByFilters = async (req, res) => {
     res.json({
       success: true,
       total: filteredTotal,
-      page: parseInt(page),
-      totalPages: Math.ceil(filteredTotal / limit) || 0,
+      page: pageN,
+      totalPages: Math.ceil(filteredTotal / limitN) || 0,
       data: products.map((product) => toPublicListingCard(product, { listingType: 'product' })),
     });
 
@@ -1592,13 +1603,13 @@ exports.getProductsByBusinessId = async (req, res) => {
     if (sort === 'price_desc') sortOption = { price: -1 };
     if (sort === 'rating') sortOption = { averageRating: -1 };
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     const products = await Product.find(filters)
       .select('title description coverImage slug brand price averageRating totalReviews')
       .sort(sortOption)
       .skip(skip)
-      .limit(parseInt(limit))
+      .limit(limitN)
       .lean();
 
     const total = await Product.countDocuments(filters);
@@ -1606,8 +1617,8 @@ exports.getProductsByBusinessId = async (req, res) => {
     res.json({
       success: true,
       total,
-      page: parseInt(page),
-      totalPages: Math.ceil(total / limit),
+      page: pageN,
+      totalPages: Math.ceil(total / limitN),
       data: products.map((product) => toPublicListingCard(product, { listingType: 'product' })),
     });
 
@@ -1678,6 +1689,13 @@ exports.searchPublicListings = async (req, res) => {
     } else if (!Array.isArray(allowedBusinessIds) && keywordBusinessIds.length) {
       allowedBusinessIds = keywordBusinessIds;
       useBusinessKeywordOnly = true;
+    }
+
+    if (!Array.isArray(allowedBusinessIds)) {
+      allowedBusinessIds = await getVisibleBusinessIds();
+      if (!allowedBusinessIds.length) {
+        return res.json(emptyPayload);
+      }
     }
 
     const baseBusinessFilter = Array.isArray(allowedBusinessIds)

--- a/controllers/stripe.controller.js
+++ b/controllers/stripe.controller.js
@@ -2,6 +2,7 @@ const Stripe = require('stripe');
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
     apiVersion: '2024-06-20',
 });
+const { assertConnectAccountOwnedByUser } = require('../utils/stripeConnectOwnership');
 
 /**
  * Create a Stripe Account Session for embedded Connect components
@@ -10,8 +11,9 @@ exports.createAccountSession = async (req, res) => {
     try {
         const { account, components } = req.body;
 
-        if (!account) {
-            return res.status(400).json({ error: 'Missing connected account id' });
+        const ownership = await assertConnectAccountOwnedByUser(account, req.user.id);
+        if (!ownership.ok) {
+            return res.status(ownership.status).json({ error: ownership.message });
         }
 
         const enablePayments = Array.isArray(components) && components.includes('payments');
@@ -50,9 +52,11 @@ exports.createAccountSession = async (req, res) => {
 exports.createExpressLoginLink = async (req, res) => {
     try {
         const { account, redirect_url } = req.body;
-        if (!account) return res.status(400).json({ error: 'Missing connected account id' });
 
-        // (recommended) verify ownership of the account vs. the authenticated vendor here
+        const ownership = await assertConnectAccountOwnedByUser(account, req.user.id);
+        if (!ownership.ok) {
+            return res.status(ownership.status).json({ error: ownership.message });
+        }
 
         const link = await stripe.accounts.createLoginLink(account, {
             redirect_url, // optional: send them back to your app after closing dashboard
@@ -70,9 +74,11 @@ exports.createExpressLoginLink = async (req, res) => {
 exports.getAccountBalance = async (req, res) => {
     try {
         const { account } = req.query;
-        if (!account) return res.status(400).json({ error: 'Missing connected account id' });
 
-        // Verify ownership of `account` to the authenticated partner here if you have auth
+        const ownership = await assertConnectAccountOwnedByUser(account, req.user.id);
+        if (!ownership.ok) {
+            return res.status(ownership.status).json({ error: ownership.message });
+        }
         const balance = await stripe.balance.retrieve({ stripeAccount: account });
 
         // choose a single currency (Stripe returns arrays per currency)
@@ -92,7 +98,11 @@ exports.getAccountBalance = async (req, res) => {
 exports.getLastPayout = async (req, res) => {
     try {
         const { account } = req.query;
-        if (!account) return res.status(400).json({ error: 'Missing connected account id' });
+
+        const ownership = await assertConnectAccountOwnedByUser(account, req.user.id);
+        if (!ownership.ok) {
+            return res.status(ownership.status).json({ error: ownership.message });
+        }
 
         // Latest payout (could be pending or paid); adjust as you like
         const payouts = await stripe.payouts.list(

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -60,6 +60,8 @@ exports.stripePaymentWebhook = async (req, res) => {
       }
 
       for (const order of orders) {
+        const shouldSendPaidEmail = !order.paidConfirmationEmailSentAt;
+
         // status updates
         order.paymentStatus = "paid";
         if (order.status === "created") {
@@ -85,7 +87,13 @@ exports.stripePaymentWebhook = async (req, res) => {
         // order.applicationFeeId = applicationFeeId;
 
         await order.save();
-        // ---------------------------------
+
+        if (!shouldSendPaidEmail) {
+          console.log(
+            `Paid confirmation email already sent for order ${order._id}, skipping duplicate send`
+          );
+          continue;
+        }
 
         // ✅ recipients (deduped)
         const customerEmails = [...new Set([order.userId?.email].filter(Boolean))];
@@ -105,6 +113,8 @@ exports.stripePaymentWebhook = async (req, res) => {
             customerEmails,
             vendorEmails: uniqueVendorEmails,
           });
+          order.paidConfirmationEmailSentAt = new Date();
+          await order.save();
         } catch (mailErr) {
           console.error("✉️ Failed to send order-paid emails:", mailErr?.message || mailErr);
         }

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -2,7 +2,7 @@
 
 Process guide for AI agents and developers working on `Techware-Hut/mosaic-backend`. Read this before opening a branch.
 
-**Related:** [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) · [LLM_CONTEXT.md](LLM_CONTEXT.md) · [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md)
+**Related:** [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) · [LLM_CONTEXT.md](LLM_CONTEXT.md) · [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) · [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md)
 
 ---
 
@@ -50,7 +50,7 @@ Process guide for AI agents and developers working on `Techware-Hut/mosaic-backe
 ## Before opening a PR
 
 1. Run relevant tests for your domain
-2. Run full suite when practical: `npm test` (expect **168/168** on current `main`)
+2. Run full suite when practical: `npm test` (expect **173/173** on current `main`)
 3. Confirm diff contains **no secrets** and **no unrelated files**
 4. Confirm docs updated where the issue requires it
 5. Do **not** use `git add .` — stage files intentionally

--- a/docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md
+++ b/docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md
@@ -1,0 +1,136 @@
+# Backend Launch Blockers — Batch 2 Audit
+
+**Branch:** `sprint/backend-launch-blockers-41-43-69`  
+**Date:** 2026-06-18  
+**Builds on:** `sprint/backend-stability-roadmap-cleanup` (`5e6995e`)
+
+Prior stabilization work is documented in [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md). This audit covers issues **#41**, **#43**, and **#69** only.
+
+---
+
+## Current checkout / order / payment flow
+
+```mermaid
+sequenceDiagram
+  participant Customer
+  participant Initiate as POST_/api/orders/initiate
+  participant Stripe
+  participant StatusWH as POST_/api/webhooks/stripe
+  participant PostWH as POST_/api/stripe/payment/webhook
+
+  Customer->>Initiate: Cart + shipping (auth customer)
+  Initiate->>Initiate: Order status=created, paymentStatus=pending
+  Initiate->>Stripe: Connect paymentIntents.create
+  Initiate-->>Customer: 201 + clientSecret
+
+  Customer->>Stripe: Confirm payment
+  Stripe->>StatusWH: payment_intent.succeeded
+  StatusWH->>StatusWH: paymentStatus=paid, status=ordered (no email)
+  Stripe->>PostWH: payment_intent.succeeded
+  PostWH->>PostWH: charge IDs + sendOrderPaidEmails (post-payment)
+```
+
+| Step | File | Function / route |
+| --- | --- | --- |
+| Checkout | [controllers/orderController.js](../controllers/orderController.js) | `initiateOrder` |
+| Connect PI | same | Stripe `paymentIntents.create` with Connect account |
+| Legacy PI (guarded) | [controllers/paymentController.js](../controllers/paymentController.js) | `POST /api/payments/create-payment-intent` |
+| Status webhook | [controllers/webhookController.js](../controllers/webhookController.js) | `handleStripeWebhook` |
+| Post-payment webhook | [controllers/stripePaymentController.js](../controllers/stripePaymentController.js) | `stripePaymentWebhook` |
+| Paid emails | [utils/OrderMail.js](../utils/OrderMail.js) | `sendOrderPaidEmails` |
+
+**Canonical checkout:** `POST /api/orders/initiate` (Stripe Connect, #42).  
+**Legacy path:** `POST /api/payments/create-payment-intent` — plain PI, now requires customer auth + order ownership.
+
+---
+
+## Email timing flow (before batch 2)
+
+| Trigger | When | Emails | Problem |
+| --- | --- | --- | --- |
+| `initiateOrder` | After PI created, **before** payment | `sendCustomerOrderPlacedEmail`, `sendVendorNewOrderEmail` | Customer/vendor notified before payment confirmed |
+| `stripePaymentWebhook` | After `payment_intent.succeeded` | `sendOrderPaidEmails` (confirmation + PDF) | Correct timing; **no duplicate guard** |
+
+**After batch 2:**
+
+- Pre-payment emails **removed** from `initiateOrder`
+- Post-payment path only via `sendOrderPaidEmails`
+- `Order.paidConfirmationEmailSentAt` prevents duplicate sends on webhook retry
+
+---
+
+## Route auth / protection map (payment-sensitive)
+
+| Route | Method | Protection (after batch 2) | Notes |
+| --- | --- | --- | --- |
+| `/api/orders/initiate` | POST | `authenticate`, `isCustomer` | Connect checkout |
+| `/api/orders/retrieve-intent/:id` | GET | `authenticate` + ownership in controller | |
+| `/api/payments/create-payment-intent` | POST | `authenticate`, `isCustomer` + order ownership | Legacy; rate limited |
+| `/stripe/account-session` | POST | `authenticate`, `isBusinessOwner` + Connect ownership | |
+| `/stripe/express-login-link` | POST | same | |
+| `/stripe/account-balance` | GET | same | |
+| `/stripe/last-payout` | GET | same | |
+| `/stripe/backfill-customers` | POST | `authenticate`, `isAdmin` | Admin-only |
+| `/api/connect/:businessId/account-link` | POST | `authenticate`, `isBusinessOwner` + owner check in controller | Pre-existing |
+| `/api/webhooks/stripe` | POST | Stripe signature | Raw body before JSON |
+| `/api/stripe/payment/webhook` | POST | Stripe signature | Raw body before JSON |
+| `/api/stripe/webhook` | POST | Stripe signature | Business draft webhook |
+| `/api/vendor-onboarding/webhook/payment` | POST | Stripe signature | Raw body mount |
+| `/api/subscription/webhook` | POST | Stripe signature | Raw body mount |
+| `/api/health` | GET | Public | Liveness — no DB |
+| `/api/ready` | GET | Public | Readiness — Mongo ping via `readyState` |
+| `/` | GET | Public | Legacy health string (unchanged) |
+
+### Intentionally public
+
+- Stripe webhooks (signature-verified, raw body)
+- `/api/connect/return`, `/api/connect/refresh` (redirect helpers)
+- `/api/health`, `/api/ready` (no secrets in response)
+
+### Deferred (out of batch 2 scope)
+
+- Billing routes `/api/subscriptions/*`, `/api/billing-portal/session` — role-only auth; IDOR audit tracked in #76 / #66
+- `GET /api/connect/:businessId/status` — owner check not in controller yet
+
+---
+
+## Health / readiness (before batch 2)
+
+| Endpoint | Behavior |
+| --- | --- |
+| `GET /` | Inline JSON in [app.js](../app.js) — liveness only |
+| `/api/health` | **Missing** |
+| `/api/ready` | **Missing** |
+
+---
+
+## Files involved in batch 2
+
+| Issue | Files |
+| --- | --- |
+| #41 | [routes/paymentRoutes.js](../routes/paymentRoutes.js), [routes/stripe.routes.js](../routes/stripe.routes.js), [routes/orderRoutes.js](../routes/orderRoutes.js), [controllers/paymentController.js](../controllers/paymentController.js), [controllers/stripe.controller.js](../controllers/stripe.controller.js), [utils/stripeConnectOwnership.js](../utils/stripeConnectOwnership.js) |
+| #43 | [controllers/orderController.js](../controllers/orderController.js), [controllers/stripePaymentController.js](../controllers/stripePaymentController.js), [models/Order.js](../models/Order.js) |
+| #69 | [routes/healthRoutes.js](../routes/healthRoutes.js), [app.js](../app.js) |
+| Tests | [tests/stripe/payment-route-protection.test.js](../tests/stripe/payment-route-protection.test.js), [tests/stripe/order-email-safety.test.js](../tests/stripe/order-email-safety.test.js), [tests/health/health-readiness.test.js](../tests/health/health-readiness.test.js) |
+
+---
+
+## Risks and assumptions
+
+| Assumption | Rationale |
+| --- | --- |
+| No guest checkout | All order routes require authenticated customer |
+| Legacy PI route may still be used by old clients | Guarded with auth + ownership instead of 410 removal |
+| Pre-payment “order placed” emails are not required for MVP | Final confirmation + invoice sent post-payment only |
+| `paidConfirmationEmailSentAt` set after successful SMTP send | Failed send allows webhook retry to attempt again |
+| Webhook raw-body order unchanged | Verified by existing `stripe-webhook-routing-signature.test.js` |
+| Health endpoints public | Standard for EB/GHA probes; no env leakage |
+
+---
+
+## Related docs
+
+- [BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md)
+- [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md)
+- [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md)
+- [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md)

--- a/docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md
+++ b/docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md
@@ -1,0 +1,173 @@
+# Backend Launch Blockers — Batch 2 Proof Pack
+
+**Branch:** `sprint/backend-launch-blockers-41-43-69`  
+**Date:** 2026-06-18  
+**Issues:** #41, #43, #69 (+ smoke support for #27)
+
+---
+
+## Commit
+
+Record after commit:
+
+```text
+git rev-parse HEAD
+```
+
+---
+
+## Files changed
+
+| File | Issue | Change |
+| --- | --- | --- |
+| `routes/paymentRoutes.js` | #41 | `authenticate`, `isCustomer` on legacy PI route |
+| `routes/stripe.routes.js` | #41 | Auth middleware on all `/stripe/*` routes |
+| `routes/orderRoutes.js` | #41 | `isCustomer` on `/initiate` |
+| `controllers/paymentController.js` | #41 | Order ownership + already-paid guard |
+| `controllers/stripe.controller.js` | #41 | Connect account ownership checks |
+| `utils/stripeConnectOwnership.js` | #41 | Shared ownership helper |
+| `controllers/orderController.js` | #43 | Removed pre-payment emails |
+| `controllers/stripePaymentController.js` | #43 | `paidConfirmationEmailSentAt` dedup |
+| `models/Order.js` | #43 | `paidConfirmationEmailSentAt` field |
+| `routes/healthRoutes.js` | #69 | New `/api/health`, `/api/ready` |
+| `app.js` | #69 | Mount health routes after JSON parser |
+| `tests/stripe/payment-route-protection.test.js` | #41 | New route/auth tests |
+| `tests/stripe/order-email-safety.test.js` | #43 | Duplicate email + no pre-payment sends |
+| `tests/health/health-readiness.test.js` | #69 | Health/readiness tests |
+| `docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md` | All | Audit |
+| `docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md` | All | This file |
+
+---
+
+## Tests run
+
+| Command | Result |
+| --- | --- |
+| `npm test` | **190/190 pass** (was 178 before batch 2) |
+| `npm run lint` | Not defined |
+| `npm run build` | Not defined |
+| `node scripts/verify-auth-check-smoke.js` | Skipped (requires live credentials) |
+
+---
+
+## Payment route protection matrix (summary)
+
+| Route | Unauthenticated | Wrong role | Authorized |
+| --- | --- | --- | --- |
+| `POST /api/payments/create-payment-intent` | **401** | **403** (non-customer) | 200 if order owned |
+| `POST /stripe/account-session` | **401** | **403** (non-vendor) | 200 if Connect account owned |
+| `POST /api/orders/initiate` | **401** | **403** (non-customer) | 201 Connect checkout |
+| Stripe webhooks | Signature required | N/A | 200 with valid sig |
+| `POST /stripe/backfill-customers` | **401** | **403** (non-admin) | Admin only |
+
+Full matrix: [BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md)
+
+---
+
+## Order email timing proof
+
+| Scenario | Expected | Test |
+| --- | --- | --- |
+| Order initiated (PI created) | **No** customer/vendor confirmation email | Source audit + removed block |
+| `payment_intent.succeeded` webhook | `sendOrderPaidEmails` once | `order-email-safety.test.js` |
+| Duplicate webhook retry | **No** second paid email | `paidConfirmationEmailSentAt` guard |
+| SMTP failure on paid email | Webhook still `{ received: true }` | Existing test preserved |
+
+**Email trigger point (after):** `stripePaymentWebhook` → `sendOrderPaidEmails` only after confirmed payment.
+
+---
+
+## Health / readiness proof
+
+| Endpoint | Status | Body highlights |
+| --- | --- | --- |
+| `GET /api/health` | 200 | `status: ok`, `service`, `uptime`, `timestamp` — no DB |
+| `GET /api/ready` (DB connected) | 200 | `status: ready`, `database: connected` |
+| `GET /api/ready` (DB down) | 503 | `status: not_ready`, `database: disconnected` |
+
+No connection strings or secrets in responses (test + source audit).
+
+---
+
+## Smoke commands (#27 support)
+
+### Local (after `npm start`)
+
+```powershell
+curl.exe -s -o NUL -w "%{http_code}" http://localhost:3001/api/health
+curl.exe -s http://localhost:3001/api/ready
+curl.exe -s "http://localhost:3001/api/featured-products?page=1&limit=12"
+curl.exe -s "http://localhost:3001/api/products/list?page=1&limit=10"
+curl.exe -s "http://localhost:3001/api/public/search?keyword=test"
+curl.exe -s "http://localhost:3001/api/ranked?page=1&pageSize=24"
+curl.exe -s http://localhost:3001/api/categories
+```
+
+### Production (pre-deploy — health endpoints 404 until EB deploy)
+
+```powershell
+curl.exe -s -o NUL -w "%{http_code}" https://api.mosaicbizhub.com/
+curl.exe -s -o NUL -w "%{http_code}" https://api.mosaicbizhub.com/api/featured-products?page=1&limit=12
+```
+
+### Authorization checks (expect 401 without cookie/token)
+
+```powershell
+curl.exe -s -o NUL -w "%{http_code}" -X POST https://api.mosaicbizhub.com/api/payments/create-payment-intent -H "Content-Type: application/json" -d "{\"orderId\":\"507f1f77bcf86cd799439011\"}"
+curl.exe -s -o NUL -w "%{http_code}" -X POST https://api.mosaicbizhub.com/stripe/account-session -H "Content-Type: application/json" -d "{\"account\":\"acct_test\"}"
+```
+
+### Stripe webhook (local only)
+
+Use Stripe CLI against raw-body routes — do not expose secrets in docs. See [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md).
+
+---
+
+## Env vars (no values)
+
+Unchanged for this batch. Payment/email still require:
+
+- `STRIPE_SECRET_KEY`, webhook secrets (`STRIPE_ORDER_*`, etc.)
+- `MAIL_USER`, `MAIL_PASSWORD` for SMTP
+- `JWT_SECRET` for auth gates
+- `MONGODB_URI` for readiness
+
+---
+
+## Schema change
+
+| Model | Field | Purpose |
+| --- | --- | --- |
+| `Order` | `paidConfirmationEmailSentAt` | Webhook email idempotency (#43) |
+
+No SQL migrations — Mongoose schema only.
+
+---
+
+## Remaining launch blockers
+
+| Issue | Status after batch 2 |
+| --- | --- |
+| #41 Payment route protection | **Addressed** in this branch (legacy + `/stripe/*`) |
+| #43 Order email timing | **Addressed** in this branch |
+| #69 Health/readiness | **Addressed** in this branch |
+| #27 Full smoke proof | **Partial** — commands documented; needs `SMOKE_TEST_*` accounts + post-deploy run |
+| #18 Sentry EB deploy | Open |
+| Billing route IDOR (#76) | Deferred |
+
+---
+
+## Risks before deploy
+
+1. Changes not live until EB deploy from merged branch
+2. Legacy clients calling `/api/payments/create-payment-intent` without auth will receive **401**
+3. Vendors/customers who relied on pre-payment “order placed” email will only get post-payment confirmation
+4. Confirm `paidConfirmationEmailSentAt` persists on existing orders (defaults null — safe)
+
+---
+
+## Related docs
+
+- [BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md)
+- [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md)
+- [production-smoke-checklist.md](production-smoke-checklist.md)

--- a/docs/BACKEND_ROADMAP_ISSUES.md
+++ b/docs/BACKEND_ROADMAP_ISSUES.md
@@ -1,0 +1,372 @@
+# Backend Roadmap Issues Plan
+
+**Branch:** `sprint/backend-stability-roadmap-cleanup`  
+**Date:** 2026-06-18  
+**Purpose:** GitHub-ready issue backlog grouped by priority lane. Maps to existing open issues where possible — do not duplicate filing without review.
+
+**Status labels used:** Defect / Bug Fix Needed · Revision Needed · Pending Developer Response · Deferred / Future Phase · Change Request Required
+
+---
+
+## 1. Launch blockers
+
+### #41 — Payment route protection hardening
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#41](https://github.com/Techware-Hut/mosaic-backend/issues/41) |
+| **Status** | Defect / Bug Fix Needed |
+| **Problem** | Legacy `/stripe/*` and unauthenticated payment intent routes expose pre-checkout attack surface |
+| **Impact** | Unauthorized payment API access; launch security gate |
+| **Scope** | Auth middleware on legacy routes; remove or guard `POST /api/payments/create-payment-intent` |
+| **Out of scope** | Connect checkout flow changes (#42 already merged) |
+| **Acceptance criteria** | All payment mutation routes require authenticated customer or server-side webhook; audit doc updated |
+| **Testing** | Unit tests for 401/403; manual curl on prod after deploy |
+| **Risk** | High |
+
+### #43 — Order email timing and webhook retry idempotency
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#43](https://github.com/Techware-Hut/mosaic-backend/issues/43) |
+| **Status** | Defect / Bug Fix Needed |
+| **Problem** | Order confirmation emails may fire before payment confirmation |
+| **Impact** | Customer confusion; false "order paid" emails |
+| **Scope** | Move customer/vendor order emails to post-webhook success path; idempotent webhook handlers |
+| **Out of scope** | Stripe Connect account creation |
+| **Acceptance criteria** | No paid-order email before `payment_intent.succeeded`; duplicate webhooks safe |
+| **Testing** | Extend `tests/stripe/order-webhook-email-safety.test.js`; manual test-mode checkout |
+| **Risk** | High |
+
+### #27 — Full production smoke proof pack (P0–P6)
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#27](https://github.com/Techware-Hut/mosaic-backend/issues/27) |
+| **Status** | Pending Developer Response |
+| **Problem** | Browse/auth smoke PASS; checkout/email/vendor tiers incomplete |
+| **Impact** | Cannot sign off launch without tiered evidence |
+| **Scope** | Execute [production-smoke-checklist.md](production-smoke-checklist.md) with `SMOKE_TEST_*` accounts |
+| **Out of scope** | New feature development |
+| **Acceptance criteria** | Proof pack filled per [production-proof-pack-template.md](production-proof-pack-template.md) |
+| **Testing** | Manual prod smoke; document SKIP reasons |
+| **Risk** | High (process) |
+
+### #69 — Health and readiness endpoints
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#69](https://github.com/Techware-Hut/mosaic-backend/issues/69) |
+| **Status** | Revision Needed |
+| **Problem** | Only `GET /` exists; no structured readiness probe |
+| **Impact** | EB/GHA cannot distinguish "up" vs "ready" (DB connected) |
+| **Scope** | Add `/api/health` or `/api/ready` with Mongo ping; keep `GET /` backward compatible |
+| **Out of scope** | Metrics dashboard |
+| **Acceptance criteria** | Readiness returns 503 when DB disconnected; documented in runbook |
+| **Testing** | Unit test + post-deploy curl |
+| **Risk** | Medium |
+
+---
+
+## 2. High-priority post-launch
+
+### #34 — Admin dashboard aggregation APIs
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) |
+| **Status** | Deferred / Future Phase (MVP partial) |
+| **Problem** | No admin sales/revenue summary API |
+| **Impact** | Admin dashboard incomplete |
+| **Scope** | Read-only aggregation endpoints for pending approvals, highlights, sales summary |
+| **Out of scope** | Full BI/analytics |
+| **Acceptance criteria** | Documented admin routes with auth; DTO tests |
+| **Testing** | Admin role tests |
+| **Risk** | Medium |
+
+### #66 — Admin authorization matrix audit
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#66](https://github.com/Techware-Hut/mosaic-backend/issues/66) |
+| **Status** | Revision Needed |
+| **Problem** | Admin routes may have inconsistent role guards |
+| **Impact** | Privilege escalation risk |
+| **Scope** | Audit all `/admin/*` and `/api/admin/*` routes; document matrix |
+| **Out of scope** | RBAC redesign |
+| **Acceptance criteria** | Matrix doc + tests for each admin mutation route |
+| **Testing** | 403 tests for customer/vendor roles |
+| **Risk** | High |
+
+### #65 — Vendor onboarding state machine audit
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#65](https://github.com/Techware-Hut/mosaic-backend/issues/65) |
+| **Status** | Revision Needed |
+| **Problem** | Multiple status fields across onboarding, business, and listings |
+| **Impact** | Edge cases in resubmit/reject/approve flows |
+| **Scope** | State diagram + gap list; fix clear defects only |
+| **Out of scope** | BusinessScreen automation |
+| **Acceptance criteria** | Documented state machine matches [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) |
+| **Testing** | Extend vendor onboarding test suite |
+| **Risk** | Medium |
+
+---
+
+## 3. Performance / loading improvements
+
+### #44 — Public API pagination and query-shaping audit
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#44](https://github.com/Techware-Hut/mosaic-backend/issues/44) |
+| **Status** | Partially addressed (this sprint) |
+| **Problem** | Inconsistent pagination shapes; unbounded limits on some routes |
+| **Impact** | Slow frontend loads; large payloads |
+| **Scope** | Unified pagination helper; document response shapes |
+| **Out of scope** | GraphQL |
+| **Acceptance criteria** | All public list endpoints cap limit; pagination metadata documented |
+| **Testing** | Marketplace tests for each list family |
+| **Risk** | Low–Medium |
+
+**This sprint delivered:** featured/list limit caps (50), search default scope, ranked `isPublished`.
+
+### #53 — Database index and explain-plan audit
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#53](https://github.com/Techware-Hut/mosaic-backend/issues/53) |
+| **Status** | Partially addressed (this sprint) |
+| **Problem** | Missing indexes on hot listing filters |
+| **Impact** | Slow queries at scale |
+| **Scope** | Product indexes (done); Service/Food indexes; Atlas explain plans |
+| **Out of scope** | Read replicas |
+| **Acceptance criteria** | Index list documented; explain plans for top 5 public queries |
+| **Testing** | Staging/Atlas index verification post-deploy |
+| **Risk** | Medium |
+
+### #54 — Media payload and image response optimization
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#54](https://github.com/Techware-Hut/mosaic-backend/issues/54) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | List endpoints may return heavy image arrays |
+| **Impact** | Bandwidth and parse time on mobile |
+| **Scope** | Card endpoints return single `imageUrl`; detail keeps gallery |
+| **Out of scope** | CDN migration |
+| **Acceptance criteria** | DTO contract updated backward-compat |
+| **Testing** | DTO tests; payload size spot check |
+| **Risk** | Low |
+
+---
+
+## 4. Vendor / admin workflow improvements
+
+### #76 — Vendor plan entitlement and subscription lifecycle
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#76](https://github.com/Techware-Hut/mosaic-backend/issues/76) |
+| **Status** | Revision Needed |
+| **Problem** | Tier limits vs subscription state may drift |
+| **Impact** | Vendors over/under-listing relative to plan |
+| **Scope** | Audit tier enforcement (#31) vs subscription webhooks |
+| **Out of scope** | New tier SKUs |
+| **Acceptance criteria** | Documented entitlement rules; defect fixes only |
+| **Testing** | Vendor quota tests + subscription webhook tests |
+| **Risk** | Medium |
+
+### #67 — Email template and notification contract cleanup
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#67](https://github.com/Techware-Hut/mosaic-backend/issues/67) |
+| **Status** | Revision Needed |
+| **Problem** | Email templates scattered across multiple mailer files |
+| **Impact** | Inconsistent branding/copy; hard to audit |
+| **Scope** | Inventory all mailers; standardize subject/body contracts |
+| **Out of scope** | Marketing automation |
+| **Acceptance criteria** | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) updated with template map |
+| **Testing** | Existing email safety tests pass |
+| **Risk** | Low |
+
+### #77 — Marketplace moderation and listing visibility rules
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#77](https://github.com/Techware-Hut/mosaic-backend/issues/77) |
+| **Status** | Partially addressed (this sprint) |
+| **Problem** | Inconsistent visibility gates across featured/search/ranked |
+| **Impact** | Inactive or unpublished listings visible publicly |
+| **Scope** | Document rules: `isActive` for browse, `isApproved` for checkout |
+| **Out of scope** | Automated moderation AI |
+| **Acceptance criteria** | Visibility matrix doc; tests for each public endpoint family |
+| **Testing** | Marketplace visibility tests (extended this sprint) |
+| **Risk** | Medium |
+
+---
+
+## 5. Marketplace / search improvements
+
+### #72 — Public search relevance and taxonomy normalization
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#72](https://github.com/Techware-Hut/mosaic-backend/issues/72) |
+| **Status** | Revision Needed |
+| **Problem** | Regex keyword search; category slug inconsistencies |
+| **Impact** | Poor search UX |
+| **Scope** | Audit search scoring; normalize category aliases |
+| **Out of scope** | Elasticsearch/Atlas Search (unless approved CR) |
+| **Acceptance criteria** | Search audit doc with recommended MVP fixes |
+| **Testing** | Search filter tests |
+| **Risk** | Medium |
+
+### #45 — DTO serializer consolidation
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#45](https://github.com/Techware-Hut/mosaic-backend/issues/45) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | Multiple response shapes across list endpoints |
+| **Impact** | Frontend integration friction |
+| **Scope** | Consolidate on `toPublicListingCard` / shared pagination wrapper |
+| **Out of scope** | Removing legacy keys (backward compat required) |
+| **Acceptance criteria** | Contract doc matches all public list endpoints |
+| **Testing** | DTO test coverage for each listing type |
+| **Risk** | Medium (breaking if done wrong) |
+
+---
+
+## 6. Observability / monitoring
+
+### #18 — Sentry production deploy and verification
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#18](https://github.com/Techware-Hut/mosaic-backend/issues/18) |
+| **Status** | Pending Developer Response |
+| **Problem** | Sentry merged to `main` (`a03305a`); not deployed to EB |
+| **Impact** | No prod error capture |
+| **Scope** | EB deploy + verify DSN; optional debug route disabled in prod |
+| **Out of scope** | Session replay |
+| **Acceptance criteria** | Test error appears in Sentry dashboard; env vars in [production-env-checklist.md](production-env-checklist.md) |
+| **Testing** | `tests/sentry/instrument.test.js`; manual debug route in staging only |
+| **Risk** | Low |
+
+### #58 — Structured logging and request correlation IDs
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#58](https://github.com/Techware-Hut/mosaic-backend/issues/58) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | `console.error` only; no request IDs |
+| **Impact** | Hard to trace prod issues |
+| **Scope** | Request ID middleware; structured JSON logs |
+| **Out of scope** | Full log aggregation stack |
+| **Acceptance criteria** | Request ID in logs and Sentry context |
+| **Testing** | Middleware unit test |
+| **Risk** | Low |
+
+### #63 — Production smoke-test automation harness
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#63](https://github.com/Techware-Hut/mosaic-backend/issues/63) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | Smoke is manual curl/scripts |
+| **Impact** | Slow release verification |
+| **Scope** | Script or GHA job for P0–P2 tiers |
+| **Out of scope** | Live Stripe charges in CI |
+| **Acceptance criteria** | Runnable smoke script with PASS/FAIL report |
+| **Testing** | CI dry-run against prod read-only endpoints |
+| **Risk** | Low |
+
+---
+
+## 7. Future scope / change requests
+
+### #35 — Reviews API
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#35](https://github.com/Techware-Hut/mosaic-backend/issues/35) |
+| **Status** | Change Request Required |
+| **Problem** | Reviews partially implemented; no full MVP audit |
+| **Impact** | Product ratings incomplete for launch |
+| **Scope** | TBD per product owner — audit existing review routes first |
+| **Out of scope** | Review follow-up emails (explicitly deferred in tests) |
+| **Acceptance criteria** | PO sign-off on MVP review scope |
+| **Risk** | Medium |
+
+### #55 — OpenAPI / API contract documentation
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#55](https://github.com/Techware-Hut/mosaic-backend/issues/55) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | No machine-readable API spec |
+| **Impact** | Frontend contract drift |
+| **Scope** | Generate OpenAPI from route registry or hand-maintain core public routes |
+| **Out of scope** | Auto-codegen of clients |
+| **Acceptance criteria** | OpenAPI file for public browse + auth routes |
+| **Risk** | Low |
+
+### BusinessScreen API verification automation
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | Not filed |
+| **Status** | Change Request Required |
+| **Problem** | Manual vendor verification only for MVP |
+| **Impact** | Ops scale limit |
+| **Scope** | External API integration — requires contract |
+| **Out of scope** | MVP launch |
+| **Acceptance criteria** | PO + legal approval |
+| **Risk** | N/A (deferred) |
+
+### Advanced geolocation / ZIP-radius search
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | See [DECISION_REGISTER.md](DECISION_REGISTER.md) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | ZIP exact match only |
+| **Impact** | Limited local discovery |
+| **Scope** | Geospatial indexes + radius query |
+| **Out of scope** | MVP (documented in #29) |
+| **Acceptance criteria** | CR approved |
+| **Risk** | Medium |
+
+### #52 — Controller/service boundary refactor
+
+| Field | Detail |
+| --- | --- |
+| **GitHub** | [#52](https://github.com/Techware-Hut/mosaic-backend/issues/52) |
+| **Status** | Deferred / Future Phase |
+| **Problem** | Fat controllers; mixed concerns |
+| **Impact** | Maintainability |
+| **Scope** | Refactor plan only in Phase 2 |
+| **Out of scope** | MVP launch changes |
+| **Acceptance criteria** | Refactor plan doc with incremental milestones |
+| **Risk** | High if done as big-bang |
+
+---
+
+## Recommended next five GitHub issues (priority order)
+
+1. **#41** — Payment route protection (P0 security)
+2. **#43** — Order email timing (P0 customer trust)
+3. **#27** — Complete smoke proof pack (launch sign-off)
+4. **#18** — Deploy and verify Sentry on EB
+5. **#69** — Health/readiness endpoints
+
+---
+
+## Related docs
+
+- [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md)
+- [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md)
+- [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md)

--- a/docs/BACKEND_STABILITY_AGENT_PROMPT.md
+++ b/docs/BACKEND_STABILITY_AGENT_PROMPT.md
@@ -1,0 +1,271 @@
+# Backend Stabilization + Roadmap Progress Prompt
+
+Use this prompt in Cursor or OpenClaw when running a controlled backend stabilization sprint on `Techware-Hut/mosaic-backend`.
+
+**Branch:** `sprint/backend-stability-roadmap-cleanup` (or a new `sprint/backend-*` branch for a focused follow-up)
+
+**Related docs:** [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) · [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md) · [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md)
+
+---
+
+## Prompt (copy from here)
+
+```text
+You are working in the backend repo:
+
+Techware-Hut/mosaic-backend
+
+Act as a senior backend engineer, release coordinator, and production-readiness auditor.
+
+Current production API:
+https://api.mosaicbizhub.com
+
+Frontend launch origin:
+https://mosaic-biz-frontend-launch.vercel.app
+
+Canonical featured endpoint:
+GET /api/featured-products
+
+IMPORTANT RULES
+
+- Do not merge to main.
+- Do not deploy.
+- Do not edit production deployment workflows unless explicitly required and documented.
+- Do not commit secrets.
+- Do not introduce breaking API changes.
+- Preserve GET /api/featured-products as the canonical featured endpoint.
+- Do not create or switch the frontend/backend contract to /api/products/featured.
+- Do not touch Stripe checkout, payment intent creation, Stripe Connect, or webhook behavior unless the issue is clearly about broken checkout and you isolate the change carefully.
+- Keep all public response changes backward compatible.
+- Prefer small, safe fixes with tests over large rewrites.
+- Leave clear documentation and proof.
+
+Branch name:
+sprint/backend-stability-roadmap-cleanup
+
+Primary goal:
+Clean up lingering backend issues, improve loading/API performance where safe, verify MVP backend readiness, and create a clear roadmap report for what remains.
+
+Context:
+Mosaic Biz Hub is a marketplace platform with vendor onboarding, public browsing, products, services, food/restaurants, business/vendor profiles, featured listings, tier plans, trust/verification workflow, checkout/order flow, admin review, and customer browsing. The project requires a structured deliverable review process, defect tracking, and separation of accepted work, defects, pending work, deferred work, and change requests.
+
+Use the existing repo docs first, especially anything under docs/, GitHub issues, API audit files, smoke proof docs, marketplace data contract docs, deployment docs, and launch-readiness notes.
+
+PHASE 1 — Repository and Issue Audit
+
+1. Inspect the full backend repo.
+2. Read existing docs and recent completed backend work.
+3. Review open GitHub issues if available locally or through gh CLI.
+4. Identify lingering backend issues related to:
+   - public marketplace APIs
+   - products
+   - services
+   - food/restaurants
+   - vendor/business profiles
+   - featured products
+   - search/filter endpoints
+   - vendor onboarding approval/rejection flow
+   - trust score/status fields
+   - admin review queues
+   - email notifications
+   - health checks
+   - CORS
+   - error handling
+   - logging/monitoring
+   - database query performance
+   - response payload consistency
+   - pagination and loading speed
+   - N+1 queries
+   - missing indexes
+   - duplicate or dead endpoints
+   - test coverage gaps
+   - production smoke readiness
+
+Deliverable:
+Create or update:
+
+docs/BACKEND_STABILITY_ROADMAP_AUDIT.md
+
+Include:
+- What exists
+- What is working
+- What is fragile
+- What is missing
+- What should be fixed now
+- What should be deferred
+- What may be change request / future scope
+- Risks before production testing
+
+PHASE 2 — Safe Backend Fixes
+
+Apply only safe, scoped fixes that improve production readiness without changing major business logic.
+
+Look for and fix:
+
+1. Slow public endpoints
+   - Add pagination defaults where missing.
+   - Add max page/limit guards.
+   - Avoid returning huge unbounded result sets.
+   - Optimize includes/selects.
+   - Remove unnecessary heavy nested payloads from list/card endpoints.
+   - Keep detail endpoints richer than card/list endpoints.
+
+2. Database performance
+   - Identify likely slow filters/sorts.
+   - Add safe indexes through migrations if the ORM/migration system supports it.
+   - Focus on fields used for:
+     - status/visibility
+     - category/type
+     - vendor/business id
+     - featured flag
+     - createdAt/updatedAt
+     - location/city/state/zip if already implemented
+     - product/service/food listing status
+   - Do not add speculative geolocation logic if ZIP/geolocation is not already implemented.
+
+3. Public response consistency
+   - Ensure cards/detail pages get predictable fields:
+     - id
+     - title/name
+     - slug if available
+     - description/summary
+     - price or priceRange where applicable
+     - image/images
+     - category/type
+     - vendor/business summary
+     - badge/trust fields if available
+     - location summary if available
+     - availability/status
+   - Use DTO/helper/serializer patterns if they already exist.
+   - Do not remove existing fields.
+
+4. Error handling
+   - Normalize error responses where safe.
+   - Avoid leaking stack traces in production.
+   - Ensure common 400/401/403/404/500 cases are handled intentionally.
+
+5. Loading and frontend experience
+   - Make list endpoints return fast, lightweight payloads.
+   - Add pagination metadata if missing:
+     - page
+     - limit
+     - total or hasMore if feasible
+   - Ensure empty states return clean arrays, not crashes.
+   - Ensure search/filter queries do not crash when params are missing or malformed.
+
+6. Health and observability
+   - Verify health endpoint behavior.
+   - Add or improve lightweight request logging if already part of the stack.
+   - If Sentry is already installed/configured, verify backend error capture is wired safely.
+   - If Sentry is not installed, do not force a major integration unless there is already an issue for it. Document the needed env vars and setup instead.
+
+7. Vendor onboarding and verification
+   - Verify approval/rejection email flow still works.
+   - Confirm failed verification or under-review statuses do not expose unapproved vendor listings publicly.
+   - Ensure vendor listings are hidden when status requires review.
+   - Do not implement external BusinessScreen/API verification unless already contracted and clearly present in code.
+   - Manual review is acceptable for MVP.
+
+8. Security/safety checks
+   - Check CORS allowed origins.
+   - Check auth guards on admin/vendor routes.
+   - Check public endpoints do not expose private vendor/customer data.
+   - Check file upload validation if present.
+   - Do not commit .env files.
+
+PHASE 3 — Tests and Proof
+
+Run the available test suite and build/lint commands.
+
+Try, in order, based on what exists in package scripts:
+
+- npm install or npm ci only if needed
+- npm run lint
+- npm test
+- npm run test
+- npm run build
+- npm run typecheck
+- any existing smoke scripts
+
+If a command does not exist, document that clearly.
+
+Add or update tests for any changed logic:
+- DTO/serializer tests
+- public endpoint tests
+- pagination/filter tests
+- status/visibility tests
+- error handling tests
+
+Create or update:
+
+docs/BACKEND_STABILITY_PROOF.md
+
+Include:
+- branch name
+- files changed
+- tests run
+- test results
+- endpoints manually checked
+- remaining risks
+- exact commands used
+- any migrations added
+- any env vars required
+- anything intentionally deferred
+
+PHASE 4 — Roadmap Issues
+
+Create a markdown issue plan in:
+
+docs/BACKEND_ROADMAP_ISSUES.md
+
+Group remaining work into GitHub-ready issues.
+
+Use these categories:
+
+1. Launch blockers
+2. High-priority post-launch
+3. Performance/loading improvements
+4. Vendor/admin workflow improvements
+5. Marketplace/search improvements
+6. Observability/monitoring
+7. Future scope/change requests
+
+For each issue include:
+- Title
+- Problem
+- User/business impact
+- Scope
+- Out of scope
+- Acceptance criteria
+- Testing notes
+- Risk level
+
+Do not overbuild. Separate real MVP defects from future roadmap ideas.
+
+PHASE 5 — Final Output
+
+Before stopping, provide a final summary with:
+
+1. What you found
+2. What you fixed
+3. What you did not fix and why
+4. Test results
+5. Any migrations/env changes
+6. Exact next recommended GitHub issues
+7. Whether this branch is safe to open as a PR
+
+Commit changes only if tests pass or if failures are clearly pre-existing and documented.
+
+Suggested commit message:
+chore: stabilize backend roadmap readiness
+```
+
+---
+
+## Fix now vs verify vs defer
+
+| Lane | Examples |
+| --- | --- |
+| **Fix now** | API speed, public listing safety, pagination caps, response consistency, hidden/unapproved vendor visibility, CORS, health checks, failed email paths, test proof |
+| **Verify now** | Stripe checkout/order flow, vendor plan/tier permissions, admin approval/rejection flows, public marketplace filters |
+| **Defer** | BusinessScreen automation, advanced geolocation, full reviews system, AI chatbot, advanced analytics, referral rewards, Diamond automation, community events, predictive dashboards |

--- a/docs/BACKEND_STABILITY_PROOF.md
+++ b/docs/BACKEND_STABILITY_PROOF.md
@@ -1,0 +1,140 @@
+# Backend Stability Proof Pack
+
+**Branch:** `sprint/backend-stability-roadmap-cleanup`  
+**Date:** 2026-06-18  
+**Production API checked:** `https://api.mosaicbizhub.com` (pre-deploy baseline SHA `7d01011`)
+
+---
+
+## Files changed
+
+| File | Change |
+| --- | --- |
+| [controllers/featuredProducts.controller.js](../controllers/featuredProducts.controller.js) | Active-business filter, pagination clamp, empty-state handling |
+| [controllers/publicListing.js](../controllers/publicListing.js) | Search default business scope, list pagination caps |
+| [controllers/productListingController.js](../controllers/productListingController.js) | Ranked `isPublished: true` filter |
+| [models/Product.js](../models/Product.js) | Compound indexes for public listing queries |
+| [app.js](../app.js) | Mount `mongo-sanitize` and `xss-clean` after JSON parser |
+| [tests/marketplace/featured-products-response.test.js](../tests/marketplace/featured-products-response.test.js) | Visibility + limit cap tests |
+| [tests/marketplace/public-search-filters.test.js](../tests/marketplace/public-search-filters.test.js) | Default business scope test |
+| [tests/marketplace/ranked-products-visibility.test.js](../tests/marketplace/ranked-products-visibility.test.js) | New ranked visibility test |
+| [docs/BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) | Reusable stabilization prompt |
+| [docs/BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md) | Audit snapshot |
+| [docs/BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Prioritized issue plan |
+| [docs/AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) | Link to agent prompt; test count update |
+| [docs/README.md](README.md) | Index links for new docs |
+
+---
+
+## Commands run
+
+| Command | Result |
+| --- | --- |
+| `npm test` | **178/178 pass** |
+| `npm run lint` | **Not defined** in package.json |
+| `npm run build` | **Not defined** in package.json |
+| `npm run typecheck` | **Not defined** in package.json |
+| `node scripts/verify-auth-check-smoke.js` | **Skipped** (requires live credentials; not required for this sprint) |
+
+Exact test command:
+
+```powershell
+npm test
+```
+
+---
+
+## Test results summary
+
+- **Before sprint:** 173 tests on `main`
+- **After sprint:** **178 tests** (+5 new marketplace tests)
+- **Failures:** None
+- **Pre-existing failures:** None introduced
+
+New tests cover:
+
+- Featured products active-business query scope
+- Featured products empty state when no active businesses
+- Featured products limit cap at 50
+- Public search default active-business scope
+- Ranked products require `isPublished: true`
+
+---
+
+## Manual endpoint checks (production, read-only GET)
+
+Checked against live API **before** this branch is deployed (baseline behavior; fixes apply after EB deploy).
+
+| Endpoint | HTTP status |
+| --- | --- |
+| `GET /` | 200 |
+| `GET /api/featured-products?page=1&limit=12` | 200 |
+| `GET /api/products/list?page=1&limit=10` | 200 |
+| `GET /api/public/search?keyword=test` | 200 |
+| `GET /api/ranked?page=1&pageSize=24` | 200 |
+| `GET /api/categories` | 200 |
+
+---
+
+## Database indexes added
+
+Added to [models/Product.js](../models/Product.js) (Mongoose schema):
+
+```javascript
+productSchema.index({ isFeatured: 1, isPublished: 1, isDeleted: 1, createdAt: -1 });
+productSchema.index({ businessId: 1, isPublished: 1, isDeleted: 1 });
+productSchema.index({ isPublished: 1, isDeleted: 1, createdAt: -1 });
+```
+
+**Note:** Mongoose builds indexes on connect when `autoIndex` is enabled (default in dev). Production Atlas may require a one-time index build after deploy. No SQL migration files — MongoDB/Mongoose only.
+
+---
+
+## Security middleware
+
+- `express-mongo-sanitize` and `xss-clean` mounted in [app.js](../app.js) **after** `express.json()` and **after** Stripe webhook raw-body routes (webhook signature verification unchanged).
+
+---
+
+## Environment variables (no values)
+
+No new env vars required for this sprint. Related observability vars (unchanged, for reference):
+
+| Variable | Purpose |
+| --- | --- |
+| `SENTRY_DSN` | Enable Sentry (#18 — on `main`, EB deploy pending) |
+| `SENTRY_ENABLED` | Opt-out toggle |
+| `MAIL_USER` / `MAIL_PASSWORD` | Vendor email delivery |
+| `MONGODB_URI` | Database connection |
+
+---
+
+## Intentionally deferred
+
+| Item | Reason | Tracked |
+| --- | --- | --- |
+| #41 payment route hardening | Out of scope; separate security PR | #41 |
+| #43 order email timing | Verify only; no checkout changes | #43 |
+| Global error response pass | Large refactor | #46 |
+| DTO consolidation | Large refactor | #45 |
+| Service/Food model indexes | Lower traffic than products in audit | #53 |
+| `getVisibleBusinessIds()` caching | Performance follow-up | #44 |
+| Dedicated `/api/health` | Separate issue | #69 |
+| Sentry prod verification | Requires EB deploy of #18 | #18 |
+
+---
+
+## Remaining risks after merge
+
+1. Fixes are **not live** until EB deploy from `main`
+2. Index build on production MongoDB should be confirmed post-deploy
+3. #41 unauthenticated payment routes remain until separate PR
+4. Full tiered smoke (#27) still needs `SMOKE_TEST_*` accounts
+
+---
+
+## Related docs
+
+- [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md)
+- [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md)
+- [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md)

--- a/docs/BACKEND_STABILITY_ROADMAP_AUDIT.md
+++ b/docs/BACKEND_STABILITY_ROADMAP_AUDIT.md
@@ -1,0 +1,146 @@
+# Backend Stability Roadmap Audit
+
+**Branch:** `sprint/backend-stability-roadmap-cleanup`  
+**Date:** 2026-06-18  
+**Production API:** `https://api.mosaicbizhub.com` (deploy SHA `7d01011`)  
+**`main` HEAD:** `a03305a` (Sentry #18 merged; EB deploy pending)
+
+This document synthesizes the MVP doc set, open GitHub issues, and a targeted code scan. For live sprint state, see [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md).
+
+---
+
+## What exists
+
+| Area | Status | Reference |
+| --- | --- | --- |
+| Full marketplace REST API | Implemented | [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) |
+| Public listing DTO contract | Merged (#28) | [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md) |
+| Canonical featured route | `GET /api/featured-products` | [routes/featuredProductRoutes.js](../routes/featuredProductRoutes.js) |
+| Search/filter (ZIP exact, no radius) | Merged (#29) | [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) |
+| Vendor onboarding + emails | Merged (#30) | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) |
+| Vendor self-service APIs | Merged (#31) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
+| Stripe Connect runtime | Merged (#32, #42) | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
+| Email notification audit | Merged (#33) | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
+| Automated tests | 173 tests (`npm test`) | [TEST_MATRIX.md](TEST_MATRIX.md) |
+| Agent guardrails | Documented | [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md), [LLM_CONTEXT.md](LLM_CONTEXT.md) |
+| Sentry SDK | On `main`, not prod-verified | [instrument.js](../instrument.js), issue #18 |
+
+---
+
+## What is working
+
+- **Browse/auth/CORS smoke (Tier A–D):** PASS on commit `7201f97` — [MVP_BACKEND_SMOKE_PROOF_PACK.md](MVP_BACKEND_SMOKE_PROOF_PACK.md)
+- **Public list endpoints** scope to `Business.isActive: true` via `getVisibleBusinessIds()` in [controllers/publicListing.js](../controllers/publicListing.js)
+- **Listing DTOs** normalize card/detail fields via [lib/listing/publicListingDto.js](../lib/listing/publicListingDto.js)
+- **Vendor approve/reject emails** wired with tests in `tests/admin/vendor-onboarding-finalize.test.js`
+- **Checkout guards** block unapproved vendors at payment time (#42)
+- **Search pagination cap** at 50 in [lib/listing/publicSearchFilters.js](../lib/listing/publicSearchFilters.js)
+- **Ranked pagination cap** at 60 in [controllers/productListingController.js](../controllers/productListingController.js)
+- **Health probe:** `GET /` returns 200 JSON (P0.1 in smoke checklist)
+- **CORS allowlist** includes launch frontend `https://mosaic-biz-frontend-launch.vercel.app`
+
+---
+
+## What is fragile (addressed in this sprint)
+
+| Issue | Risk | Fix in this branch |
+| --- | --- | --- |
+| Featured products omit inactive-business filter | Inactive vendor featured items may appear | Add `businessId: { $in: activeIds }` in featured controller |
+| Public search with no filters skips business scope | Unscoped listings when no location/tag/verified params | Default `allowedBusinessIds` to `getVisibleBusinessIds()` |
+| Ranked simple path omits `isPublished` | Unpublished products in ranked feed | Add `isPublished: true` to find/count and aggregation |
+| Featured/list limits uncapped | Large payloads, slow responses | Cap `limit` at 50 on featured and list handlers |
+| Product model lacks compound indexes | Slow featured/list queries at scale | Add Mongoose indexes on hot filter fields |
+| `mongo-sanitize` / `xss-clean` imported but not mounted | Input sanitization gap | Mount after `express.json()` (webhooks stay raw) |
+
+---
+
+## What is missing or incomplete
+
+| Gap | Impact | Tracked |
+| --- | --- | --- |
+| Full P0–P6 prod smoke | Launch sign-off incomplete | #27, [production-smoke-checklist.md](production-smoke-checklist.md) |
+| `SMOKE_TEST_*` prod accounts | Checkout/vendor tier smoke SKIP | [deploy-verification.md](deploy-verification.md) |
+| Payment route auth on legacy `/stripe/*` | Security exposure | #41 |
+| Order email timing before payment confirm | Wrong email timing | #43 |
+| Live SMTP inbox proof on prod | Email delivery unverified | #33 docs |
+| Admin aggregation APIs | Admin dashboard gaps | #34 |
+| Reviews API/tests | Reviews not MVP-complete | #35 |
+| Sentry on production EB | Observability gap | #18 (deploy pending) |
+| Dedicated `/api/health` | Minimal diagnostics | #69 |
+| OpenAPI / contract docs | No machine-readable API spec | #55 |
+| Geolocation / ZIP-radius search | ZIP exact only (by design) | [DECISION_REGISTER.md](DECISION_REGISTER.md) |
+| BusinessScreen API verification | Manual review for MVP | Deferred |
+
+---
+
+## Fix now (this sprint)
+
+1. Public visibility consistency (featured, search default scope, ranked `isPublished`)
+2. Pagination max guards on featured and list endpoints
+3. Product compound indexes (Mongoose schema)
+4. Mount security sanitization middleware
+5. Tests + proof docs for all of the above
+
+---
+
+## Verify now (document only — no blind rewrites)
+
+| Area | Action | Reference |
+| --- | --- | --- |
+| Stripe checkout / Connect / webhooks | Confirm runtime docs match code; no code changes | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
+| Vendor approve/reject flow | Rely on existing unit tests | `tests/admin/vendor-onboarding-finalize.test.js` |
+| CORS | Already smoke-verified | Smoke Tier D |
+| Sentry wiring | Code review + env var checklist; prod deploy separate | `.env.example`, #18 |
+| Public browse vs `isApproved` | Browse gates on `isActive`; checkout gates on `isApproved` — intentional | [utils/checkoutGuards.js](../utils/checkoutGuards.js) |
+
+---
+
+## Defer / change request
+
+| Item | Status | Issue |
+| --- | --- | --- |
+| Payment route hardening | Separate security PR | #41 |
+| Order email idempotency | Post-launch hardening | #43 |
+| Full error response normalization | Large pass | #46 |
+| DTO consolidation | Large pass | #45 |
+| Controller/service refactor | Future | #52 |
+| BusinessScreen automation | Change request / future phase | DECISION_REGISTER |
+| Geolocation radius | Deferred | #29, DECISION_REGISTER |
+| Reviews system | Not started | #35 |
+| OpenAPI generation | Docs-only future | #55 |
+| Dead route cleanup | Audit first | #60 |
+
+---
+
+## Risks before production testing
+
+1. **Production is first integrated environment** — no hosted staging ([hosted-staging-decision.md](hosted-staging-decision.md))
+2. **Prod SHA lags `main`** — Sentry and this sprint’s fixes not live until EB deploy
+3. **Unauthenticated payment/stripe routes** (#41) — P0 security follow-up
+4. **Partial smoke evidence** — browse PASS; checkout/email tiers need test accounts
+5. **Empty featured feed in prod DB** — route healthy; frontend must handle empty array
+6. **`getVisibleBusinessIds()` per request** — acceptable for MVP; cache later (#44)
+
+---
+
+## Open GitHub issues map (sample)
+
+| Priority | Issues |
+| --- | --- |
+| Launch blockers | #41, #43, #27, #69 |
+| Post-launch high | #34, #65, #66 |
+| Performance | #44, #53, #54 |
+| Vendor/admin | #76, #67, #77 |
+| Marketplace | #72, #45 |
+| Observability | #18, #58, #63 |
+| Future | #55, #52, #35, BusinessScreen, geolocation |
+
+Full issue plan: [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md)
+
+---
+
+## Related documentation
+
+- [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md) — test and manual verification evidence
+- [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) — reusable agent prompt
+- [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) — canonical sprint hub

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 | If you are… | Read in this order |
 | --- | --- |
-| **LLM / AI agent** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [LLM_CONTEXT.md](LLM_CONTEXT.md) → [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) → [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) → [API_SURFACE.md](API_SURFACE.md) |
+| **LLM / AI agent** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [LLM_CONTEXT.md](LLM_CONTEXT.md) → [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) → [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) → [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) → [API_SURFACE.md](API_SURFACE.md) |
 | **New backend developer** | [ARCHITECTURE.md](ARCHITECTURE.md) → [SETUP.md](../SETUP.md) → [AUTH_FLOW.md](AUTH_FLOW.md) → [API_SURFACE.md](API_SURFACE.md) |
 | **QA / smoke tester** | [production-smoke-checklist.md](production-smoke-checklist.md) → [TEST_MATRIX.md](TEST_MATRIX.md) → [API_SURFACE.md](API_SURFACE.md) |
 | **Release / deploy owner** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) → [DEPLOYMENT.md](../DEPLOYMENT.md) → [production-proof-pack-template.md](production-proof-pack-template.md) |
@@ -47,6 +47,10 @@ Canonical deep-dives. Prefer these over duplicating detail in chat or new docs.
 | [LLM_CONTEXT.md](LLM_CONTEXT.md) | Safe-edit rules, env names, issue map, and fast navigation for AI assistants |
 | [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) | Route → controller → model ownership, boundaries, and no-touch zones (issue #50) |
 | [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) | Branch/PR guardrails, before-coding and before-PR checklists for agents |
+| [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) | Controlled stabilization sprint prompt for Cursor/OpenClaw |
+| [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md) | Stability audit snapshot (working / fragile / deferred) |
+| [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md) | Test and manual verification evidence for stability sprint |
+| [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Prioritized GitHub-ready issue backlog by lane |
 | [API_SURFACE.md](API_SURFACE.md) | Full HTTP route map, middleware, auth/role boundaries, smoke and risk notes |
 | [AUTH_FLOW.md](AUTH_FLOW.md) | Login, register, OTP, password reset, JWT, Google OAuth, rate limits |
 | [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding states, admin review, payments, uploads, resubmit |
@@ -179,4 +183,6 @@ Follow these when changing code **or** docs.
 - [API surface map](API_SURFACE.md)
 - [Decision register](DECISION_REGISTER.md)
 - [Proof-pack template](production-proof-pack-template.md)
+- [Backend stability audit](BACKEND_STABILITY_ROADMAP_AUDIT.md)
+- [Backend roadmap issues](BACKEND_ROADMAP_ISSUES.md)
 - [Deployment docs](../DEPLOYMENT.md) · [Staging](../STAGING.md) · [Setup](../SETUP.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,8 @@ Canonical deep-dives. Prefer these over duplicating detail in chat or new docs.
 | [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md) | Stability audit snapshot (working / fragile / deferred) |
 | [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md) | Test and manual verification evidence for stability sprint |
 | [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Prioritized GitHub-ready issue backlog by lane |
+| [BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md) | Batch 2 audit — payment auth, email timing, health (#41/#43/#69) |
+| [BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md) | Batch 2 test and smoke proof |
 | [API_SURFACE.md](API_SURFACE.md) | Full HTTP route map, middleware, auth/role boundaries, smoke and risk notes |
 | [AUTH_FLOW.md](AUTH_FLOW.md) | Login, register, OTP, password reset, JWT, Google OAuth, rate limits |
 | [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding states, admin review, payments, uploads, resubmit |
@@ -185,4 +187,5 @@ Follow these when changing code **or** docs.
 - [Proof-pack template](production-proof-pack-template.md)
 - [Backend stability audit](BACKEND_STABILITY_ROADMAP_AUDIT.md)
 - [Backend roadmap issues](BACKEND_ROADMAP_ISSUES.md)
+- [Launch blockers batch 2 audit](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md)
 - [Deployment docs](../DEPLOYMENT.md) · [Staging](../STAGING.md) · [Setup](../SETUP.md)

--- a/models/Order.js
+++ b/models/Order.js
@@ -173,6 +173,10 @@ const orderSchema = new Schema(
       type: String, // Stripe PaymentIntent ID
       required: false,
     },
+    paidConfirmationEmailSentAt: {
+      type: Date,
+      default: null,
+    },
     stripeCustomerId: {
       type: String, // Optional: if using Stripe Customer objects
     },

--- a/models/Product.js
+++ b/models/Product.js
@@ -139,6 +139,10 @@ const productSchema = new mongoose.Schema({
 
 }, { timestamps: true });
 
+productSchema.index({ isFeatured: 1, isPublished: 1, isDeleted: 1, createdAt: -1 });
+productSchema.index({ businessId: 1, isPublished: 1, isDeleted: 1 });
+productSchema.index({ isPublished: 1, isDeleted: 1, createdAt: -1 });
+
 productSchema.pre('save', async function (next) {
   if (!this.slug && this.title) {
     let baseSlug = slugify(this.title, { lower: true, strict: true });

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const mongoose = require('mongoose');
+
+const router = express.Router();
+const SERVICE_NAME = 'mosaic-backend';
+
+router.get('/health', (_req, res) => {
+  res.status(200).json({
+    status: 'ok',
+    service: SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+  });
+});
+
+router.get('/ready', (_req, res) => {
+  const connected = mongoose.connection.readyState === 1;
+
+  res.status(connected ? 200 : 503).json({
+    status: connected ? 'ready' : 'not_ready',
+    database: connected ? 'connected' : 'disconnected',
+    timestamp: new Date().toISOString(),
+  });
+});
+
+module.exports = router;

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -10,7 +10,7 @@ const { getInvoicePdf } = require('../controllers/invoiceController');
 
 
 
-router.post('/initiate', authenticate, initiateOrder);
+router.post('/initiate', authenticate, isCustomer, initiateOrder);
 router.get('/retrieve-intent/:id', authenticate, retrieveIntent);
 router.get('/user', authenticate, getUserOrders);
 router.get('/:id/invoice.pdf', authenticate, getInvoicePdf);

--- a/routes/paymentRoutes.js
+++ b/routes/paymentRoutes.js
@@ -2,6 +2,8 @@ const express = require('express');
 const rateLimit = require('express-rate-limit');
 const { createPaymentIntent } = require('../controllers/paymentController');
 const { body } = require('express-validator');
+const authenticate = require('../middlewares/authenticate');
+const isCustomer = require('../middlewares/isCustomer');
 
 
 const paymentRouter = express.Router();
@@ -15,6 +17,8 @@ const paymentLimiter = rateLimit({
 
 paymentRouter.post(
   '/create-payment-intent',
+  authenticate,
+  isCustomer,
   paymentLimiter,
   [
     body('orderId').isMongoId().withMessage('Invalid Order ID format'),

--- a/routes/stripe.routes.js
+++ b/routes/stripe.routes.js
@@ -1,15 +1,24 @@
 const express = require('express');
 const router = express.Router();
-const { createAccountSession, createExpressLoginLink, getAccountBalance, getLastPayout, backfillMissingStripeCustomers } = require('../controllers/stripe.controller');
+const authenticate = require('../middlewares/authenticate');
+const isBusinessOwner = require('../middlewares/isBusinessOwner');
+const isAdmin = require('../middlewares/isAdmin');
+const {
+  createAccountSession,
+  createExpressLoginLink,
+  getAccountBalance,
+  getLastPayout,
+  backfillMissingStripeCustomers,
+} = require('../controllers/stripe.controller');
 
 // POST /stripe/account-session
-router.post('/account-session', createAccountSession);
-router.post('/express-login-link', createExpressLoginLink);
+router.post('/account-session', authenticate, isBusinessOwner, createAccountSession);
+router.post('/express-login-link', authenticate, isBusinessOwner, createExpressLoginLink);
 
-router.get('/account-balance', getAccountBalance);
-router.get('/last-payout', getLastPayout);
+router.get('/account-balance', authenticate, isBusinessOwner, getAccountBalance);
+router.get('/last-payout', authenticate, isBusinessOwner, getLastPayout);
 
-router.post('/backfill-customers', backfillMissingStripeCustomers);
+router.post('/backfill-customers', authenticate, isAdmin, backfillMissingStripeCustomers);
 
 
 

--- a/tests/health/health-readiness.test.js
+++ b/tests/health/health-readiness.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const healthRoutesPath = path.resolve(__dirname, '../../routes/healthRoutes.js');
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function loadHealthRouter(mongooseMock) {
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'mongoose') return mongooseMock;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[healthRoutesPath];
+  const router = require(healthRoutesPath);
+  Module._load = originalLoad;
+  return router;
+}
+
+function getRouteHandler(router, method, routePath) {
+  const layer = router.stack.find(
+    (entry) => entry.route && entry.route.path === routePath && entry.route.methods[method]
+  );
+  assert.ok(layer, `missing ${method.toUpperCase()} ${routePath}`);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+test('GET /health returns ok without database dependency', () => {
+  const router = loadHealthRouter({ connection: { readyState: 0 } });
+  const handler = getRouteHandler(router, 'get', '/health');
+  const res = mockResponse();
+
+  handler({}, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.status, 'ok');
+  assert.equal(res.body.service, 'mosaic-backend');
+  assert.ok(typeof res.body.uptime === 'number');
+  assert.ok(res.body.timestamp);
+});
+
+test('GET /ready returns 200 when database is connected', async () => {
+  const router = loadHealthRouter({ connection: { readyState: 1 } });
+  const handler = getRouteHandler(router, 'get', '/ready');
+  const res = mockResponse();
+
+  await handler({}, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.status, 'ready');
+  assert.equal(res.body.database, 'connected');
+});
+
+test('GET /ready returns 503 when database is disconnected', async () => {
+  const router = loadHealthRouter({ connection: { readyState: 0 } });
+  const handler = getRouteHandler(router, 'get', '/ready');
+  const res = mockResponse();
+
+  await handler({}, res);
+
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.body.status, 'not_ready');
+  assert.equal(res.body.database, 'disconnected');
+  assert.ok(!JSON.stringify(res.body).includes('mongodb'));
+});
+
+test('healthRoutes source does not expose secrets', () => {
+  const source = fs.readFileSync(healthRoutesPath, 'utf8');
+  assert.ok(!source.includes('process.env.MONGODB_URI'));
+  assert.ok(!source.includes('JWT_SECRET'));
+});

--- a/tests/marketplace/featured-products-response.test.js
+++ b/tests/marketplace/featured-products-response.test.js
@@ -23,7 +23,13 @@ function mockResponse() {
   };
 }
 
-function loadController(mockProduct, total = 1) {
+function loadController(mockProduct, total = 1, options = {}) {
+  const {
+    visibleBusinessIds = ['507f1f77bcf86cd799439014'],
+    capturedFindQuery = { value: null },
+    capturedLimit = { value: null },
+  } = options;
+
   const chain = {
     populate() {
       return chain;
@@ -37,25 +43,38 @@ function loadController(mockProduct, total = 1) {
     skip() {
       return chain;
     },
-    limit() {
+    limit(value) {
+      capturedLimit.value = value;
       return Promise.resolve([mockProduct]);
     },
   };
 
   const Product = {
-    find: () => chain,
+    find: (query) => {
+      capturedFindQuery.value = query;
+      return chain;
+    },
     countDocuments: async () => total,
+  };
+
+  const Business = {
+    find: () => ({
+      select: () => ({
+        lean: async () => visibleBusinessIds.map((id) => ({ _id: id })),
+      }),
+    }),
   };
 
   const originalLoad = Module._load;
   Module._load = function mockLoad(request, parent, isMain) {
     if (request === '../models/Product') return Product;
+    if (request === '../models/Business') return Business;
     return originalLoad.call(this, request, parent, isMain);
   };
   delete require.cache[controllerPath];
   const loaded = require(controllerPath);
   Module._load = originalLoad;
-  return loaded;
+  return { controller: loaded, capturedFindQuery, capturedLimit };
 }
 
 test('getFeaturedProducts maps products through toPublicListingCard', async () => {
@@ -75,7 +94,7 @@ test('getFeaturedProducts maps products through toPublicListingCard', async () =
     },
   };
 
-  const controller = loadController(mockProduct);
+  const { controller } = loadController(mockProduct);
   const res = mockResponse();
 
   await controller.getFeaturedProducts({ query: { page: 1, limit: 12 } }, res);
@@ -106,7 +125,7 @@ test('getFeaturedProducts preserves products and pagination wrapper', async () =
     },
   };
 
-  const controller = loadController(mockProduct, 5);
+  const { controller } = loadController(mockProduct, 5);
   const res = mockResponse();
 
   await controller.getFeaturedProducts({ query: { page: 2, limit: 2 } }, res);
@@ -119,4 +138,50 @@ test('getFeaturedProducts preserves products and pagination wrapper', async () =
   assert.equal(res.body.pagination.totalPages, 3);
   assert.equal(res.body.products[0].price, null);
   assert.equal(res.body.products[0].priceLabel, 'Contact for price');
+});
+
+test('getFeaturedProducts scopes query to active businesses', async () => {
+  const mockProduct = {
+    toObject() {
+      return { _id: '507f1f77bcf86cd799439011', title: 'Featured' };
+    },
+  };
+  const activeBusinessId = '507f1f77bcf86cd799439014';
+  const { controller, capturedFindQuery } = loadController(mockProduct, 1, {
+    visibleBusinessIds: [activeBusinessId],
+  });
+  const res = mockResponse();
+
+  await controller.getFeaturedProducts({ query: { page: 1, limit: 12 } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.ok(capturedFindQuery.value);
+  assert.equal(capturedFindQuery.value.isFeatured, true);
+  assert.equal(capturedFindQuery.value.isPublished, true);
+  assert.deepEqual(capturedFindQuery.value.businessId.$in, [activeBusinessId]);
+});
+
+test('getFeaturedProducts returns empty list when no active businesses', async () => {
+  const { controller } = loadController(null, 0, { visibleBusinessIds: [] });
+  const res = mockResponse();
+
+  await controller.getFeaturedProducts({ query: { page: 1, limit: 12 } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.products, []);
+  assert.equal(res.body.pagination.totalProducts, 0);
+});
+
+test('getFeaturedProducts caps limit at 50', async () => {
+  const mockProduct = {
+    toObject() {
+      return { _id: '507f1f77bcf86cd799439011', title: 'Featured' };
+    },
+  };
+  const { controller, capturedLimit } = loadController(mockProduct, 1);
+  const res = mockResponse();
+
+  await controller.getFeaturedProducts({ query: { page: 1, limit: 500 } }, res);
+
+  assert.equal(capturedLimit.value, 50);
 });

--- a/tests/marketplace/public-search-filters.test.js
+++ b/tests/marketplace/public-search-filters.test.js
@@ -323,3 +323,51 @@ test('searchPublicListings preserves backward compatible response shape', async 
   assert.ok(Array.isArray(res.body.data.services));
   assert.ok(Array.isArray(res.body.data.foods));
 });
+
+test('searchPublicListings defaults to active business scope when no filters', async () => {
+  const activeBusinessId = '507f1f77bcf86cd799439011';
+  let productFindFilter = null;
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).includes('models/Product')) {
+      return {
+        find: (filter) => {
+          productFindFilter = filter;
+          return buildFindChain([]);
+        },
+      };
+    }
+    if (String(request).includes('models/Service')) return { find: () => buildFindChain([]) };
+    if (String(request).includes('models/Food')) return { find: () => buildFindChain([]) };
+    if (String(request).includes('models/Business')) {
+      return wrapModelFind({
+        find: async (filter) => {
+          if (filter?.isActive === true) {
+            return [{ _id: activeBusinessId }];
+          }
+          return [];
+        },
+      });
+    }
+    if (String(request).includes('models/VendorOnboardingStage1')) {
+      return wrapModelFind({ find: async () => [] });
+    }
+    if (String(request).includes('models/MinorityType')) return { find: async () => [] };
+    if (String(request).includes('models/ProductCategory')) return { findOne: async () => null };
+    if (String(request).includes('models/ServiceCategory')) return { findOne: async () => null };
+    if (String(request).includes('models/FoodCategory')) return { findOne: async () => null };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[controllerPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+
+  const res = mockResponse();
+  await controller.searchPublicListings({ query: {} }, res);
+
+  assert.equal(res.body.success, true);
+  assert.ok(productFindFilter);
+  assert.equal(productFindFilter.isPublished, true);
+  assert.deepEqual(productFindFilter.businessId.$in, [activeBusinessId]);
+});

--- a/tests/marketplace/ranked-products-visibility.test.js
+++ b/tests/marketplace/ranked-products-visibility.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/productListingController.js'
+);
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function loadRankedController(options = {}) {
+  const {
+    visibleBusinessIds = ['507f1f77bcf86cd799439014'],
+    capturedFindQuery = { value: null },
+  } = options;
+
+  const chain = {
+    populate() {
+      return chain;
+    },
+    sort() {
+      return chain;
+    },
+    skip() {
+      return chain;
+    },
+    limit() {
+      return Promise.resolve([]);
+    },
+  };
+
+  const Product = {
+    find: (query) => {
+      capturedFindQuery.value = query;
+      return chain;
+    },
+    countDocuments: async (query) => {
+      capturedFindQuery.value = query;
+      return 0;
+    },
+    aggregate: async () => [],
+  };
+
+  const Business = {
+    find: () => ({
+      select: () => ({
+        lean: async () => visibleBusinessIds.map((id) => ({ _id: id })),
+      }),
+    }),
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Product') return Product;
+    if (request === '../models/Business') return Business;
+    if (request === '../models/ProductCategory') return {};
+    if (request === '../models/ProductSubcategory') return {};
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  delete require.cache[controllerPath];
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+  return { controller: loaded, capturedFindQuery };
+}
+
+test('listProductsRanked requires published products on simple path', async () => {
+  const { controller, capturedFindQuery } = loadRankedController();
+  const res = mockResponse();
+
+  await controller.listProductsRanked({ query: { page: 1, pageSize: 24 } }, res);
+
+  assert.ok(capturedFindQuery.value);
+  assert.equal(capturedFindQuery.value.isDeleted, false);
+  assert.equal(capturedFindQuery.value.isPublished, true);
+  assert.ok(Array.isArray(capturedFindQuery.value.businessId.$in));
+});

--- a/tests/stripe/order-email-safety.test.js
+++ b/tests/stripe/order-email-safety.test.js
@@ -38,13 +38,14 @@ function createStripeModule(stripeMock) {
   };
 }
 
-function buildOrderForPostPayment() {
+function buildOrderForPostPayment(overrides = {}) {
   return {
     _id: ORDER_ID,
     paymentId: PAYMENT_ID,
     paymentStatus: 'pending',
     status: 'created',
     statusHistory: [{ status: 'created' }],
+    paidConfirmationEmailSentAt: null,
     items: [{ chargeId: null, transferId: null, applicationFeeId: null }],
     userId: { email: 'customer@example.com' },
     vendorId: { email: 'vendor@example.com' },
@@ -56,6 +57,7 @@ function buildOrderForPostPayment() {
     save: async function save() {
       return this;
     },
+    ...overrides,
   };
 }
 
@@ -134,6 +136,7 @@ test('post-payment webhook calls sendOrderPaidEmails on success', async () => {
 
   assert.ok(res.body.received);
   assert.equal(getEmailSendCount(), 1);
+  assert.ok(order.paidConfirmationEmailSentAt instanceof Date);
 });
 
 test('post-payment webhook still returns received when email send fails', async () => {
@@ -165,16 +168,29 @@ test('post-payment webhook still returns received when email send fails', async 
   assert.ok(!errorLogs.some((line) => line.includes('whsec_')));
 });
 
-test('initiateOrder catches pre-payment email failures without rethrowing', () => {
-  const source = fs.readFileSync(orderControllerPath, 'utf8');
-  const initiateBlock = source.slice(
-    source.indexOf('// 📧 EMAILS (CUSTOMER + VENDOR)'),
-    source.indexOf('return res.status(201).json({', source.indexOf('// 📧 EMAILS (CUSTOMER + VENDOR)'))
+test('post-payment webhook skips duplicate paid confirmation emails', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment({
+    paidConfirmationEmailSentAt: new Date('2026-06-18T00:00:00.000Z'),
+  });
+  const { stripePaymentWebhook, getEmailSendCount } = loadPostPaymentWebhook({ orders: [order] });
+  const res = mockResponse();
+
+  await stripePaymentWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
   );
 
-  assert.ok(initiateBlock.includes('try {'));
-  assert.ok(initiateBlock.includes('sendCustomerOrderPlacedEmail'));
-  assert.ok(initiateBlock.includes('sendVendorNewOrderEmail'));
-  assert.ok(initiateBlock.includes('catch (err)'));
-  assert.ok(initiateBlock.includes('err?.message'));
+  assert.ok(res.body.received);
+  assert.equal(getEmailSendCount(), 0);
+});
+
+test('initiateOrder no longer sends pre-payment customer or vendor emails', () => {
+  const source = fs.readFileSync(orderControllerPath, 'utf8');
+
+  assert.ok(!source.includes('sendCustomerOrderPlacedEmail'));
+  assert.ok(!source.includes('sendVendorNewOrderEmail'));
 });

--- a/tests/stripe/payment-route-protection.test.js
+++ b/tests/stripe/payment-route-protection.test.js
@@ -1,0 +1,137 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const paymentRoutesPath = path.resolve(__dirname, '../../routes/paymentRoutes.js');
+const stripeRoutesPath = path.resolve(__dirname, '../../routes/stripe.routes.js');
+const orderRoutesPath = path.resolve(__dirname, '../../routes/orderRoutes.js');
+const paymentControllerPath = path.resolve(__dirname, '../../controllers/paymentController.js');
+const ownershipPath = path.resolve(__dirname, '../../utils/stripeConnectOwnership.js');
+const authenticatePath = path.resolve(__dirname, '../../middlewares/authenticate.js');
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('paymentRoutes wires authenticate and isCustomer before create-payment-intent', () => {
+  const source = fs.readFileSync(paymentRoutesPath, 'utf8');
+  const routeBlock = source.slice(source.indexOf("'/create-payment-intent'"));
+
+  assert.ok(routeBlock.includes('authenticate'));
+  assert.ok(routeBlock.includes('isCustomer'));
+  assert.ok(routeBlock.indexOf('authenticate') < routeBlock.indexOf('createPaymentIntent'));
+});
+
+test('stripe.routes wires auth middleware on Connect helper routes', () => {
+  const source = fs.readFileSync(stripeRoutesPath, 'utf8');
+
+  assert.match(source, /router\.post\('\/account-session', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.post\('\/express-login-link', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/account-balance', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/last-payout', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.post\('\/backfill-customers', authenticate, isAdmin/);
+});
+
+test('orderRoutes requires customer role for initiate checkout', () => {
+  const source = fs.readFileSync(orderRoutesPath, 'utf8');
+  assert.match(source, /router\.post\('\/initiate', authenticate, isCustomer, initiateOrder\)/);
+});
+
+test('authenticate rejects unauthenticated payment route access', async () => {
+  const authenticate = require(authenticatePath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await authenticate({ headers: {}, cookies: {} }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 401);
+});
+
+test('createPaymentIntent rejects orders owned by another customer', async () => {
+  const ORDER_ID = '507f1f77bcf86cd799439011';
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Order') {
+      return {
+        findById: async () => ({
+          _id: ORDER_ID,
+          userId: '507f1f77bcf86cd799439099',
+          paymentStatus: 'pending',
+          totalAmount: 25,
+          currency: 'USD',
+        }),
+      };
+    }
+    if (request === 'stripe') {
+      return () => ({
+        paymentIntents: { create: async () => ({ id: 'pi_should_not_run', client_secret: 'secret' }) },
+      });
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[paymentControllerPath];
+  const { createPaymentIntent } = require(paymentControllerPath);
+  Module._load = originalLoad;
+
+  const res = mockResponse();
+  await createPaymentIntent(
+    {
+      body: { orderId: ORDER_ID },
+      user: { id: '507f1f77bcf86cd799439012' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /Not allowed/i);
+});
+
+test('assertConnectAccountOwnedByUser returns 403 for foreign Connect account', async () => {
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request.endsWith('models/Business')) {
+      return {
+        findOne: () => ({
+          select: async () => null,
+        }),
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[ownershipPath];
+  const { assertConnectAccountOwnedByUser } = require(ownershipPath);
+  Module._load = originalLoad;
+
+  const result = await assertConnectAccountOwnedByUser('acct_foreign', '507f1f77bcf86cd799439012');
+  assert.equal(result.ok, false);
+  assert.equal(result.status, 403);
+});
+
+test('app.js keeps Stripe webhook raw-body mounts before express.json', () => {
+  const source = fs.readFileSync(path.resolve(__dirname, '../../app.js'), 'utf8');
+  const jsonIndex = source.indexOf('app.use(express.json())');
+  const vendorWebhookIndex = source.indexOf("app.use('/api/vendor-onboarding/webhook/payment'");
+  const stripeWebhookIndex = source.indexOf("app.use('/api/stripe'");
+
+  assert.ok(vendorWebhookIndex > -1 && vendorWebhookIndex < jsonIndex);
+  assert.ok(stripeWebhookIndex > -1 && stripeWebhookIndex < jsonIndex);
+});

--- a/utils/stripeConnectOwnership.js
+++ b/utils/stripeConnectOwnership.js
@@ -1,0 +1,24 @@
+const Business = require('../models/Business');
+
+async function assertConnectAccountOwnedByUser(accountId, userId) {
+  if (!accountId) {
+    return { ok: false, status: 400, message: 'Missing connected account id' };
+  }
+
+  const business = await Business.findOne({
+    stripeConnectAccountId: accountId,
+    owner: userId,
+  }).select('_id owner stripeConnectAccountId');
+
+  if (!business) {
+    return {
+      ok: false,
+      status: 403,
+      message: 'Not allowed to access this Connect account.',
+    };
+  }
+
+  return { ok: true, business };
+}
+
+module.exports = { assertConnectAccountOwnedByUser };


### PR DESCRIPTION
## Summary

Stacks backend stabilization (`5e6995e`) and launch-blocker fixes (`c775a3b`) for marketplace visibility, payment route protection, order email timing, and health/readiness probes.

**Stabilization (batch 1):**
- Featured/search/ranked public visibility fixes and pagination caps
- Product compound indexes and security middleware (`mongo-sanitize`, `xss-clean`)
- Agent/audit/proof/roadmap docs (`BACKEND_STABILITY_*`, `BACKEND_ROADMAP_ISSUES.md`)
- Tests: 173 → 178

**Launch blockers (batch 2):**
- **#41** Auth + ownership on legacy payment intent and `/stripe/*` routes; `isCustomer` on checkout initiate
- **#43** Remove pre-payment order emails; post-payment confirmation only with `paidConfirmationEmailSentAt` dedup
- **#69** Add `GET /api/health` and `GET /api/ready`
- Tests: 178 → 190

## Test plan

- [x] `npm test` — 190/190 pass
- [ ] Post-merge EB deploy
- [ ] `GET /api/health` and `GET /api/ready` on deployed API
- [ ] Verify unauthenticated `POST /api/payments/create-payment-intent` returns 401
- [ ] Tiered smoke (#27) with `SMOKE_TEST_*` accounts when available

## Docs

- `docs/BACKEND_STABILITY_ROADMAP_AUDIT.md`
- `docs/BACKEND_STABILITY_PROOF.md`
- `docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md`
- `docs/BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md`

## Risk notes

- Legacy clients calling payment intent without auth will get 401
- Pre-payment order-placed emails removed; only post-payment confirmation remains
- Mongo index + schema fields apply on deploy

## Rollback

Revert branch merge; no breaking changes to public browse response shapes or `GET /api/featured-products`.
