### PR TITLE
Add backend launch proof pack documentation (issues #80, #84, #55, #18)

### DIFF
--- a/docs/BACKEND_DEPLOYMENT_PROOF.md
+++ b/docs/BACKEND_DEPLOYMENT_PROOF.md
@@ -1,0 +1,151 @@
+# Backend Deployment Proof — Post-Deploy Release Verification
+
+**Recorded:** 2026-06-18 18:22:36 UTC  
+**Verification branch:** `audit/backend-post-deploy-release-verification`  
+**Production API:** `https://api.mosaicbizhub.com`  
+**Issues:** [#80 CORS](https://github.com/Techware-Hut/mosaic-backend/issues/80) · [#84 Smoke](https://github.com/Techware-Hut/mosaic-backend/issues/84) · [#18 Sentry](https://github.com/Techware-Hut/mosaic-backend/issues/18)
+
+---
+
+## Release metadata
+
+| Field | Value |
+|-------|-------|
+| Repo `main` SHA | `5f98461` — Merge PR #85 (CORS allowlist) |
+| Last GHA EB deploy SHA | `7d01011` — 2026-06-18T01:13:55Z |
+| Deploy of `5f98461` confirmed live | **NO** |
+| Deploy proxy evidence | `GET /api/health` → **404**; `GET /api/ready` → **404** |
+| Executor | Automated post-deploy verification run |
+
+**Conclusion:** Code is merged to `main`, but **production API behavior matches pre-merge deploy** (`7d01011` era). Full launch sign-off **blocked** until redeploy + env confirmation.
+
+---
+
+## EB environment variables (names only)
+
+AWS CLI unavailable in audit environment — **presence not directly verified**. Required names per [`docs/ENV_VAR_INVENTORY.md`](ENV_VAR_INVENTORY.md):
+
+### CORS / frontend
+
+| Variable | Expected | Verified |
+|----------|----------|----------|
+| `CORS_ORIGINS` | Four launch origins (see CORS proof doc) | **INFER FAIL** — apex CORS 500 |
+| `FRONTEND_URL` | `https://app.mosaicbizhub.com` | **BLOCKED** |
+
+### Sentry
+
+| Variable | Purpose |
+|----------|---------|
+| `SENTRY_DSN` | Enable monitoring |
+| `SENTRY_ENVIRONMENT` | e.g. `production` |
+| `SENTRY_RELEASE` | e.g. `mosaic-5f98461` |
+| `SENTRY_TRACES_SAMPLE_RATE` | Default `0` |
+| `SENTRY_PROFILES_SAMPLE_RATE` | Default `0` |
+| `SENTRY_ENABLED` | Optional disable switch |
+| `ENABLE_SENTRY_DEBUG_ROUTE` | Must be **false/unset** at launch |
+
+### Stripe (names only)
+
+`STRIPE_SECRET_KEY`, `STRIPE_ORDER_WEBHOOK_SECRET`, `STRIPE_BUSINESS_DRAFT_WEBHOOK_SECRET`, `STRIPE_SUBSCRIPTION_WEBHOOK_SECRET`, `STRIPE_VENDOR_VERIFICATION_WEBHOOK_SECRET`, `STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET`
+
+### Email (names only)
+
+`MAIL_USER`, `MAIL_PASSWORD`
+
+No secret values recorded.
+
+---
+
+## Smoke summary
+
+### Local
+
+| Check | Result |
+|-------|--------|
+| `npm test` | **196/196 PASS** |
+| `node -c app.js` | **PASS** |
+
+### Production public
+
+| Tier | Result |
+|------|--------|
+| Root + marketplace browse | **PASS** (200) |
+| Health/readiness | **FAIL** (404) |
+| Featured canonical route | **PASS** |
+
+### CORS (OPTIONS `/api/featured-products`)
+
+| Origin | Result |
+|--------|--------|
+| launch.vercel.app | **PASS** |
+| app.mosaicbizhub.com | **PASS** |
+| mosaicbizhub.com (apex) | **FAIL** |
+| www.mosaicbizhub.com | **PASS** |
+| evil.example.com | **PASS** (rejected) |
+
+### Unauth protected routes
+
+**PASS** — 401 on auth, vendor, order, connect, admin routes; no stack traces in bodies.
+
+### Authenticated / checkout
+
+**BLOCKED** — no `SMOKE_TEST_*` tokens; no live payment tests.
+
+### Email safety
+
+**PASS** — unit tests + `paidConfirmationEmailSentAt` guard; no pre-payment emails in `initiateOrder`.
+
+### Sentry
+
+| Check | Result |
+|-------|--------|
+| Debug route disabled | **PASS** (404) |
+| No stack leak on 401 | **PASS** |
+| Dashboard event proof | **BLOCKED** |
+
+---
+
+## Stakeholder summary
+
+| Gate | Status |
+|------|--------|
+| Code on `main` | **PASS** |
+| EB deploy of latest `main` | **FAIL** |
+| EB env configured | **BLOCKED / INFER FAIL** |
+| Public API browse | **PASS** |
+| CORS 4/4 | **FAIL** (3/4) |
+| Auth rejection | **PASS** |
+| Email safety (code) | **PASS** |
+| Full launch sign-off | **NOT READY** |
+
+---
+
+## Remaining launch blockers
+
+1. **Deploy** `main` @ `5f98461`+ to Elastic Beanstalk (workflow_dispatch)
+2. **Set** `CORS_ORIGINS` and `FRONTEND_URL` on EB before or with deploy
+3. **Confirm** `GET /api/health` → 200 and apex CORS → 204
+4. **Provide** approved smoke test tokens for authenticated tier
+5. **Verify** Sentry dashboard capture (optional debug route — disable after)
+
+---
+
+## Related proof packs
+
+- [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md)
+- [`docs/BACKEND_PRODUCTION_SMOKE_PROOF.md`](BACKEND_PRODUCTION_SMOKE_PROOF.md)
+- [`docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md`](BACKEND_FRONTEND_ROUTE_CONTRACT.md) *(on branch `audit/backend-frontend-route-contract`)*
+- [`docs/SENTRY_EB_DEPLOY_VERIFICATION.md`](SENTRY_EB_DEPLOY_VERIFICATION.md)
+- [`docs/EB_DEPLOYMENT_READINESS_CHECKLIST.md`](EB_DEPLOYMENT_READINESS_CHECKLIST.md)
+
+---
+
+## Repro commands
+
+```powershell
+git checkout main
+npm test
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+```
+
+CORS per-origin OPTIONS — see [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md).

--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -1,0 +1,271 @@
+# Backend Frontend Route Contract
+
+**Purpose:** Launch-readiness route contract for frontend cleanup. Maps frontend-suspect paths to actual Express registrations.  
+**Issue:** [#55 Backend OpenAPI and API contract documentation](https://github.com/Techware-Hut/mosaic-backend/issues/55)  
+**Branch:** `audit/backend-frontend-route-contract`  
+**Audited against `main` commit:** `5f98461` (2026-06-18)  
+**Production base URL:** `https://api.mosaicbizhub.com`
+
+**Related (full backend maps):** [API_SURFACE.md](API_SURFACE.md) · [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) · [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md)
+
+**Registry source:** [`app.js`](../app.js) mounts + per-file routers under [`routes/`](../routes/). No central route generator.
+
+---
+
+## Executive summary — frontend-suspect paths
+
+| Frontend suspect | Verdict | Use instead | Auth |
+|------------------|---------|-------------|------|
+| `/admin/users` | **valid** | Same path (see Admin users table) | Yes — `admin` |
+| `/admin/api/products` | **valid** | Same path (see Admin products table) | Yes — `admin` |
+| `/api/admin/products` | **missing** (wrong prefix) | `GET /admin/api/products` | — |
+| `/api/products/featured` | **missing/stale** | **`GET /api/featured-products`** | Public |
+| `/stripe/...` (vendor finance) | **valid** | `/stripe/account-session`, `/stripe/express-login-link`, etc. | Yes — `business_owner` |
+| `/api/stripe/...` | **valid, different purpose** | Checkout: `POST /api/stripe/create-checkout-session`; webhooks: server-only | Mixed |
+| Stripe webhooks | **server-only** | Never call from browser | Stripe signature |
+
+**Compatibility fix required:** None on backend. Frontend should update stale paths (especially featured products and admin product prefix).
+
+**Prefix traps (do not “normalize” in frontend without checking):**
+
+| Pattern | Example routes |
+|---------|----------------|
+| `/admin/api/*` | products, blogs, business admin |
+| `/api/admin/*` | categories, testimonials, business admin duplicate mount |
+| `/admin/*` (no `/api`) | users, FAQs, vendor verify |
+| `/stripe/*` | Vendor Connect dashboard embed (no `/api` prefix) |
+| `/api/stripe/*` | Business draft checkout + webhooks |
+| `/api/connect/*` | Connect onboarding account links |
+
+---
+
+## A. Public marketplace (launch-critical)
+
+Mount: `/api` via [`routes/publicListing.js`](../routes/publicListing.js), [`routes/featuredProductRoutes.js`](../routes/featuredProductRoutes.js), [`routes/businessRoutes.js`](../routes/businessRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/featured-products` | GET | No | Public | Home / featured carousel | **valid** | **Canonical featured route.** Registered in `featuredProductRoutes.js`. |
+| `/api/products/featured` | GET | — | — | — | **missing/stale** | **Not registered.** Returns 404. Do not use. |
+| `/api/products/list` | GET | No | Public | Product browse / filters | **valid** | Primary product listing |
+| `/api/products/filters` | GET | No | Public | Product browse filters | **valid** | Filter metadata |
+| `/api/public/product/:productId` | GET | No | Public | Product detail | **valid** | Canonical public product detail |
+| `/api/public/products/business/:businessId` | GET | No | Public | Vendor storefront products | **valid** | Products by business |
+| `/api/public/product/vendor-profile/:businessId` | GET | No | Public | Vendor public profile | **valid** | Business card on product pages |
+| `/api/public/search` | GET | No | Public | Search results | **valid** | Unified public search |
+| `/api/services/list` | GET | No | Public | Services browse | **valid** | |
+| `/api/services/:slug` | GET | No | Public | Service detail (slug) | **valid** | Alternate to ID route |
+| `/api/public/services/:id` | GET | No | Public | Service detail (ID) | **valid** | Preferred when ID known |
+| `/api/food/list` | GET | No | Public | Food browse | **valid** | |
+| `/api/public/foods/:id` | GET | No | Public | Food detail | **valid** | Canonical public food detail |
+| `/api/business/` | GET | No | Public | Business directory browse | **valid** | `getProductBusinesses` |
+| `/api/business/public/:slug` | GET | No | Public | Public business page | **valid** | Slug-based public profile |
+| `/api/ranked` | GET | No | Public | Ranked products | **valid** | Optional browse enhancement |
+| `/api/:id/similar` | GET | No | Public | Similar products | **valid** | Detail page related items |
+
+**Alternate public detail paths (also valid, prefer canonical above):**
+
+| Route | Method | Status | Notes |
+|-------|--------|--------|-------|
+| `/api/service/business-service/:id` | GET | valid | Public service detail via `serviceRoutes.js` |
+| `/api/food/business-food/:id` | GET | valid | Public food detail via `foodRoutes.js` |
+
+**Vendor CRUD (not public browse):** Product/service/food management uses singular mounts `/api/product`, `/api/service`, `/api/food` with `business_owner` auth — not `/api/products`.
+
+---
+
+## B. Auth session probe
+
+Mount: `/api/users` via [`routes/userRoutes.js`](../routes/userRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/users/auth/check` | GET | Yes | Any authenticated | App shell / route guard | **valid** | Returns `toPublicAuthUser` whitelist; 401 if unauthenticated |
+| `/api/users/login` | POST | No | Public | Login | **valid** | |
+| `/api/users/logout` | POST | No | Public | Logout | **valid** | Clears cookies |
+| `/api/auth/google` | GET | No | Public | OAuth start | **valid** | Browser redirect flow |
+| `/api/auth/google/callback` | GET | No | Public | OAuth callback | **valid** | Sets cookies |
+
+Use `credentials: 'include'` (fetch) or `withCredentials: true` (axios) for authenticated requests.
+
+---
+
+## C. Admin launch routes
+
+### Admin users
+
+Mount: `/admin/users` → [`routes/admin/userRoutes.js`](../routes/admin/userRoutes.js). Router-level: `authenticate`, `isAdmin`.
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/admin/users` | GET | Yes | admin | Admin user list | **valid** | Frontend suspect path confirmed |
+| `/admin/users/:id` | GET | Yes | admin | Admin user detail | **valid** | |
+| `/admin/users/:id` | PUT | Yes | admin | Admin user edit | **valid** | |
+| `/admin/users/:id` | DELETE | Yes | admin | Admin user soft delete | **valid** | |
+| `/admin/users/:id/block` | PUT | Yes | admin | Block/unblock user | **valid** | |
+| `/admin/users/admins` | POST | Yes | admin | Create admin user | **valid** | Body validators required |
+
+### Admin products
+
+Mount: `/admin/api/products` → [`routes/admin/adminProductRoutes.js`](../routes/admin/adminProductRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/admin/api/products` | GET | Yes | admin | Admin product list / featured mgmt | **valid** | Frontend suspect path confirmed |
+| `/admin/api/products/:productId/featured` | PATCH | Yes | admin | Toggle featured flag | **valid** | Sets `Product.isFeatured` for carousel |
+| `/admin/api/products/test` | GET | No | Public | — | **valid** | Debug-only; no auth — do not use in prod UI |
+
+**Wrong prefix:** `GET /api/admin/products` is **missing**. Admin products live under `/admin/api/products`, not `/api/admin/products`.
+
+### Other admin mounts (prefix reference)
+
+| Mount prefix | Purpose | Auth |
+|--------------|---------|------|
+| `/admin/vendor-onboard-verify-stage1` | Stage-1 application review | admin |
+| `/admin/api/blogs` | Blog CMS | admin |
+| `/admin/api/business` | Admin business management | admin |
+| `/api/admin/business` | Same router, alternate mount | admin |
+| `/api/admin/category/*` | Category CRUD | admin |
+| `/api/admin/testimonials` | Testimonials | admin |
+| `/admin/faqs` | FAQ admin | admin |
+
+---
+
+## D. Vendor onboarding and business profile
+
+### Vendor onboarding
+
+Mount: `/api/vendor-onboarding` → [`routes/vendorOnboarding.routes.js`](../routes/vendorOnboarding.routes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/vendor-onboarding/onboarding-data` | GET | Yes | business_owner (verified vendor) | Vendor onboarding wizard | **valid** | Primary onboarding state fetch |
+| `/api/vendor-onboarding/draft` | GET | Yes | verified vendor | Draft load | **valid** | |
+| `/api/vendor-onboarding/draft` | POST | Yes | verified vendor | Draft save | **valid** | |
+| `/api/vendor-onboarding/submit` | POST | Yes | verified vendor | Submit application | **valid** | |
+| `/api/vendor-onboarding/business-profile` | PUT | Yes | stage-1 verified vendor | Business profile update | **valid** | Full replace |
+| `/api/vendor-onboarding/business-profile` | PATCH | Yes | stage-1 verified vendor | Business profile patch | **valid** | Partial update |
+| `/api/vendor-onboarding/stage1/upload-url` | GET | Yes | verified vendor | Doc upload | **valid** | |
+| `/api/vendor-onboarding/stage1/create-payment` | POST | Yes | verified vendor | Verification fee | **valid** | Stripe Checkout path |
+| `/api/vendor-onboarding/stage1/payment-status` | GET | Yes | verified vendor | Payment poll | **valid** | |
+| `/api/vendor-onboarding/status/:applicationId` | GET | No | Public | Application status page | **valid** | |
+| `/api/vendor-onboarding/applicationId` | GET | Yes | Any authenticated | Resolve application ID | **valid** | |
+
+Admin review mount: `/admin/vendor-onboard-verify-stage1` (same router file, admin routes).
+
+### Business profile — `/api/business/my`
+
+Mount: `/api/business` → [`routes/businessRoutes.js`](../routes/businessRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/business/my` | GET | Yes | business_owner | Vendor dashboard / business picker | **valid** | Returns businesses for current user |
+| `/api/business/:slug` | GET | Yes | business_owner | Vendor business detail (auth) | **valid** | Slug-based, owner-scoped |
+| `/api/business/:id` | PUT | Yes | business_owner | Update business | **valid** | |
+| `/api/business/draft` | POST | Yes | business_owner | Create business draft | **valid** | Legacy business creation flow |
+
+**Separate legacy flow:** `/api/business-profile/*` ([`routes/businessProfileRoutes.js`](../routes/businessProfileRoutes.js)) — authenticated but distinct from vendor onboarding. Prefer `/api/vendor-onboarding/*` and `/api/business/my` for launch vendor screens unless frontend already targets business-profile specifically.
+
+---
+
+## E. Stripe Connect, payments, and orders
+
+### Connect onboarding (`/api/connect`)
+
+Mount: [`routes/connectRoutes.js`](../routes/connectRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/connect/:businessId/account-link` | POST | Yes | business_owner | Connect onboarding start | **valid** | Creates Stripe Account Link |
+| `/api/connect/:businessId/status` | GET | Yes | business_owner | Connect status poll | **valid** | |
+| `/api/connect/return` | GET | No | Public | OAuth return redirect | **valid** | Browser redirect handler |
+| `/api/connect/refresh` | GET | No | Public | OAuth refresh redirect | **valid** | Browser redirect handler |
+
+### Vendor finance dashboard (`/stripe/*`)
+
+Mount: `/stripe` → [`routes/stripe.routes.js`](../routes/stripe.routes.js). **No `/api` prefix.**
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/stripe/account-session` | POST | Yes | business_owner | Embedded Connect dashboard | **valid** | Frontend finance suspect path |
+| `/stripe/express-login-link` | POST | Yes | business_owner | Express Dashboard login | **valid** | |
+| `/stripe/account-balance` | GET | Yes | business_owner | Balance widget | **valid** | |
+| `/stripe/last-payout` | GET | Yes | business_owner | Payout history widget | **valid** | |
+| `/stripe/backfill-customers` | POST | Yes | admin | — | **server-only** | Admin maintenance; not for frontend |
+
+### Business draft checkout (`/api/stripe`)
+
+Mount: [`routes/stripeRoutes.js`](../routes/stripeRoutes.js).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/stripe/create-checkout-session` | POST | Yes | business_owner | Business subscription checkout | **valid** | Not the same as `/stripe/*` finance routes |
+
+### Customer checkout flow
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/api/orders/initiate` | POST | Yes | customer | Checkout / payment start | **valid** | **Primary** — creates Connect destination PaymentIntent |
+| `/api/orders/retrieve-intent/:id` | GET | Yes | Any authenticated | Payment status poll | **valid** | Poll after initiate |
+| `/api/payments/create-payment-intent` | POST | Yes | customer | Legacy PI creation | **valid** | Secondary; order initiate preferred for marketplace checkout |
+
+### Webhooks — do not call from frontend
+
+| Route | Method | Auth | Status | Notes |
+|-------|--------|------|--------|-------|
+| `/api/webhooks/stripe` | POST | Stripe signature | **server-only** | Canonical order webhook |
+| `/api/stripe/webhook` | POST | Stripe signature | **server-only** | Business draft + Connect sync |
+| `/api/stripe/payment/webhook` | POST | Stripe signature | **server-only** | Post-payment emails |
+| `/api/vendor-onboarding/webhook/payment` | POST | Stripe signature | **server-only** | Vendor verification payment |
+| `/api/subscription/webhook` | POST | Stripe signature | **server-only** | Subscription events |
+
+---
+
+## F. Frontend cleanup checklist
+
+1. **Featured products:** Change any `GET /api/products/featured` call to **`GET /api/featured-products`**.
+2. **Admin products:** Use **`/admin/api/products`**, not `/api/admin/products`.
+3. **Admin users:** **`/admin/users`** is correct as-is; requires admin JWT/cookie session.
+4. **Vendor finance:** Use **`/stripe/*`** routes for dashboard embed, balance, payouts — not `/api/stripe/*`.
+5. **Marketplace checkout:** Use **`POST /api/orders/initiate`** then **`GET /api/orders/retrieve-intent/:id`** to poll.
+6. **Connect onboarding:** Use **`POST /api/connect/:businessId/account-link`**; handle return via `/api/connect/return`.
+7. **Webhooks:** Remove any frontend fetch/axios calls to webhook URLs.
+8. **Auth:** All protected routes need credentials; use `/api/users/auth/check` for session probe.
+
+---
+
+## G. Compatibility assessment
+
+| Question | Answer |
+|----------|--------|
+| Backend route aliases needed? | **No** — frontend path corrections sufficient |
+| Routes to remove? | **No** — audit is docs-only |
+| Payment/webhook logic changes? | **No** |
+| `/api/products/featured` alias? | **Do not add** — preserve canonical `GET /api/featured-products` |
+
+If frontend discovers a path that 404s after applying this contract, open a follow-up with the exact URL and screen — do not add aliases without explicit backend approval.
+
+---
+
+## H. Validation record
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Test suite | `npm test` | **PASS** — 196/196 (2026-06-18) |
+| Syntax | `node -c app.js` | **PASS** — exit 0 |
+| Featured canonical guard | `tests/stripe/checkout-approval-paymentintent-safety.test.js` | Asserts `/featured-products` remains registered |
+
+---
+
+## References
+
+- Mount registry: [`app.js`](../app.js) lines 120–237
+- Featured route: [`routes/featuredProductRoutes.js`](../routes/featuredProductRoutes.js)
+- Public browse: [`routes/publicListing.js`](../routes/publicListing.js)
+- Admin users: [`routes/admin/userRoutes.js`](../routes/admin/userRoutes.js)
+- Admin products: [`routes/admin/adminProductRoutes.js`](../routes/admin/adminProductRoutes.js)
+- Connect: [`routes/connectRoutes.js`](../routes/connectRoutes.js)
+- Vendor finance: [`routes/stripe.routes.js`](../routes/stripe.routes.js)
+- Orders: [`routes/orderRoutes.js`](../routes/orderRoutes.js)
+- Payment flow detail: [PAYMENT_FLOW.md](PAYMENT_FLOW.md)
+- Webhook registration: [stripe-webhook-registration.md](stripe-webhook-registration.md)

--- a/docs/BACKEND_PRODUCTION_SMOKE_PROOF.md
+++ b/docs/BACKEND_PRODUCTION_SMOKE_PROOF.md
@@ -1,0 +1,136 @@
+# Backend Production Smoke Proof — Auth, Checkout, Order, Email
+
+**Issue:** [#84 Backend production smoke proof for domain/API/auth](https://github.com/Techware-Hut/mosaic-backend/issues/84)  
+**Recorded:** 2026-06-18 18:22:36 UTC (post-deploy verification pass)  
+**Branch:** `audit/backend-post-deploy-release-verification`  
+**Repo `main` commit:** `5f98461`  
+**Production API:** `https://api.mosaicbizhub.com`
+
+---
+
+## Deploy status
+
+| Field | Value |
+|-------|-------|
+| `main` HEAD | `5f98461` (PR #85 CORS merge) |
+| Last GHA EB deploy | `7d01011` — 2026-06-18T01:13:55Z |
+| Live deploy confirmed | **NO** — `/api/health` + `/api/ready` return **404** on production |
+| EB env names verified | **BLOCKED** — AWS CLI not available in audit environment |
+
+No secrets in this document.
+
+---
+
+## Local validation (2026-06-18)
+
+| Check | Result |
+|-------|--------|
+| `npm test` | **PASS** — 196/196 |
+| `node -c app.js` | **PASS** |
+
+### Email / order safety (unit tests + code)
+
+| Finding | Result |
+|---------|--------|
+| No pre-payment emails in `initiateOrder` | **PASS** — `order-email-safety.test.js` |
+| Duplicate paid confirmation guard | **PASS** — `paidConfirmationEmailSentAt` in `stripePaymentController.js` |
+| Webhook idempotency | **PASS** — `order-webhook-handlers.test.js` |
+| Route protection on `POST /api/orders/initiate` | **PASS** — `payment-route-protection.test.js` |
+
+---
+
+## Production — public endpoints
+
+| Endpoint | HTTP | Expected | Result |
+|----------|------|----------|--------|
+| `GET /` | 200 | 200 | **PASS** |
+| `GET /api/health` | 404 | 200 | **FAIL** |
+| `GET /api/ready` | 404 | 200 | **FAIL** |
+| `GET /api/featured-products` | 200 | 200 | **PASS** |
+| `GET /api/products/list?limit=5` | 200 | 200 | **PASS** |
+| `GET /api/services/list?limit=5` | 200 | 200 | **PASS** |
+| `GET /api/food/list?limit=5` | 200 | 200 | **PASS** |
+| `GET /api/public/search?keyword=test&limit=5` | 200 | 200 | **PASS** |
+| `GET /api/categories` | 200 | 200 | **PASS** |
+| `GET /api/ranked` | 200 | 200 | **PASS** |
+
+Smoke script: **PASS=9 FAIL=2 SKIP=1 BLOCKED=3**
+
+---
+
+## Production — CORS credentials
+
+See [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md). Summary: **3/4** allowlisted origins pass; apex **FAIL**.
+
+---
+
+## Production — unauth protected routes
+
+| Route | Method | HTTP | Stack leak | Result |
+|-------|--------|------|------------|--------|
+| `/api/users/auth/check` | GET | 401 | No | **PASS** |
+| `/api/business/my` | GET | 401 | No | **PASS** |
+| `/api/vendor-onboarding/onboarding-data` | GET | 401 | No | **PASS** |
+| `/api/orders/initiate` | POST | 401 | No | **PASS** |
+| `/api/orders/vendor` | GET | 401 | No | **PASS** |
+| `/api/connect/.../account-link` | POST | 401 | No | **PASS** |
+| `/stripe/account-session` | POST | 400 | No | **PARTIAL** (rejected, not 401) |
+| `/admin/users` | GET | 401 | No | **PASS** |
+
+Unauth body example: `{"success":false,"message":"Authentication required"}` — no stack trace.
+
+---
+
+## Authenticated smoke — BLOCKED
+
+| Check | Status |
+|-------|--------|
+| `SMOKE_TEST_CUSTOMER_TOKEN` | Not set |
+| `SMOKE_TEST_VENDOR_TOKEN` | Not set |
+| `SMOKE_TEST_ADMIN_TOKEN` | Not set |
+| Customer/vendor/admin auth/check | **BLOCKED** |
+| Role protection (403 probes) | **BLOCKED** |
+| Checkout initiation | **BLOCKED** — no tokens; no live payment tests per policy |
+
+---
+
+## Sentry (safe probes)
+
+| Check | Result |
+|-------|--------|
+| `GET /internal/sentry-debug` | **404** — debug route disabled (launch-safe) |
+| Unauth error body stack leak | **PASS** — no stack in JSON |
+| Sentry dashboard event capture | **BLOCKED** — no dashboard access; debug route not enabled |
+
+---
+
+## Acceptance criteria
+
+| Criterion | Result |
+|-----------|--------|
+| npm test passes | **PASS** |
+| Public browse routes | **PASS** |
+| Health/readiness on prod | **FAIL** — deploy not live |
+| Protected routes reject unauth | **PASS** |
+| CORS credentials (4 origins) | **FAIL** — apex |
+| No pre-payment email regression | **PASS** (unit tests) |
+| No duplicate paid email risk | **PASS** (unit tests + code) |
+| Authenticated checkout on prod | **BLOCKED** |
+
+---
+
+## Remaining blockers
+
+1. Redeploy `main` @ `5f98461`+ to EB
+2. Confirm `CORS_ORIGINS` + `FRONTEND_URL` on EB
+3. Re-run smoke after deploy (`/api/health` must return 200)
+4. Provide approved smoke test tokens for auth/checkout tier
+
+---
+
+## References
+
+- [`scripts/smoke-backend.ps1`](../scripts/smoke-backend.ps1)
+- [`docs/BACKEND_DEPLOYMENT_PROOF.md`](BACKEND_DEPLOYMENT_PROOF.md)
+- [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md)
+- [`docs/SENTRY_EB_DEPLOY_VERIFICATION.md`](SENTRY_EB_DEPLOY_VERIFICATION.md)

--- a/docs/CORS_PRODUCTION_SMOKE_PROOF.md
+++ b/docs/CORS_PRODUCTION_SMOKE_PROOF.md
@@ -1,0 +1,211 @@
+# CORS Production Smoke Proof — Issue #80
+
+**Issue:** [#80 Backend CORS origin allowlist deployment and proof](https://github.com/Techware-Hut/mosaic-backend/issues/80)  
+**PR:** [#85 Add CORS_ORIGINS env-driven allowlist](https://github.com/Techware-Hut/mosaic-backend/pull/85)  
+**Recorded:** 2026-06-18 16:45:02 UTC  
+**Branch:** `fix/backend-cors-origin-allowlist-80`  
+**Commit:** `eb35d8c` (`eb35d8c8cf94006ffa60cf3f51e2a8fdfd25f3da`)  
+**Deployed backend URL:** `https://api.mosaicbizhub.com`  
+**Probe endpoint:** `OPTIONS /api/featured-products`
+
+---
+
+## Release gates
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| PR #85 merged to `main` | **YES** | Merged @ `5f98461` (2026-06-18) |
+| `utils/corsOrigins.js` on `main` | **YES** | Present on `main` |
+| EB production deploy of merge commit | **FAIL / UNVERIFIED** | Last GHA deploy `7d01011`; live probes show pre-merge behavior |
+| EB `CORS_ORIGINS` configured | **BLOCKED** | AWS CLI unavailable; apex CORS still fails on prod |
+| EB `FRONTEND_URL` configured | **BLOCKED** | AWS CLI unavailable |
+| Post-deploy live smoke (all 4 origins) | **FAIL** | 3/4 pass; apex still 500 (2026-06-18 18:22 UTC) |
+
+---
+
+## Required EB environment variables
+
+Set on Elastic Beanstalk production **before or with** deploy of PR #85 merge commit:
+
+| Variable | Required value |
+|----------|----------------|
+| `CORS_ORIGINS` | `https://mosaic-biz-frontend-launch.vercel.app,https://app.mosaicbizhub.com,https://mosaicbizhub.com,https://www.mosaicbizhub.com` |
+| `FRONTEND_URL` | `https://app.mosaicbizhub.com` |
+
+**Important:** Legacy fallback (when `CORS_ORIGINS` is unset) does **not** include apex `https://mosaicbizhub.com`. Setting only `FRONTEND_URL` will not fix the apex domain.
+
+No secrets in this document.
+
+---
+
+## Local validation (branch `eb35d8c`)
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Unit / integration tests | `npm test` | **PASS** — 196/196 (2026-06-18) |
+| Syntax check | `node -c app.js` | **PASS** — exit 0 |
+| CI (GitHub Actions) | PR #85 Test workflow | **PASS** — SUCCESS |
+
+CORS unit tests: `tests/cors/cors-origins.test.js` (6 tests) — all pass.
+
+---
+
+## Curl commands (copy-paste)
+
+Replace `<ORIGIN>` with each test origin. Run from PowerShell or bash.
+
+### PowerShell
+
+```powershell
+curl.exe -s -D - -o NUL -X OPTIONS `
+  -H "Origin: <ORIGIN>" `
+  -H "Access-Control-Request-Method: GET" `
+  -H "Access-Control-Request-Headers: Content-Type" `
+  "https://api.mosaicbizhub.com/api/featured-products"
+```
+
+### Bash
+
+```bash
+curl -s -D - -o /dev/null -X OPTIONS \
+  -H "Origin: <ORIGIN>" \
+  -H "Access-Control-Request-Method: GET" \
+  -H "Access-Control-Request-Headers: Content-Type" \
+  "https://api.mosaicbizhub.com/api/featured-products"
+```
+
+### Test origins
+
+1. `https://mosaic-biz-frontend-launch.vercel.app`
+2. `https://app.mosaicbizhub.com`
+3. `https://mosaicbizhub.com`
+4. `https://www.mosaicbizhub.com`
+5. `https://evil.example.com` (negative control — must not receive allowlisted ACAO)
+
+### Expected (allowlisted origins)
+
+- HTTP **204**
+- `Access-Control-Allow-Origin: <exact Origin header>`
+- `Access-Control-Allow-Credentials: true`
+
+### Expected (negative control)
+
+- Must **not** echo an allowlisted `Access-Control-Allow-Origin`
+- Current pre-merge behavior: HTTP **500** (CORS rejection via Express error handler)
+
+---
+
+## Pre-merge production baseline (2026-06-18 16:44:55 UTC)
+
+Live API still on pre-PR hardcoded allowlist (`main` `app.js`). Results below are **baseline only** — not full issue #80 acceptance.
+
+| Origin | HTTP | ACAO exact match | ACAO-Credentials `true` | Result |
+|--------|------|------------------|-------------------------|--------|
+| `https://mosaic-biz-frontend-launch.vercel.app` | 204 | YES | YES | **PASS** |
+| `https://app.mosaicbizhub.com` | 204 | YES | YES | **PASS** |
+| `https://mosaicbizhub.com` | 500 | NO (absent) | NO (absent) | **FAIL** |
+| `https://www.mosaicbizhub.com` | 204 | YES | YES | **PASS** |
+| `https://evil.example.com` (negative) | 500 | NO (absent) | N/A | **PASS** (rejected) |
+
+**Summary:** 3/4 allowlisted origins pass pre-merge. Apex domain fails because it is not in the current hardcoded production allowlist.
+
+### Actual response headers — launch Vercel (PASS)
+
+```
+HTTP/1.1 204 No Content
+Access-Control-Allow-Origin: https://mosaic-biz-frontend-launch.vercel.app
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
+Access-Control-Allow-Headers: Content-Type
+```
+
+### Actual response headers — app (PASS)
+
+```
+HTTP/1.1 204 No Content
+Access-Control-Allow-Origin: https://app.mosaicbizhub.com
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
+Access-Control-Allow-Headers: Content-Type
+```
+
+### Actual response headers — apex (FAIL)
+
+```
+HTTP/1.1 500 Internal Server Error
+Content-Type: text/html; charset=utf-8
+(no Access-Control-Allow-Origin header)
+```
+
+### Actual response headers — www (PASS)
+
+```
+HTTP/1.1 204 No Content
+Access-Control-Allow-Origin: https://www.mosaicbizhub.com
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET,HEAD,PUT,PATCH,POST,DELETE
+Access-Control-Allow-Headers: Content-Type
+```
+
+### Actual response headers — evil.example.com (negative, PASS)
+
+```
+HTTP/1.1 500 Internal Server Error
+Content-Type: text/html; charset=utf-8
+(no Access-Control-Allow-Origin header)
+```
+
+---
+
+## Post-deploy verification (2026-06-18 18:22:36 UTC)
+
+**Recorded by:** post-deploy release verification (`audit/backend-post-deploy-release-verification`)
+
+**Deploy evidence:**
+
+| Signal | Value |
+|--------|-------|
+| `main` HEAD | `5f98461` |
+| Last GHA EB deploy SHA | `7d01011` (2026-06-18T01:13:55Z) — **older than merge commit** |
+| `GET /api/health` on prod | **404** — merge commit not confirmed live |
+| Apex CORS on prod | **500** — `CORS_ORIGINS` env-driven allowlist not confirmed live |
+
+| Origin | HTTP | ACAO exact | Credentials `true` | Result |
+|--------|------|------------|---------------------|--------|
+| `https://mosaic-biz-frontend-launch.vercel.app` | 204 | YES | YES | **PASS** |
+| `https://app.mosaicbizhub.com` | 204 | YES | YES | **PASS** |
+| `https://mosaicbizhub.com` | 500 | NO | NO | **FAIL** |
+| `https://www.mosaicbizhub.com` | 204 | YES | YES | **PASS** |
+| `https://evil.example.com` (negative) | 500 | NO | N/A | **PASS** (rejected) |
+
+**Summary:** 3/4 allowlisted origins pass. Apex failure indicates production is still running pre-`CORS_ORIGINS` behavior despite merge to `main`.
+
+---
+
+## Blockers
+
+1. **Deploy lag:** GHA last deploy `7d01011`; `main` is `5f98461`. Redeploy required.
+2. **EB env:** `CORS_ORIGINS` / `FRONTEND_URL` not verified (AWS CLI unavailable); apex failure suggests env not applied or deploy not live.
+3. **Issue closure:** Do **not** close #80 until all four allowlisted origins pass and deploy SHA is confirmed.
+
+---
+
+## Next required action (release owner)
+
+1. Set EB env (if not already):
+   - `CORS_ORIGINS=https://mosaic-biz-frontend-launch.vercel.app,https://app.mosaicbizhub.com,https://mosaicbizhub.com,https://www.mosaicbizhub.com`
+   - `FRONTEND_URL=https://app.mosaicbizhub.com`
+2. Deploy `main` @ `5f98461`+ to EB via `workflow_dispatch`
+3. Confirm `GET /api/health` → 200 and apex OPTIONS → 204
+4. Re-run OPTIONS curls; update this document; close #80 only if 4/4 pass
+
+---
+
+## References
+
+- [`utils/corsOrigins.js`](../utils/corsOrigins.js) — env-driven allowlist on `main`
+- [`docs/BACKEND_DEPLOYMENT_PROOF.md`](BACKEND_DEPLOYMENT_PROOF.md) — post-deploy rollup (2026-06-18)
+- [`app.js`](../app.js) — `credentials: true` preserved
+- [`tests/cors/cors-origins.test.js`](../tests/cors/cors-origins.test.js)
+- [`docs/EB_DEPLOYMENT_READINESS_CHECKLIST.md`](EB_DEPLOYMENT_READINESS_CHECKLIST.md)
+- [`.github/workflows/deploy-eb-production.yml`](../.github/workflows/deploy-eb-production.yml) — GHA post-deploy CORS probe (launch + app only; manual proof must cover all four origins)

--- a/docs/SENTRY_EB_DEPLOY_VERIFICATION.md
+++ b/docs/SENTRY_EB_DEPLOY_VERIFICATION.md
@@ -1,8 +1,8 @@
 # Sentry Elastic Beanstalk Deploy Verification (#18)
 
 **Issue:** [#18 Add Sentry or production error monitoring](https://github.com/Techware-Hut/mosaic-backend/issues/18)  
-**Status:** Code complete on `main`; **EB deploy + event capture pending**  
-**Branch baseline:** `main` @ `fbe3aac`
+**Status:** Code on `main`; **post-deploy probe 2026-06-18** — debug route disabled; dashboard proof **BLOCKED**  
+**Branch baseline:** `main` @ `5f98461`
 
 ---
 
@@ -154,14 +154,31 @@ If Sentry causes boot issues:
 
 ---
 
+## Post-deploy safe probes (2026-06-18 18:22 UTC)
+
+Production: `https://api.mosaicbizhub.com`
+
+| Probe | Result | Notes |
+| --- | --- | --- |
+| `GET /internal/sentry-debug` | **404** | Route not mounted — `ENABLE_SENTRY_DEBUG_ROUTE` not active (launch-safe) |
+| `GET /api/users/auth/check` unauth body | **PASS** | JSON `{"success":false,"message":"Authentication required"}` — no stack trace |
+| Sentry dashboard event | **BLOCKED** | No dashboard access in audit session |
+| EB `SENTRY_*` env names | **BLOCKED** | AWS CLI unavailable |
+
+Do **not** enable debug route for launch sign-off without explicit infra approval.
+
+---
+
 ## #18 acceptance criteria checklist
 
 | Criterion | Status |
 | --- | --- |
-| Sentry initialized with EB env DSN | **Pending** — set on EB |
-| Unhandled errors + 5xx captured | **Code ready** — verify after DSN |
-| Release tagged with EB label/SHA | **Pending** — set `SENTRY_RELEASE` |
-| No secrets committed | **Pass** |
-| Documented in production runbook | **Pass** — [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) |
+| Sentry initialized with EB env DSN | **BLOCKED** — cannot verify without AWS/Sentry access |
+| Unhandled errors + 5xx captured | **Code ready** — verify after DSN + deploy of latest `main` |
+| Release tagged with EB label/SHA | **BLOCKED** — deploy of `5f98461` not confirmed live |
+| Debug route disabled at launch | **PASS** — `/internal/sentry-debug` → 404 |
+| No stack traces in client JSON errors | **PASS** — auth probe |
+| No secrets committed | **PASS** |
+| Documented in production runbook | **PASS** — [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) |
 
-**Blocked proof:** Sentry dashboard access + EB env configuration required from deployment owner.
+**Blocked proof:** Sentry dashboard access + EB env configuration + redeploy of `main` @ `5f98461` required from deployment owner.


### PR DESCRIPTION
## Summary

- **Docs-only** PR — no payment, webhook, or order logic changes
- Consolidates launch proof documentation from audit branches:
  - `docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md` — frontend/backend route contract (#55)
  - `docs/CORS_PRODUCTION_SMOKE_PROOF.md` — CORS production smoke proof (#80)
  - `docs/BACKEND_PRODUCTION_SMOKE_PROOF.md` — production smoke proof (#84)
  - `docs/BACKEND_DEPLOYMENT_PROOF.md` — deployment rollup / post-deploy verification
  - `docs/SENTRY_EB_DEPLOY_VERIFICATION.md` — Sentry EB deploy checklist update (#18)
- Skipped superseded `audit/backend-production-checkout-auth-smoke` branch to avoid duplicate smoke proof docs

## Current production blockers (documented honestly)

- Last EB deploy (`7d01011`) is **behind** `main` (`5f98461`) — `/api/health` and `/api/ready` return **404** until redeploy
- Apex CORS (`https://mosaicbizhub.com`) **FAIL** until `CORS_ORIGINS` is set on EB env and redeployed

## Test plan

- [x] `npm test` — 196/196 pass
- [x] `node -c app.js` — syntax OK
- [ ] CI green on PR
- [ ] Post-merge: trigger `deploy-eb-production.yml` and re-run live smoke
