### PR TITLE
chore: smoke test token harness and launch hardening index

### DIFF
--- a/docs/BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md
+++ b/docs/BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md
@@ -1,0 +1,132 @@
+# Backend Next Launch Hardening Batch
+
+**Created:** 2026-06-18  
+**Context:** Issue [#80 CORS](https://github.com/Techware-Hut/mosaic-backend/issues/80) closed — 4/4 production CORS verified after EB env update.  
+**Production API:** `https://api.mosaicbizhub.com`  
+**EB runtime SHA:** `afa56ca`
+
+This document indexes the next controlled backend launch-hardening work. **Each batch is a separate branch/PR** — do not combine.
+
+---
+
+## Completed
+
+| Item | Status | Proof |
+|------|--------|-------|
+| CORS 4/4 on production | **DONE** | [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md) |
+| EB `CORS_ORIGINS` + `FRONTEND_URL` | **DONE** | Release owner applied on `mosaic-backend-env` |
+| Public smoke + health/readiness | **PASS** | [`docs/BACKEND_PRODUCTION_SMOKE_PROOF.md`](BACKEND_PRODUCTION_SMOKE_PROOF.md) |
+
+---
+
+## Batch A — Authenticated smoke unblock
+
+| Field | Value |
+|-------|-------|
+| Branch | `chore/backend-smoke-token-harness` |
+| Owner | Backend + release owner (test account provisioning) |
+| Scope | Document smoke token env vars; optional CLI params on smoke script |
+
+### Required environment variables (never commit values)
+
+| Variable | Role | Used by |
+|----------|------|---------|
+| `SMOKE_TEST_CUSTOMER_TOKEN` | Customer JWT or session token | P2.2 auth/check |
+| `SMOKE_TEST_VENDOR_TOKEN` | Vendor (`business_owner`) token | P2.3 auth/check |
+| `SMOKE_TEST_ADMIN_TOKEN` | Admin token | P2.4 auth/check |
+| `SMOKE_TEST_PRODUCT_ID` | Optional public product ID | P1 product detail |
+| `FRONTEND_ORIGIN` | Optional CORS probe origin | P0.4 CORS preflight |
+
+See [`docs/SMOKE_TEST_TOKENS.md`](SMOKE_TEST_TOKENS.md) for setup steps.
+
+### Acceptance
+
+- When tokens are supplied (env or script params), P2.2–P2.4 run instead of BLOCKED.
+- No real secrets in repo, docs, or CI logs.
+- No changes to payment/checkout/webhook/order/Stripe logic.
+
+---
+
+## Batch B — Sentry production proof
+
+| Field | Value |
+|-------|-------|
+| Branch | Docs update (see Batch C runbook or [`docs/SENTRY_EB_DEPLOY_VERIFICATION.md`](SENTRY_EB_DEPLOY_VERIFICATION.md)) |
+| Owner | Release owner (AWS Console + Sentry dashboard) |
+| Scope | Safe production probes; dashboard validation steps |
+
+### Checks
+
+| Check | Expected | Owner | Status |
+|-------|----------|-------|--------|
+| `GET /internal/sentry-debug` on prod | **404** | Agent (curl) | **PASS** — route disabled at launch |
+| Unauth 401 bodies | No stack trace | Agent | **PASS** |
+| EB `SENTRY_*` env names documented | Names only | Docs | **PASS** — see Sentry doc |
+| Sentry dashboard event capture | Event visible | Release owner | **BLOCKED** — no dashboard access in agent env |
+| `ENABLE_SENTRY_DEBUG_ROUTE` in prod | **false/unset** | Release owner | **BLOCKED** — AWS CLI unavailable |
+
+### Acceptance
+
+- Sentry proof doc clearly marks PASS/BLOCKED per check with owner action.
+- Do **not** enable production debug route unless explicitly approved for a one-time verification window.
+
+---
+
+## Batch C — Backend deployment workflow documentation
+
+| Field | Value |
+|-------|-------|
+| Branch | `docs/backend-deploy-runbook` |
+| Owner | Backend |
+| Scope | Manual EB deploy runbook |
+
+### Acceptance
+
+- Documents [`.github/workflows/deploy-eb-production.yml`](../.github/workflows/deploy-eb-production.yml) is **`workflow_dispatch` only** (push to `main` commented out).
+- Exact deploy commands, post-deploy probes, rollback steps, EB env update pattern (CORS).
+- Release owner can deploy without guessing.
+
+See [`docs/BACKEND_EB_DEPLOY_RUNBOOK.md`](BACKEND_EB_DEPLOY_RUNBOOK.md) (created in Batch C PR).
+
+---
+
+## Batch D — Route contract / API docs follow-up
+
+| Field | Value |
+|-------|-------|
+| Branch | `docs/backend-route-contract-followup` |
+| Owner | Backend |
+| Scope | Clarify featured + ranked routes for frontend |
+
+### Canonical routes (do not change backend)
+
+| Route | Status | Notes |
+|-------|--------|-------|
+| `GET /api/featured-products` | **Canonical** | Featured carousel — do not add `/api/products/featured` |
+| `GET /api/ranked` | **Canonical** | Ranked products browse |
+| `GET /api/products/ranked` | **404 / stale** | Frontend must not use |
+
+### Acceptance
+
+- Frontend team has unambiguous route table in [`docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md`](BACKEND_FRONTEND_ROUTE_CONTRACT.md).
+
+---
+
+## Remaining launch blockers (post-CORS)
+
+| Blocker | Batch | Owner | Action |
+|---------|-------|-------|--------|
+| Authenticated smoke tokens | A | Release owner | Create test accounts; set env vars locally/CI secret |
+| Sentry dashboard proof | B | Release owner | Verify event in Sentry after deploy; confirm EB env names |
+| Deploy runbook | C | Backend | Merge runbook PR |
+| Route ambiguity | D | Backend | Merge route contract follow-up PR |
+| GHA CORS probe (2 origins only) | Future | Backend | Optional: extend deploy workflow to probe all 4 origins |
+
+---
+
+## References
+
+- [`docs/BACKEND_DEPLOYMENT_PROOF.md`](BACKEND_DEPLOYMENT_PROOF.md)
+- [`docs/BACKEND_PRODUCTION_SMOKE_PROOF.md`](BACKEND_PRODUCTION_SMOKE_PROOF.md)
+- [`scripts/smoke-backend.ps1`](../scripts/smoke-backend.ps1)
+- [`docs/ENV_VAR_INVENTORY.md`](ENV_VAR_INVENTORY.md)

--- a/docs/SMOKE_TEST_TOKENS.md
+++ b/docs/SMOKE_TEST_TOKENS.md
@@ -1,0 +1,70 @@
+# Smoke Test Tokens — Production Auth Smoke
+
+**Purpose:** Enable authenticated tiers in [`scripts/smoke-backend.ps1`](../scripts/smoke-backend.ps1) without committing secrets.  
+**Batch:** A in [`BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md`](BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md)
+
+No secret values belong in this document or the repository.
+
+---
+
+## Required variables
+
+| Variable | Role | Smoke check |
+|----------|------|-------------|
+| `SMOKE_TEST_CUSTOMER_TOKEN` | Customer session JWT | P2.2 `GET /api/users/auth/check` → 200 |
+| `SMOKE_TEST_VENDOR_TOKEN` | Vendor (`business_owner`) JWT | P2.3 auth/check → 200 |
+| `SMOKE_TEST_ADMIN_TOKEN` | Admin JWT | P2.4 auth/check → 200 |
+
+## Optional variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SMOKE_TEST_PRODUCT_ID` | Public product ID for `GET /api/public/product/:id` |
+| `FRONTEND_ORIGIN` | Origin header for CORS preflight probe (default: launch Vercel URL) |
+| `API_BASE_URL` | API base (default in script: localhost; use `-ApiBaseUrl` for prod) |
+
+---
+
+## Setup (release owner)
+
+1. Create or designate **non-production test accounts** for customer, vendor, and admin roles in the production database (or a staging mirror if policy requires).
+2. Sign in via the normal auth flow and obtain session JWTs (Bearer tokens).
+3. Store tokens in a local `.env.smoke` file or shell session — **never commit**.
+
+### PowerShell (session only)
+
+```powershell
+$env:SMOKE_TEST_CUSTOMER_TOKEN = '<customer-jwt>'
+$env:SMOKE_TEST_VENDOR_TOKEN = '<vendor-jwt>'
+$env:SMOKE_TEST_ADMIN_TOKEN = '<admin-jwt>'
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+```
+
+### Script parameters (alternative to env)
+
+```powershell
+./scripts/smoke-backend.ps1 `
+  -ApiBaseUrl https://api.mosaicbizhub.com `
+  -CustomerToken '<customer-jwt>' `
+  -VendorToken '<vendor-jwt>' `
+  -AdminToken '<admin-jwt>'
+```
+
+Parameters override env vars when both are set.
+
+---
+
+## Acceptance
+
+When all three tokens are supplied, smoke summary should show P2.2–P2.4 as **PASS** instead of **BLOCKED**.
+
+When tokens are absent, script continues to report **BLOCKED** (expected for CI without secrets).
+
+---
+
+## Security rules
+
+- Do not commit tokens to git, docs, or issue comments.
+- Do not use production admin accounts for routine smoke — dedicated test accounts only.
+- Rotate tokens if exposed.
+- No live payment tests — auth/check probes only unless explicitly extended later.

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -1,9 +1,22 @@
 # Lightweight backend smoke tests - public endpoints first, optional auth if tokens set.
 # Usage: ./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+# Optional auth: -CustomerToken / -VendorToken / -AdminToken (or SMOKE_TEST_* env vars)
+# See docs/SMOKE_TEST_TOKENS.md
 
 param(
-    [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "http://localhost:3001" })
+    [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "http://localhost:3001" }),
+    [string]$CustomerToken,
+    [string]$VendorToken,
+    [string]$AdminToken,
+    [string]$ProductId,
+    [string]$FrontendOrigin
 )
+
+if ($CustomerToken) { $env:SMOKE_TEST_CUSTOMER_TOKEN = $CustomerToken }
+if ($VendorToken) { $env:SMOKE_TEST_VENDOR_TOKEN = $VendorToken }
+if ($AdminToken) { $env:SMOKE_TEST_ADMIN_TOKEN = $AdminToken }
+if ($ProductId) { $env:SMOKE_TEST_PRODUCT_ID = $ProductId }
+if ($FrontendOrigin) { $env:FRONTEND_ORIGIN = $FrontendOrigin }
 
 $Base = $ApiBaseUrl.TrimEnd('/')
 $Pass = 0


### PR DESCRIPTION
## Summary

Add launch hardening work order index and smoke test token harness documentation.

## Changes

- `docs/BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md` — indexes Batches A–D with owners and acceptance criteria
- `docs/SMOKE_TEST_TOKENS.md` — setup guide for `SMOKE_TEST_*` env vars (no secrets)
- `scripts/smoke-backend.ps1` — optional `-CustomerToken`, `-VendorToken`, `-AdminToken`, `-ProductId`, `-FrontendOrigin` params

## Acceptance

- When tokens supplied via env or params, P2.2–P2.4 run instead of BLOCKED
- No payment/auth logic changes; no secrets committed

## Test plan

- [x] `./scripts/smoke-backend.ps1` without tokens — BLOCKED unchanged
- [x] Script accepts new params without error
