### PR TITLE
Add CORS_ORIGINS env-driven allowlist (fixes #80)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ MONGODB_URI=mongodb://localhost:27017/mbh
 
 FRONTEND_URL=http://localhost:3000
 
+# Comma-separated browser origins allowed for CORS (production). Falls back to FRONTEND_URL + legacy defaults when unset.
+# CORS_ORIGINS=https://mosaic-biz-frontend-launch.vercel.app,https://app.mosaicbizhub.com,https://mosaicbizhub.com,https://www.mosaicbizhub.com
+
 JWT_SECRET=replace-with-a-long-random-secret
 
 COOKIE_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Add only the values needed for the features you plan to run locally. Some flows 
 | `PORT` | Optional | HTTP port, defaults to `3001` |
 | `NODE_ENV` | Optional | Runtime mode used in auth/cookie behavior |
 | `MONGODB_URI` | Yes | MongoDB connection string |
-| `FRONTEND_URL` | Recommended | Frontend base URL used in CORS and generated links |
+| `FRONTEND_URL` | Recommended | Frontend base URL for OAuth redirects, emails, and CORS fallback when `CORS_ORIGINS` is unset |
+| `CORS_ORIGINS` | Recommended (prod) | Comma-separated browser origins allowed for CORS (explicit domains only; no `*`). When unset, falls back to `FRONTEND_URL` plus legacy production defaults. See [`utils/corsOrigins.js`](utils/corsOrigins.js). |
 | `JWT_SECRET` | Yes | JWT signing/verification secret |
 | `COOKIE_DOMAIN` | Optional | Cookie domain override; defaults to `.mosaicbizhub.com` in production and unset locally |
 | `COOKIE_SECURE` | Optional | Cookie `Secure` override; defaults to `true` in production and `false` locally |
@@ -252,6 +253,6 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 ## Deployment notes
 
 - Ensure all Stripe webhook endpoints in the deployed environment use the correct secrets documented above.
-- Confirm `FRONTEND_URL` is set correctly for CORS and link generation.
+- Confirm `CORS_ORIGINS` (or `FRONTEND_URL` fallback) allows all production frontend origins; confirm `FRONTEND_URL` for OAuth redirects and link generation.
 - Configure AWS and mail credentials before enabling upload or notification flows.
 - For production, verify MongoDB, Stripe, SMTP, and S3 credentials in the deployment environment rather than relying on a local `.env`.

--- a/app.js
+++ b/app.js
@@ -86,24 +86,11 @@ const mongoSanitize = require('express-mongo-sanitize');
 const { clean: xssClean } = require('xss-clean/lib/xss');
 const sentryHttpCapture = require('./middlewares/sentryHttpCapture');
 const { isSentryEnabled } = require('./instrument');
+const { getAllowedOrigins } = require('./utils/corsOrigins');
 
 const app = express();
 
-const allowedOrigins = Array.from(
-  new Set([
-    'https://www.mosaicbizhub.com',
-    'https://app.mosaicbizhub.com',
-    'https://mosaic-biz-frontend-launch.vercel.app',
-    'http://localhost:3000',
-    'http://localhost:8081',
-    'https://app.minorityownedbusiness.info',
-    'http://192.168.1.50:3000',
-    'exp://192.168.0.104:8081',
-    'exp://192.168.0.104:3000',
-    'exp://192.168.0.104:3001',
-    process.env.FRONTEND_URL,
-  ].filter(Boolean))
-);
+const allowedOrigins = getAllowedOrigins();
 app.set('trust proxy', 1);
 app.use(sentryHttpCapture);
 app.use(cors({

--- a/docs/AUTH_FLOW.md
+++ b/docs/AUTH_FLOW.md
@@ -476,8 +476,9 @@ All use `express-rate-limit`, **15-minute window**, defined in route files.
 
 ### CORS and cookies
 
-- CORS allowlist in `app.js` includes production frontends and `FRONTEND_URL`; `credentials: true`.
+- CORS allowlist resolved by [`utils/corsOrigins.js`](../utils/corsOrigins.js): `CORS_ORIGINS` (comma-separated) when set, otherwise `FRONTEND_URL` plus legacy production defaults. [`app.js`](../app.js) mounts `cors` with `credentials: true` (no wildcard `*`).
 - Production cookies: `secure` + `sameSite` from env; domain `.mosaicbizhub.com` when `NODE_ENV=production`.
+- Frontend authenticated requests must use `credentials: 'include'` (fetch) or `withCredentials: true` (axios).
 
 ---
 

--- a/docs/EB_DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/EB_DEPLOYMENT_READINESS_CHECKLIST.md
@@ -81,8 +81,13 @@ Full list: [production-env-checklist.md](production-env-checklist.md)
 
 ## CORS and frontend
 
-- [ ] `FRONTEND_URL` matches launch frontend
-- [ ] Launch origin allowed: `https://mosaic-biz-frontend-launch.vercel.app` (verify in [app.js](../app.js) allowlist)
+- [ ] `CORS_ORIGINS` set on EB with explicit production frontends (recommended):
+  - `https://mosaic-biz-frontend-launch.vercel.app`
+  - `https://app.mosaicbizhub.com`
+  - `https://mosaicbizhub.com`
+  - `https://www.mosaicbizhub.com`
+- [ ] `FRONTEND_URL` matches canonical app host (`https://app.mosaicbizhub.com`) for OAuth redirects and emails
+- [ ] If `CORS_ORIGINS` is unset, verify legacy fallback still allows launch Vercel + app origins ([`utils/corsOrigins.js`](../utils/corsOrigins.js))
 - [ ] Frontend `NEXT_PUBLIC_API_BASE_URL` → `https://api.mosaicbizhub.com`
 
 ---

--- a/docs/ENV_VAR_INVENTORY.md
+++ b/docs/ENV_VAR_INVENTORY.md
@@ -29,7 +29,8 @@ Sources compared: [`.env.example`](../.env.example), [README.md](../README.md), 
 | `NODE_ENV` | Required-prod | Optional | No | Yes | `production` on EB |
 | `MONGODB_URI` | Required-prod | Yes | No | Yes | Atlas connection string |
 | `JWT_SECRET` | Required-prod | Yes | No | Yes | Auth signing |
-| `FRONTEND_URL` | Required-prod | Yes | No | Yes | CORS + redirects |
+| `FRONTEND_URL` | Required-prod | Yes | No | Yes | CORS fallback + redirects |
+| `CORS_ORIGINS` | Recommended-prod | Optional | No | Yes | Comma-separated CORS allowlist; explicit domains only |
 | `API_BASE_URL` | Required-prod | Yes | No | Yes | OAuth callback base |
 | `GOOGLE_CLIENT_ID` | Required-prod | Yes | No | Yes | Auth module load |
 | `GOOGLE_CLIENT_SECRET` | Required-prod | Yes | No | Yes | OAuth |

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -12,7 +12,8 @@ Set these in the Elastic Beanstalk environment configuration (or secret manager 
 |----------|-------|
 | `MONGODB_URI` | Production MongoDB (`config/Db.js`) |
 | `JWT_SECRET` | Auth signing |
-| `FRONTEND_URL` | CORS + redirects; required by `authController.js` |
+| `FRONTEND_URL` | CORS fallback + redirects; required by `authController.js` |
+| `CORS_ORIGINS` | Comma-separated explicit browser origins for CORS (recommended in production). When unset, falls back to `FRONTEND_URL` plus legacy defaults (`app`, `www`, launch Vercel). See [`utils/corsOrigins.js`](../utils/corsOrigins.js). |
 | `GOOGLE_CLIENT_ID` | Module load throws if missing (`authController.js`) |
 | `GOOGLE_CLIENT_SECRET` | Same |
 | `API_BASE_URL` | Public production API base for OAuth callback (e.g. `https://api.mosaicbizhub.com`) |

--- a/tests/cors/cors-origins.test.js
+++ b/tests/cors/cors-origins.test.js
@@ -1,0 +1,128 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const corsOriginsPath = path.resolve(__dirname, '../../utils/corsOrigins.js');
+const ENV_KEYS = ['CORS_ORIGINS', 'FRONTEND_URL', 'NODE_ENV'];
+
+function snapshotEnv() {
+  const saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+  return saved;
+}
+
+function restoreEnv(saved) {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+  delete require.cache[corsOriginsPath];
+}
+
+function loadCorsOrigins(envOverrides = {}) {
+  const saved = snapshotEnv();
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+  delete require.cache[corsOriginsPath];
+  return {
+    mod: require(corsOriginsPath),
+    cleanup: () => restoreEnv(saved),
+  };
+}
+
+test.afterEach(() => {
+  delete require.cache[corsOriginsPath];
+});
+
+test('parseCorsOrigins trims and filters empty entries', () => {
+  const { mod, cleanup } = loadCorsOrigins();
+  try {
+    assert.deepEqual(
+      mod.parseCorsOrigins(' https://a.com , https://b.com , , '),
+      ['https://a.com', 'https://b.com']
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('getAllowedOrigins uses CORS_ORIGINS when set', () => {
+  const { mod, cleanup } = loadCorsOrigins({
+    NODE_ENV: 'production',
+    CORS_ORIGINS: 'https://mosaic-biz-frontend-launch.vercel.app,https://app.mosaicbizhub.com,https://mosaicbizhub.com,https://www.mosaicbizhub.com',
+  });
+  try {
+    const origins = mod.getAllowedOrigins();
+    assert.ok(origins.includes('https://mosaicbizhub.com'));
+    assert.ok(origins.includes('https://www.mosaicbizhub.com'));
+    assert.equal(origins.length, 4);
+  } finally {
+    cleanup();
+  }
+});
+
+test('getAllowedOrigins dedupes CORS_ORIGINS entries', () => {
+  const { mod, cleanup } = loadCorsOrigins({
+    NODE_ENV: 'production',
+    CORS_ORIGINS: 'https://app.mosaicbizhub.com,https://app.mosaicbizhub.com',
+  });
+  try {
+    assert.deepEqual(mod.getAllowedOrigins(), ['https://app.mosaicbizhub.com']);
+  } finally {
+    cleanup();
+  }
+});
+
+test('getAllowedOrigins falls back to FRONTEND_URL and legacy when CORS_ORIGINS unset', () => {
+  const { mod, cleanup } = loadCorsOrigins({
+    NODE_ENV: 'production',
+    FRONTEND_URL: 'https://app.mosaicbizhub.com',
+  });
+  try {
+    const origins = mod.getAllowedOrigins();
+    assert.ok(origins.includes('https://app.mosaicbizhub.com'));
+    for (const legacy of mod.LEGACY_DEFAULT_ORIGINS) {
+      assert.ok(origins.includes(legacy));
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('getAllowedOrigins appends dev origins only outside production', () => {
+  const { mod, cleanup } = loadCorsOrigins({
+    NODE_ENV: 'development',
+    CORS_ORIGINS: 'https://app.mosaicbizhub.com',
+  });
+  try {
+    const origins = mod.getAllowedOrigins();
+    assert.ok(origins.includes('https://app.mosaicbizhub.com'));
+    assert.ok(origins.includes('http://localhost:3000'));
+    for (const dev of mod.DEV_ORIGINS) {
+      assert.ok(origins.includes(dev));
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test('getAllowedOrigins excludes dev origins in production', () => {
+  const { mod, cleanup } = loadCorsOrigins({
+    NODE_ENV: 'production',
+    CORS_ORIGINS: 'https://app.mosaicbizhub.com',
+  });
+  try {
+    const origins = mod.getAllowedOrigins();
+    assert.ok(!origins.includes('http://localhost:3000'));
+    assert.ok(!origins.includes('exp://192.168.0.104:8081'));
+  } finally {
+    cleanup();
+  }
+});

--- a/utils/corsOrigins.js
+++ b/utils/corsOrigins.js
@@ -1,0 +1,46 @@
+const LEGACY_DEFAULT_ORIGINS = [
+  'https://app.mosaicbizhub.com',
+  'https://www.mosaicbizhub.com',
+  'https://mosaic-biz-frontend-launch.vercel.app',
+];
+
+const DEV_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:8081',
+  'https://app.minorityownedbusiness.info',
+  'http://192.168.1.50:3000',
+  'exp://192.168.0.104:8081',
+  'exp://192.168.0.104:3000',
+  'exp://192.168.0.104:3001',
+];
+
+function parseCorsOrigins(value) {
+  return value.split(',').map((o) => o.trim()).filter(Boolean);
+}
+
+function getAllowedOrigins() {
+  const isProd = process.env.NODE_ENV === 'production';
+  let origins;
+
+  if (process.env.CORS_ORIGINS) {
+    origins = parseCorsOrigins(process.env.CORS_ORIGINS);
+  } else {
+    origins = [
+      process.env.FRONTEND_URL,
+      ...LEGACY_DEFAULT_ORIGINS,
+    ].filter(Boolean);
+  }
+
+  if (!isProd) {
+    origins = [...origins, ...DEV_ORIGINS];
+  }
+
+  return [...new Set(origins)];
+}
+
+module.exports = {
+  LEGACY_DEFAULT_ORIGINS,
+  DEV_ORIGINS,
+  parseCorsOrigins,
+  getAllowedOrigins,
+};


### PR DESCRIPTION
## Summary
- Add `utils/corsOrigins.js` to resolve allowed browser origins from comma-separated `CORS_ORIGINS`, with backward-compatible fallback to `FRONTEND_URL` plus legacy production defaults.
- Wire `app.js` to use `getAllowedOrigins()`; keep `credentials: true` and explicit origin matching (no wildcard `*`).
- Dev-only origins (localhost, Expo, LAN) apply only when `NODE_ENV !== 'production'`.
- Add unit tests and document `CORS_ORIGINS` in env checklists.

Fixes #80

## Test plan
- [x] `npm test` (196 tests)
- [ ] After EB deploy + `CORS_ORIGINS` set, run OPTIONS curl for each origin (see issue #80)
- [ ] Confirm dev origins not returned in production ACAO headers

## EB env (names/URLs only — set after merge + deploy)
`CORS_ORIGINS=https://mosaic-biz-frontend-launch.vercel.app,https://app.mosaicbizhub.com,https://mosaicbizhub.com,https://www.mosaicbizhub.com`

Keep `FRONTEND_URL=https://app.mosaicbizhub.com` for OAuth redirects and emails.

## Post-deploy curl proof (per origin)
```bash
curl.exe -s -D - -o NUL -X OPTIONS \
  -H "Origin: <ORIGIN>" \
  -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: Content-Type" \
  "https://api.mosaicbizhub.com/api/featured-products"
```
Expected: `204`, `Access-Control-Allow-Origin: <ORIGIN>` (exact), `Access-Control-Allow-Credentials: true`
