### PR TITLE
fix: vendor login session audit and cookie hardening (#81)

### DIFF
--- a/docs/BACKEND_PRODUCTION_SMOKE_PROOF.md
+++ b/docs/BACKEND_PRODUCTION_SMOKE_PROOF.md
@@ -90,8 +90,45 @@ Unauth body example: `{"success":false,"message":"Authentication required"}` —
 | `SMOKE_TEST_VENDOR_TOKEN` | Not set |
 | `SMOKE_TEST_ADMIN_TOKEN` | Not set |
 | Customer/vendor/admin auth/check | **BLOCKED** |
+| Vendor `GET /api/business/my` (P2.5) | **BLOCKED** — needs vendor token |
+| Vendor `GET /api/vendor-onboarding/onboarding-data` (P2.6) | **BLOCKED** — needs vendor token |
+| Credentialed vendor login + cookie chain (P2.7) | **PASS** — see [`docs/VENDOR_LOGIN_SESSION_AUDIT.md`](VENDOR_LOGIN_SESSION_AUDIT.md) |
 | Role protection (403 probes) | **BLOCKED** |
 | Checkout initiation | **BLOCKED** — no tokens; no live payment tests per policy |
+
+---
+
+## Vendor login session proof (issue #81)
+
+**Audit doc:** [`docs/VENDOR_LOGIN_SESSION_AUDIT.md`](VENDOR_LOGIN_SESSION_AUDIT.md)  
+**Script:** [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1)
+
+### Public probes (2026-06-18, no credentials)
+
+| Probe | HTTP | Result |
+|-------|------|--------|
+| CORS preflight `OPTIONS /api/users/login` (`Origin: https://app.mosaicbizhub.com`) | 204 | **PASS** |
+| `GET /api/users/auth/check` unauth | 401 | **PASS** |
+
+### Credentialed vendor login (release owner)
+
+Set `SMOKE_TEST_VENDOR_EMAIL` + `SMOKE_TEST_VENDOR_PASSWORD` (or `SMOKE_TEST_VENDOR_TOKEN`) locally — never commit.
+
+| Step | Expected |
+|------|----------|
+| `POST /api/users/login` | **200**; body includes `user.role: business_owner`, `isOtpVerified: true`; token value redacted in logs |
+| `Set-Cookie` | `token` (HttpOnly, Secure, SameSite=None, Domain=.mosaicbizhub.com, Path=/), `user_session`, `user_gender` |
+| Cookie `GET /api/users/auth/check` | **200** `loggedIn: true` |
+| `GET /api/business/my` | **200** (empty businesses OK) |
+| `GET /api/vendor-onboarding/onboarding-data` | **404** for fresh vendor — authenticated missing-data response, **not 401** |
+
+**Recorded 2026-06-18 (redacted):** All credentialed steps **PASS** via [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1). Hand off to frontend [#142](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/142).
+
+**Root cause (code audit):** Backend login/cookies are role-agnostic. Credentialed prod proof confirms backend chain works; separate-login kick-out from `app.mosaicbizhub.com` is **not explained by backend vendor login branching** — investigate frontend credentialed fetch, role string (`business_owner` vs `vendor`), and 404 handling on onboarding-data.
+
+**Backend hardening (this branch):** `cookieHelper.js` omits empty `COOKIE_DOMAIN` and normalizes `COOKIE_SAMESITE` casing.
+
+**Unit tests:** `vendor-login-session.test.js`, `cookie-helper-prod-options.test.js` — `npm test` **212/212 PASS**.
 
 ---
 
@@ -118,13 +155,14 @@ Unauth body example: `{"success":false,"message":"Authentication required"}` —
 | No pre-payment email regression | **PASS** (unit tests) |
 | No duplicate paid email risk | **PASS** (unit tests + code) |
 | Authenticated checkout on prod | **BLOCKED** |
+| Vendor login session audit (#81) | **PASS** — public probes, unit tests (212/212), credentialed prod cookie chain |
 
 ---
 
 ## Remaining blockers
 
 1. ~~CORS 4/4 on production~~ — **RESOLVED** (2026-06-18)
-2. Provide approved smoke test tokens for auth/checkout tier — see [`docs/BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md`](BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md) Batch A
+2. Provide approved smoke test tokens for auth/checkout tier — see [`docs/BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md`](BACKEND_NEXT_LAUNCH_HARDENING_BATCH.md) Batch A; vendor credentialed login proof via [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1)
 3. Sentry dashboard proof — **BLOCKED** until release owner verifies — Batch B
 
 ---
@@ -134,4 +172,5 @@ Unauth body example: `{"success":false,"message":"Authentication required"}` —
 - [`scripts/smoke-backend.ps1`](../scripts/smoke-backend.ps1)
 - [`docs/BACKEND_DEPLOYMENT_PROOF.md`](BACKEND_DEPLOYMENT_PROOF.md)
 - [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md)
-- [`docs/SENTRY_EB_DEPLOY_VERIFICATION.md`](SENTRY_EB_DEPLOY_VERIFICATION.md)
+- [`docs/VENDOR_LOGIN_SESSION_AUDIT.md`](VENDOR_LOGIN_SESSION_AUDIT.md)
+- [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1)

--- a/docs/SMOKE_TEST_TOKENS.md
+++ b/docs/SMOKE_TEST_TOKENS.md
@@ -12,7 +12,7 @@ No secret values belong in this document or the repository.
 | Variable | Role | Smoke check |
 |----------|------|-------------|
 | `SMOKE_TEST_CUSTOMER_TOKEN` | Customer session JWT | P2.2 `GET /api/users/auth/check` → 200 |
-| `SMOKE_TEST_VENDOR_TOKEN` | Vendor (`business_owner`) JWT | P2.3 auth/check → 200 |
+| `SMOKE_TEST_VENDOR_TOKEN` | Vendor (`business_owner`) JWT | P2.3 auth/check → 200; P2.5 `/api/business/my`; P2.6 onboarding-data |
 | `SMOKE_TEST_ADMIN_TOKEN` | Admin JWT | P2.4 auth/check → 200 |
 
 ## Optional variables
@@ -56,7 +56,9 @@ Parameters override env vars when both are set.
 
 ## Acceptance
 
-When all three tokens are supplied, smoke summary should show P2.2–P2.4 as **PASS** instead of **BLOCKED**.
+When all three tokens are supplied, smoke summary should show P2.2–P2.4 as **PASS** instead of **BLOCKED**. With a vendor token, P2.5–P2.6 should also pass (onboarding-data may return **404** for fresh vendors).
+
+For credentialed **cookie** login proof (not Bearer-only), use [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1) with `SMOKE_TEST_VENDOR_EMAIL` and `SMOKE_TEST_VENDOR_PASSWORD` — see [`docs/VENDOR_LOGIN_SESSION_AUDIT.md`](VENDOR_LOGIN_SESSION_AUDIT.md).
 
 When tokens are absent, script continues to report **BLOCKED** (expected for CI without secrets).
 

--- a/docs/VENDOR_LOGIN_SESSION_AUDIT.md
+++ b/docs/VENDOR_LOGIN_SESSION_AUDIT.md
@@ -1,0 +1,116 @@
+# Vendor Login Session Audit
+
+**Issue context:** Verified vendor OTP succeeds; separate login from production frontend (`https://app.mosaicbizhub.com`) does not keep session.  
+**Tracking:** [#81 Backend auth cookie and credentialed request verification](https://github.com/Techware-Hut/mosaic-backend/issues/81)  
+**Branch:** `fix/backend-vendor-login-session-cookie-smoke`  
+**Recorded:** 2026-06-18
+
+No secrets, JWTs, cookies, OTPs, passwords, or real user data in this document.
+
+---
+
+## Root cause summary
+
+**Backend login/session/cookie code does not treat vendors differently from customers.**
+
+| Layer | Finding |
+|-------|---------|
+| `POST /api/users/login` | Same handler for all roles; gates are `isDeleted`, `isBlocked`, `isOtpVerified`, password only |
+| JWT + cookies | Same `buildSessionToken` + `setAuthCookies` as customer OTP verify |
+| `GET /api/users/auth/check` | No role or vendor onboarding gate |
+| Vendor routes | `isBusinessOwner` / `requireVerifiedVendor` apply **after** auth succeeds |
+
+**Verdict:** The reported failure on **separate login after OTP verification** is **not explained by vendor-specific backend login logic**. Credentialed production proof (2026-06-18) confirms the backend login/cookie chain works for a verified `business_owner` test account. **Ownership passes to frontend** ([#142](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/142), [#143](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/143), [#144](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/144)).
+
+Most likely frontend causes:
+
+1. Vendor login path not sending `credentials: 'include'`.
+2. Session role check expecting `vendor` instead of `business_owner`.
+3. Treating `GET /api/vendor-onboarding/onboarding-data` **404** (normal for fresh vendors) as logout.
+
+---
+
+## Code audit evidence
+
+| File | Relevant behavior |
+|------|-------------------|
+| [`controllers/userController.js`](../controllers/userController.js) | `loginUser` lines 350–414 — no `role === 'business_owner'` branch |
+| [`utils/cookieHelper.js`](../utils/cookieHelper.js) | `setAuthCookies` — `token`, `user_session`, `user_gender` |
+| [`middlewares/authenticate.js`](../middlewares/authenticate.js) | Bearer or `cookies.token`; sessionVersion check only |
+| [`middlewares/requireVerifiedVendor.js`](../middlewares/requireVerifiedVendor.js) | Used on onboarding routes, not login/auth/check |
+| [`controllers/vendorOnboarding.controller.js`](../controllers/vendorOnboarding.controller.js) | `getOnboardingData` → **404** when no onboarding doc (expected pre-draft) |
+
+Unit tests added:
+
+- [`tests/auth/vendor-login-session.test.js`](../tests/auth/vendor-login-session.test.js) — verified vendor login 200 + cookies; unverified/blocked/deleted paths
+- [`tests/auth/cookie-helper-prod-options.test.js`](../tests/auth/cookie-helper-prod-options.test.js) — prod cookie flag defaults and empty-domain guard
+
+`npm test`: **212/212 PASS** (includes new tests).
+
+---
+
+## Production repro (redacted)
+
+Script: [`scripts/vendor-login-session-proof.ps1`](../scripts/vendor-login-session-proof.ps1)
+
+```powershell
+./scripts/vendor-login-session-proof.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -FrontendOrigin https://app.mosaicbizhub.com
+```
+
+### Public / unauth probes (2026-06-18)
+
+| Probe | HTTP | Result |
+|-------|------|--------|
+| CORS preflight `OPTIONS /api/users/login` from `https://app.mosaicbizhub.com` | 204 | **PASS** — ACAO exact origin, `Access-Control-Allow-Credentials: true` |
+| `GET /api/users/auth/check` (no cookie) | 401 | **PASS** — `{"success":false,"message":"Authentication required"}` |
+
+### Credentialed vendor login chain (2026-06-18)
+
+Run with session-only env vars (`SMOKE_TEST_VENDOR_EMAIL`, `SMOKE_TEST_VENDOR_PASSWORD`) — never commit credentials.
+
+| Probe | HTTP | Result |
+|-------|------|--------|
+| `POST /api/users/login` (verified vendor) | 200 | **PASS** — `success: true`, `user.role: business_owner`, `user.isOtpVerified: true` |
+| `Set-Cookie` attributes | — | **PASS** — `token` (HttpOnly, Secure, SameSite=None, Domain=.mosaicbizhub.com, Path=/), `user_session`, `user_gender` |
+| Cookie `GET /api/users/auth/check` | 200 | **PASS** — `loggedIn: true`, `user.role: business_owner` |
+| Cookie `GET /api/business/my` | 200 | **PASS** |
+| Cookie `GET /api/vendor-onboarding/onboarding-data` | 404 | **PASS** — expected for fresh vendor (no onboarding draft); **not an auth failure** |
+
+Cookie values and JWT bodies redacted in script output. Re-run:
+
+```powershell
+$env:SMOKE_TEST_VENDOR_EMAIL = '<session-only>'
+$env:SMOKE_TEST_VENDOR_PASSWORD = '<session-only>'
+./scripts/vendor-login-session-proof.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -FrontendOrigin https://app.mosaicbizhub.com
+```
+
+---
+
+## Backend change in this branch
+
+[`utils/cookieHelper.js`](../utils/cookieHelper.js) — defensive hardening only:
+
+- Omit `domain` when `COOKIE_DOMAIN` is empty/whitespace (avoids invalid `domain=` on EB misconfig)
+- Normalize `COOKIE_SAMESITE` to lowercase (`None` → `none`)
+
+No change to login vendor logic, CORS, or Stripe paths.
+
+---
+
+## Frontend handoff (credentialed prod proof **PASS**)
+
+Backend cookie/session chain verified against production API. Verify on `https://app.mosaicbizhub.com`:
+
+1. Vendor login uses `POST /api/users/login` with `credentials: 'include'`.
+2. Session role check uses **`business_owner`**, not `vendor`.
+3. `GET /api/vendor-onboarding/onboarding-data` **404** routes to onboarding wizard, not logout.
+4. `GET /api/users/auth/check` uses same credentialed fetch as customer dashboard.
+
+---
+
+## References
+
+- [`docs/AUTH_FLOW.md`](AUTH_FLOW.md)
+- [`docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md`](BACKEND_FRONTEND_ROUTE_CONTRACT.md)
+- [`docs/BACKEND_PRODUCTION_SMOKE_PROOF.md`](BACKEND_PRODUCTION_SMOKE_PROOF.md) — vendor login session section
+- [`docs/production-env-checklist.md`](production-env-checklist.md) — `COOKIE_*` env names

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -116,8 +116,22 @@ if ($env:SMOKE_TEST_VENDOR_TOKEN) {
     $hdr = @{ Authorization = (Get-AuthHeader $env:SMOKE_TEST_VENDOR_TOKEN) }
     $code = Get-StatusCode -Uri "$Base/api/users/auth/check" -Headers $hdr
     if ($code -eq 200) { Write-SmokePass "P2.3 vendor auth/check ($code)" } else { Write-SmokeFail "P2.3 vendor auth/check ($code)" }
+
+    $code = Get-StatusCode -Uri "$Base/api/business/my" -Headers $hdr
+    if ($code -eq 200) { Write-SmokePass "P2.5 vendor GET /api/business/my ($code)" } else { Write-SmokeFail "P2.5 vendor GET /api/business/my ($code, expected 200)" }
+
+    $code = Get-StatusCode -Uri "$Base/api/vendor-onboarding/onboarding-data" -Headers $hdr
+    if ($code -in 200, 404) {
+        Write-SmokePass "P2.6 vendor GET /api/vendor-onboarding/onboarding-data ($code, 404 OK for fresh vendor)"
+    } elseif ($code -eq 401) {
+        Write-SmokeFail "P2.6 vendor onboarding-data ($code, expected 200 or 404 — not 401)"
+    } else {
+        Write-SmokeFail "P2.6 vendor onboarding-data ($code, expected 200 or 404)"
+    }
 } else {
     Write-SmokeBlocked 'P2.3 vendor auth' 'SMOKE_TEST_VENDOR_TOKEN not set'
+    Write-SmokeBlocked 'P2.5 vendor business/my' 'SMOKE_TEST_VENDOR_TOKEN not set'
+    Write-SmokeBlocked 'P2.6 vendor onboarding-data' 'SMOKE_TEST_VENDOR_TOKEN not set'
 }
 
 if ($env:SMOKE_TEST_ADMIN_TOKEN) {

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -91,8 +91,20 @@ if [ -n "${SMOKE_TEST_VENDOR_TOKEN:-}" ]; then
   hdr=$(auth_header "$SMOKE_TEST_VENDOR_TOKEN")
   code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $hdr" "$BASE/api/users/auth/check")
   if [ "$code" = "200" ]; then pass "P2.3 vendor auth/check ($code)"; else fail "P2.3 vendor auth/check ($code)"; fi
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $hdr" "$BASE/api/business/my")
+  if [ "$code" = "200" ]; then pass "P2.5 vendor GET /api/business/my ($code)"; else fail "P2.5 vendor GET /api/business/my ($code, expected 200)"; fi
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $hdr" "$BASE/api/vendor-onboarding/onboarding-data")
+  if [ "$code" = "200" ] || [ "$code" = "404" ]; then
+    pass "P2.6 vendor GET /api/vendor-onboarding/onboarding-data ($code, 404 OK for fresh vendor)"
+  elif [ "$code" = "401" ]; then
+    fail "P2.6 vendor onboarding-data ($code, expected 200 or 404 — not 401)"
+  else
+    fail "P2.6 vendor onboarding-data ($code, expected 200 or 404)"
+  fi
 else
   blocked "P2.3 vendor auth" "SMOKE_TEST_VENDOR_TOKEN not set"
+  blocked "P2.5 vendor business/my" "SMOKE_TEST_VENDOR_TOKEN not set"
+  blocked "P2.6 vendor onboarding-data" "SMOKE_TEST_VENDOR_TOKEN not set"
 fi
 
 if [ -n "${SMOKE_TEST_ADMIN_TOKEN:-}" ]; then

--- a/scripts/vendor-login-session-proof.ps1
+++ b/scripts/vendor-login-session-proof.ps1
@@ -1,0 +1,227 @@
+# Vendor login session proof — credentialed cross-origin probe (no secrets in output).
+# Usage:
+#   $env:SMOKE_TEST_VENDOR_EMAIL = 'vendor-test@example.com'
+#   $env:SMOKE_TEST_VENDOR_PASSWORD = '<password>'
+#   ./scripts/vendor-login-session-proof.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+#
+# Optional: SMOKE_TEST_VENDOR_TOKEN for Bearer-only follow-up (skips login step).
+
+param(
+    [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "https://api.mosaicbizhub.com" }),
+    [string]$FrontendOrigin = $(if ($env:FRONTEND_ORIGIN) { $env:FRONTEND_ORIGIN } else { "https://app.mosaicbizhub.com" }),
+    [string]$VendorEmail = $env:SMOKE_TEST_VENDOR_EMAIL,
+    [string]$VendorPassword = $env:SMOKE_TEST_VENDOR_PASSWORD,
+    [string]$VendorToken = $env:SMOKE_TEST_VENDOR_TOKEN,
+    [string]$CookieJar = $(Join-Path $env:TEMP "mosaic-vendor-login-cookies.txt")
+)
+
+$ErrorActionPreference = 'Stop'
+$Base = $ApiBaseUrl.TrimEnd('/')
+
+function Write-Proof($status, $msg) {
+    $color = switch ($status) {
+        'PASS' { 'Green' }
+        'FAIL' { 'Red' }
+        'BLOCKED' { 'DarkYellow' }
+        'INFO' { 'Cyan' }
+        default { 'White' }
+    }
+    Write-Host "$status  $msg" -ForegroundColor $color
+}
+
+function Get-HttpResponse($Uri, $Method = 'GET', $Headers = @{}, $Body = $null, $WebSession = $null) {
+    try {
+        $params = @{
+            Uri             = $Uri
+            Method          = $Method
+            Headers         = $Headers
+            UseBasicParsing = $true
+            ErrorAction     = 'Stop'
+        }
+        if ($Body) {
+            $params.Body = $Body
+            $params.ContentType = 'application/json'
+        }
+        if ($WebSession) { $params.WebSession = $WebSession }
+        $r = Invoke-WebRequest @params
+        return @{ StatusCode = [int]$r.StatusCode; Response = $r; Error = $null }
+    } catch {
+        if ($_.Exception.Response) {
+            $resp = $_.Exception.Response
+            $reader = New-Object System.IO.StreamReader($resp.GetResponseStream())
+            $content = $reader.ReadToEnd()
+            $reader.Close()
+            return @{
+                StatusCode = [int]$resp.StatusCode.value__
+                Response   = @{ Content = $content; Headers = @{} }
+                Error      = $null
+            }
+        }
+        return @{ StatusCode = 0; Response = $null; Error = $_.Exception.Message }
+    }
+}
+
+function Redact-SetCookie($headerValue) {
+    if (-not $headerValue) { return '(none)' }
+    $parts = @()
+    foreach ($line in @($headerValue)) {
+        if ($line -match '^([^=]+)=([^;]+)(.*)$') {
+            $parts += "$($Matches[1])=<redacted>$($Matches[3])"
+        } else {
+            $parts += '<redacted>'
+        }
+    }
+    return ($parts -join '; ')
+}
+
+Write-Host "=== Vendor Login Session Proof ==="
+Write-Host "API=$Base Origin=$FrontendOrigin"
+Write-Host ""
+
+# P1: CORS preflight on login
+try {
+    $cors = Invoke-WebRequest -Uri "$Base/api/users/login" -Method OPTIONS `
+        -Headers @{
+            Origin = $FrontendOrigin
+            'Access-Control-Request-Method' = 'POST'
+            'Access-Control-Request-Headers' = 'content-type'
+        } -UseBasicParsing
+    $acao = $cors.Headers['Access-Control-Allow-Origin']
+    $acac = $cors.Headers['Access-Control-Allow-Credentials']
+    if ($cors.StatusCode -in 200, 204 -and $acao -eq $FrontendOrigin -and $acac -eq 'true') {
+        Write-Proof 'PASS' "CORS preflight POST /api/users/login ($($cors.StatusCode), ACAO=$FrontendOrigin, credentials=true)"
+    } else {
+        Write-Proof 'FAIL' "CORS preflight ($($cors.StatusCode), ACAO=$acao, credentials=$acac)"
+    }
+} catch {
+    Write-Proof 'FAIL' "CORS preflight - $($_.Exception.Message)"
+}
+
+# P2: Unauth auth/check baseline
+$anon = Get-HttpResponse -Uri "$Base/api/users/auth/check" -Headers @{ Origin = $FrontendOrigin }
+if ($anon.Error) {
+    Write-Proof 'FAIL' "Unauth auth/check - $($anon.Error)"
+} elseif ($anon.StatusCode -eq 401) {
+    Write-Proof 'PASS' "Unauth GET /api/users/auth/check (401)"
+} else {
+    Write-Proof 'FAIL' "Unauth auth/check ($($anon.StatusCode), expected 401)"
+}
+
+if (-not $VendorEmail -or -not $VendorPassword) {
+    if ($VendorToken) {
+        Write-Proof 'INFO' 'Login step skipped — using SMOKE_TEST_VENDOR_TOKEN for follow-up probes'
+    } else {
+        Write-Proof 'BLOCKED' 'Credentialed login — set SMOKE_TEST_VENDOR_EMAIL and SMOKE_TEST_VENDOR_PASSWORD (or SMOKE_TEST_VENDOR_TOKEN)'
+        exit 0
+    }
+}
+
+if ($VendorEmail -and $VendorPassword) {
+    if (Test-Path $CookieJar) { Remove-Item $CookieJar -Force }
+
+    $loginBody = @{ email = $VendorEmail; password = $VendorPassword } | ConvertTo-Json
+    try {
+        $login = Invoke-WebRequest -Uri "$Base/api/users/login" -Method POST `
+            -Headers @{ Origin = $FrontendOrigin; 'Content-Type' = 'application/json' } `
+            -Body $loginBody -SessionVariable 'session' -UseBasicParsing
+
+        $setCookie = $login.Headers['Set-Cookie']
+        $redactedCookies = Redact-SetCookie $setCookie
+        Write-Proof 'INFO' "POST /api/users/login HTTP $($login.StatusCode)"
+        Write-Proof 'INFO' "Set-Cookie: $redactedCookies"
+
+        if ($login.Content) {
+            $parsed = $login.Content | ConvertFrom-Json
+            $role = $parsed.user.role
+            $verified = $parsed.user.isOtpVerified
+            Write-Proof 'INFO' "Body: success=$($parsed.success) role=$role isOtpVerified=$verified (token redacted)"
+        }
+
+        if ($login.StatusCode -ne 200) {
+            Write-Proof 'FAIL' "Vendor login expected 200, got $($login.StatusCode)"
+            exit 1
+        }
+
+        if (-not $setCookie) {
+            Write-Proof 'FAIL' 'Login 200 but no Set-Cookie headers'
+            exit 1
+        }
+
+        $hasToken = ($setCookie -match 'token=')
+        $hasSession = ($setCookie -match 'user_session=')
+        if ($hasToken -and $hasSession) {
+            Write-Proof 'PASS' 'Set-Cookie includes token and user_session'
+        } else {
+            Write-Proof 'FAIL' 'Set-Cookie missing expected cookie names'
+        }
+
+        foreach ($flag in @('HttpOnly', 'Secure', 'SameSite=None', 'Domain=.mosaicbizhub.com', 'Path=/')) {
+            if ($setCookie -match [regex]::Escape($flag) -or ($flag -eq 'SameSite=None' -and $setCookie -match 'SameSite=None')) {
+                Write-Proof 'PASS' "Cookie attribute present: $flag"
+            } else {
+                Write-Proof 'FAIL' "Cookie attribute missing: $flag"
+            }
+        }
+
+        # Save cookies for curl-style follow-up
+        $session.Cookies.GetCookies([Uri]$Base) | ForEach-Object {
+            "$($_.Name)=<redacted>; domain=$($_.Domain); path=$($_.Path); secure=$($_.Secure); httponly=$($_.HttpOnly)"
+        } | Out-File -FilePath $CookieJar -Encoding utf8
+
+        $check = Invoke-WebRequest -Uri "$Base/api/users/auth/check" -Method GET `
+            -WebSession $session -Headers @{ Origin = $FrontendOrigin } -UseBasicParsing
+        if ($check.StatusCode -eq 200) {
+            $checkBody = $check.Content | ConvertFrom-Json
+            Write-Proof 'PASS' "Cookie auth/check 200 role=$($checkBody.user.role)"
+        } else {
+            Write-Proof 'FAIL' "Cookie auth/check $($check.StatusCode) (expected 200)"
+        }
+
+        $biz = Invoke-WebRequest -Uri "$Base/api/business/my" -Method GET `
+            -WebSession $session -Headers @{ Origin = $FrontendOrigin } -UseBasicParsing
+        if ($biz.StatusCode -eq 200) {
+            Write-Proof 'PASS' "GET /api/business/my 200"
+        } else {
+            Write-Proof 'FAIL' "GET /api/business/my $($biz.StatusCode) (expected 200)"
+        }
+
+        try {
+            $onb = Invoke-WebRequest -Uri "$Base/api/vendor-onboarding/onboarding-data" -Method GET `
+                -WebSession $session -Headers @{ Origin = $FrontendOrigin } -UseBasicParsing
+            $onbStatus = $onb.StatusCode
+        } catch {
+            if ($_.Exception.Response) {
+                $onbStatus = [int]$_.Exception.Response.StatusCode.value__
+            } else { throw }
+        }
+        if ($onbStatus -in 200, 404) {
+            Write-Proof 'PASS' "GET /api/vendor-onboarding/onboarding-data $onbStatus (404 expected for fresh vendor)"
+        } elseif ($onbStatus -eq 401) {
+            Write-Proof 'FAIL' 'onboarding-data returned 401 — session not sent or invalid'
+        } else {
+            Write-Proof 'INFO' "GET onboarding-data $onbStatus"
+        }
+    } catch {
+        Write-Proof 'FAIL' "Login probe failed: $($_.Exception.Message)"
+        exit 1
+    }
+} elseif ($VendorToken) {
+    $hdr = @{ Authorization = "Bearer $VendorToken"; Origin = $FrontendOrigin }
+    foreach ($pair in @(
+            @{ Name = 'auth/check'; Url = "$Base/api/users/auth/check"; Expect = @(200) },
+            @{ Name = 'business/my'; Url = "$Base/api/business/my"; Expect = @(200) },
+            @{ Name = 'onboarding-data'; Url = "$Base/api/vendor-onboarding/onboarding-data"; Expect = @(200, 404) }
+        )) {
+        $r = Get-HttpResponse -Uri $pair.Url -Headers $hdr
+        if ($r.Error) {
+            Write-Proof 'FAIL' "$($pair.Name) - $($r.Error)"
+            continue
+        }
+        $ok = @($pair.Expect) -contains $r.StatusCode
+        if ($ok) { Write-Proof 'PASS' "$($pair.Name) $($r.StatusCode)" }
+        else { Write-Proof 'FAIL' "$($pair.Name) $($r.StatusCode) (expected $($pair.Expect -join '/'))" }
+    }
+}
+
+Write-Host ''
+Write-Host '=== Proof complete (no secrets logged) ==='

--- a/tests/auth/cookie-helper-prod-options.test.js
+++ b/tests/auth/cookie-helper-prod-options.test.js
@@ -1,0 +1,108 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const cookieHelperPath = path.resolve(__dirname, '../../utils/cookieHelper.js');
+
+function loadCookieHelper(envOverrides = {}) {
+  const saved = {};
+  for (const key of [
+    'NODE_ENV',
+    'COOKIE_SECURE',
+    'COOKIE_SAMESITE',
+    'COOKIE_DOMAIN',
+  ]) {
+    saved[key] = process.env[key];
+    if (Object.prototype.hasOwnProperty.call(envOverrides, key)) {
+      if (envOverrides[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = envOverrides[key];
+      }
+    }
+  }
+
+  delete require.cache[cookieHelperPath];
+  const helper = require(cookieHelperPath);
+
+  for (const [key, value] of Object.entries(saved)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return helper;
+}
+
+test('getCookieOptions uses production defaults when NODE_ENV=production', () => {
+  const { getCookieOptions } = loadCookieHelper({
+    NODE_ENV: 'production',
+    COOKIE_SECURE: undefined,
+    COOKIE_SAMESITE: undefined,
+    COOKIE_DOMAIN: undefined,
+  });
+
+  const options = getCookieOptions(3600000);
+
+  assert.equal(options.httpOnly, true);
+  assert.equal(options.secure, true);
+  assert.equal(options.sameSite, 'none');
+  assert.equal(options.domain, '.mosaicbizhub.com');
+  assert.equal(options.path, '/');
+  assert.equal(options.maxAge, 3600000);
+});
+
+test('getCookieOptions honors explicit production env overrides', () => {
+  const { getCookieOptions } = loadCookieHelper({
+    NODE_ENV: 'production',
+    COOKIE_SECURE: 'true',
+    COOKIE_SAMESITE: 'none',
+    COOKIE_DOMAIN: '.mosaicbizhub.com',
+  });
+
+  const options = getCookieOptions(86400000);
+
+  assert.equal(options.secure, true);
+  assert.equal(options.sameSite, 'none');
+  assert.equal(options.domain, '.mosaicbizhub.com');
+});
+
+test('getCookieOptions omits domain when COOKIE_DOMAIN is empty string', () => {
+  const { getCookieOptions } = loadCookieHelper({
+    NODE_ENV: 'production',
+    COOKIE_DOMAIN: '   ',
+  });
+
+  const options = getCookieOptions(1000);
+
+  assert.equal('domain' in options, false);
+});
+
+test('getCookieOptions normalizes COOKIE_SAMESITE casing', () => {
+  const { getCookieOptions } = loadCookieHelper({
+    NODE_ENV: 'production',
+    COOKIE_SAMESITE: 'None',
+  });
+
+  const options = getCookieOptions(1000);
+
+  assert.equal(options.sameSite, 'none');
+});
+
+test('getCookieOptions allows non-httpOnly override for user_session cookie', () => {
+  const { getCookieOptions } = loadCookieHelper({
+    NODE_ENV: 'development',
+    COOKIE_SECURE: 'false',
+    COOKIE_SAMESITE: 'lax',
+    COOKIE_DOMAIN: undefined,
+  });
+
+  const options = getCookieOptions(1000, { httpOnly: false });
+
+  assert.equal(options.httpOnly, false);
+  assert.equal(options.secure, false);
+  assert.equal(options.sameSite, 'lax');
+  assert.equal('domain' in options, false);
+});

--- a/tests/auth/vendor-login-session.test.js
+++ b/tests/auth/vendor-login-session.test.js
@@ -1,0 +1,206 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const userControllerPath = path.resolve(__dirname, '../../controllers/userController.js');
+
+function withMocks(modulePath, mocks) {
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[modulePath];
+  const loadedModule = require(modulePath);
+  Module._load = originalLoad;
+
+  return loadedModule;
+}
+
+function createResponse() {
+  const res = {
+    statusCode: null,
+    body: null,
+    authCookies: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    cookie() {},
+  };
+  return res;
+}
+
+const verifiedVendor = {
+  _id: '507f1f77bcf86cd799439011',
+  email: 'vendor-login@example.com',
+  name: 'Vendor Login',
+  role: 'business_owner',
+  gender: 'other',
+  mobile: '+15551234567',
+  passwordHash: 'hashed-password',
+  isOtpVerified: true,
+  isDeleted: false,
+  isBlocked: false,
+  sessionVersion: 0,
+};
+
+function baseMocks(overrides = {}) {
+  let setAuthCookiesCalled = false;
+
+  const cookieHelper = {
+    getCookieOptions: () => ({}),
+    clearCookie: () => {},
+    setAuthCookies: (res, token, user, maxAge) => {
+      setAuthCookiesCalled = true;
+      res.authCookies = { token, userId: user._id.toString(), maxAge };
+    },
+    clearAuthCookies: () => {},
+    ...(overrides.cookieHelper || {}),
+  };
+
+  return {
+    mocks: {
+      '../models/User': {
+        findOne: async () => verifiedVendor,
+        ...(overrides.User || {}),
+      },
+      bcryptjs: {
+        hash: async (value) => `hashed:${value}`,
+        compare: async () => true,
+        ...(overrides.bcryptjs || {}),
+      },
+      'express-validator': {
+        validationResult: () => ({ isEmpty: () => true, array: () => [] }),
+      },
+      '../utils/mailer': {
+        sendOtpEmail: async () => {},
+        sendWelcomeEmail: async () => {},
+        sendPasswordResetOtpEmail: async () => {},
+      },
+      '../utils/cookieHelper': cookieHelper,
+      jsonwebtoken: {
+        sign: () => 'vendor-session-jwt',
+      },
+      ...overrides.extra,
+    },
+    cookieHelper,
+    getSetAuthCookiesCalled: () => setAuthCookiesCalled,
+  };
+}
+
+test('loginUser returns 200 and sets auth cookies for verified business_owner', async () => {
+  const { mocks } = baseMocks();
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: verifiedVendor.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.user.role, 'business_owner');
+  assert.equal(res.body.user.isOtpVerified, true);
+  assert.equal(res.authCookies.token, 'vendor-session-jwt');
+  assert.equal(res.body.token, 'vendor-session-jwt');
+});
+
+test('loginUser returns 403 otpPending when vendor is not OTP verified', async () => {
+  const { mocks } = baseMocks({
+    User: {
+      findOne: async () => ({
+        ...verifiedVendor,
+        isOtpVerified: false,
+        save: async function save() {
+          return this;
+        },
+      }),
+    },
+  });
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: verifiedVendor.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.otpPending, true);
+  assert.equal(res.body.user.role, 'business_owner');
+  assert.equal(res.authCookies, null);
+});
+
+test('loginUser returns 403 when vendor account is blocked', async () => {
+  const { mocks } = baseMocks({
+    User: {
+      findOne: async () => ({ ...verifiedVendor, isBlocked: true }),
+    },
+  });
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: verifiedVendor.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /blocked/i);
+});
+
+test('loginUser returns 403 when vendor account is deleted', async () => {
+  const { mocks } = baseMocks({
+    User: {
+      findOne: async () => ({ ...verifiedVendor, isDeleted: true }),
+    },
+  });
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: verifiedVendor.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.match(res.body.message, /deleted/i);
+});
+
+test('loginUser uses same session token shape as customer (sub claim via jwt.sign payload)', async () => {
+  let signedPayload = null;
+  const { mocks } = baseMocks({
+    extra: {
+      jsonwebtoken: {
+        sign: (payload) => {
+          signedPayload = payload;
+          return 'signed-token';
+        },
+      },
+    },
+  });
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: verifiedVendor.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(signedPayload.sub, verifiedVendor._id);
+  assert.equal(signedPayload.role, 'business_owner');
+  assert.equal(signedPayload.sessionVersion, 0);
+});

--- a/utils/cookieHelper.js
+++ b/utils/cookieHelper.js
@@ -5,20 +5,45 @@ function parseBooleanEnv(value, fallback) {
   return String(value).toLowerCase() === 'true';
 }
 
+function normalizeSameSite(value) {
+  if (value === undefined || value === null) return undefined;
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'none' || normalized === 'lax' || normalized === 'strict') {
+    return normalized;
+  }
+  return normalized;
+}
+
+function resolveCookieDomain() {
+  if (process.env.COOKIE_DOMAIN === undefined) {
+    return isProd ? '.mosaicbizhub.com' : undefined;
+  }
+
+  const trimmed = String(process.env.COOKIE_DOMAIN).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 const cookieSecure = parseBooleanEnv(process.env.COOKIE_SECURE, isProd);
-const cookieSameSite = process.env.COOKIE_SAMESITE || (cookieSecure ? 'none' : 'lax');
-const cookieDomain = process.env.COOKIE_DOMAIN || (isProd ? '.mosaicbizhub.com' : undefined);
+const cookieSameSite = normalizeSameSite(
+  process.env.COOKIE_SAMESITE || (cookieSecure ? 'none' : 'lax')
+);
+const cookieDomain = resolveCookieDomain();
 
 function getCookieOptions(maxAge, { httpOnly = true, ...overrides } = {}) {
-  return {
+  const options = {
     httpOnly,
     secure: cookieSecure,
     sameSite: cookieSameSite,
-    domain: cookieDomain,
     path: '/',
     maxAge,
     ...overrides,
   };
+
+  if (cookieDomain) {
+    options.domain = cookieDomain;
+  }
+
+  return options;
 }
 
 function setCookie(res, name, value, options = {}) {


### PR DESCRIPTION
## Summary
- Audit confirms backend login/cookies are role-agnostic; credentialed prod proof PASS for verified business_owner (login 200 + Set-Cookie + auth/check + business/my + onboarding-data 404).
- Harden cookieHelper: omit empty COOKIE_DOMAIN, normalize COOKIE_SAMESITE casing.
- Add vendor-login-session and cookie-helper-prod-options unit tests; vendor-login-session-proof.ps1 smoke harness; P2.5-P2.6 vendor smoke probes.

Closes #81 backend scope. Frontend handoff: Digital-Builders-757/mosaic-biz-frontend-launch#142, #143, #144.

## Test plan
- [x] npm test (212/212 PASS)
- [x] scripts/vendor-login-session-proof.ps1 against https://api.mosaicbizhub.com (credentialed chain PASS)
- [x] CORS preflight + unauth auth/check PASS
- [x] No Stripe/payment/CORS wildcard changes
- [x] Customer login and OTP paths unchanged

Made with [Cursor](https://cursor.com)