### PR TITLE
fix: remove unauthenticated admin products test route

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -438,7 +438,6 @@ Global `router.use(authenticate, isAdmin)` noted as **admin** below.
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/admin/api/products/test` | — | inline | ⚪ Public | Test endpoint | 🟢 |
 | GET | `/admin/api/products/` | `authenticate`, `isAdmin` | `getAllProducts` | admin | All products | 🟡 |
 | PATCH | `/admin/api/products/:productId/featured` | same | `toggleProductFeatured` | admin | Toggle featured | 🟡 |
 

--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -129,7 +129,8 @@ Mount: `/admin/api/products` → [`routes/admin/adminProductRoutes.js`](../route
 |-------|--------|------|------|-----------------|--------|-------|
 | `/admin/api/products` | GET | Yes | admin | Admin product list / featured mgmt | **valid** | Frontend suspect path confirmed |
 | `/admin/api/products/:productId/featured` | PATCH | Yes | admin | Toggle featured flag | **valid** | Sets `Product.isFeatured` for carousel |
-| `/admin/api/products/test` | GET | No | Public | — | **valid** | Debug-only; no auth — do not use in prod UI |
+
+**Removed (2026-06-19):** `GET /admin/api/products/test` — unauthenticated debug route removed in launch hardening fix.
 
 **Wrong prefix:** `GET /api/admin/products` is **missing**. Admin products live under `/admin/api/products`, not `/api/admin/products`.
 

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -14,9 +14,9 @@
 
 | Field | Value |
 | --- | --- |
-| Branch | `test/backend-launch-contract-smoke-guards` |
-| Commit SHA | `c074888` |
-| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
+| Branch | `fix/backend-guard-admin-products-test-route` |
+| Commit SHA | `728d059` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/96 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
 

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -1,0 +1,156 @@
+# Backend Launch Contract Verification
+
+**Purpose:** Automated and smoke-script proof that P0/P1 launch contracts from the merged as-built documentation pack are registered, guarded, and test-ready — without changing payment, auth, webhook, or middleware logic.
+
+**Branch:** `test/backend-launch-contract-smoke-guards` (verification); `fix/backend-guard-admin-products-test-route` (hardening fix)  
+**Evidence date:** 2026-06-19  
+**Baseline docs:** [BACKEND_ROUTE_REGISTRATION.md](BACKEND_ROUTE_REGISTRATION.md), [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md), [AUTH_CORS_COOKIE_AUDIT.md](AUTH_CORS_COOKIE_AUDIT.md), [STRIPE_PAYMENT_CONNECT_AUDIT.md](STRIPE_PAYMENT_CONNECT_AUDIT.md)
+
+**Related:** [BACKEND_P0_P1_RISK_REGISTER.md](BACKEND_P0_P1_RISK_REGISTER.md)
+
+---
+
+## PR metadata (fill on merge)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-launch-contract-smoke-guards` |
+| Commit SHA | `c074888` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |
+
+---
+
+## Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull origin main` | 0 | Fast-forward to docs pack on main |
+| `git checkout -b test/backend-launch-contract-smoke-guards` | 0 | Branch created |
+| `npm test` | 0 | **228 pass**, 0 fail |
+| `npm run test:contract` | 0 | **16 pass**, 0 fail |
+| `npm run smoke:backend` | **Not run** | Requires live API (`API_BASE_URL`); see smoke script extensions below |
+
+### Test summary
+
+```
+npm test → node --test tests/**/*.test.js
+ℹ tests 228
+ℹ pass 228
+ℹ fail 0
+
+npm run test:contract → node --test tests/launch/backend-launch-contract.test.js
+ℹ tests 16
+ℹ pass 16
+ℹ fail 0
+```
+
+**Delta from docs pack baseline:** +16 contract tests (212 → 228 total).
+
+---
+
+## P0/P1 contract matrix
+
+| ID | Contract | Evidence | Result | Type |
+| --- | --- | --- | --- | --- |
+| P0.1 | `GET /`, `GET /api/health`, `GET /api/ready` registered and public | `tests/launch/backend-launch-contract.test.js`, `tests/health/health-readiness.test.js` | **PASS** | static + unit |
+| P0.2 | Stripe webhooks mounted before `express.json()` | `tests/launch/backend-launch-contract.test.js`, `tests/stripe/stripe-webhook-routing-signature.test.js`, `tests/stripe/payment-route-protection.test.js` | **PASS** | static |
+| P0.3 | Log hygiene (no OTP in logs) | Existing auth tests | **Not in scope** | manual |
+| P0.4 | CORS preflight on featured-products | `scripts/smoke-backend.ps1` / `.sh` | **BLOCKED** (smoke not run) | smoke |
+| P1 featured | `GET /api/featured-products` canonical public endpoint | Contract test + `tests/marketplace/featured-products-response.test.js` + `tests/stripe/checkout-approval-paymentintent-safety.test.js` | **PASS** | static + unit |
+| P1 absent | `GET /api/products/featured` not registered | Contract test + checkout-approval test | **PASS** | static |
+| P1 business | `GET /api/business/my` requires `authenticate` + `isBusinessOwner` | Contract test | **PASS** | static |
+| P1 admin users | `/admin/users/*` requires admin auth | Contract test + `tests/admin/admin-users-response.test.js` | **PASS** | static + unit |
+| P1 admin products | `/admin/api/products/` list + featured PATCH require admin | Contract test | **PASS** | static |
+| P1 admin leak | Admin DTO strips sensitive fields; non-admin gets 403 | Contract test + admin-users-response | **PASS** | unit |
+| P1 orders | `POST /api/orders/initiate` requires customer auth | Contract test + `tests/stripe/order-initiate-connect.test.js` + smoke P4.2 | **PASS** (static); smoke **BLOCKED** | static + smoke |
+| P1 legacy payment | `POST /api/payments/create-payment-intent` guarded (legacy; canonical is `orders/initiate`) | Contract test + `tests/stripe/payment-route-protection.test.js` | **PASS** | static + unit |
+| P1 Connect | `/api/connect/:businessId/account-link` and `/status` guarded | Contract test | **PASS** | static |
+| P1 Stripe finance | `/stripe/account-session`, `/express-login-link`, `/account-balance`, `/last-payout` guarded | Contract test + payment-route-protection | **PASS** | static |
+| P3 admin smoke | Unauthenticated admin list returns 401 | Smoke P3.0, P3.1 | **BLOCKED** (smoke not run) | smoke |
+| P4 payment smoke | Unauthenticated legacy payment intent returns 401 | Smoke P4.3 | **BLOCKED** (smoke not run) | smoke |
+| P5 finance smoke | Unauthenticated `/stripe/account-balance` returns 401 | Smoke P5.0 | **BLOCKED** (smoke not run) | smoke |
+| P6 absent smoke | `GET /api/products/featured` returns 404 | Smoke P6.0 | **BLOCKED** (smoke not run) | smoke |
+
+---
+
+## Route inspection table (task-specific paths)
+
+| Path | Registered | Guarded | Notes |
+| --- | --- | --- | --- |
+| `/admin/users` | **Yes** | **Yes** — `router.use(authenticate, isAdmin)` | Mount: `app.js` → `routes/admin/userRoutes.js` |
+| `/admin/api/products` | **Yes** | **Yes** — per-route `authenticate, isAdmin` on `/` and `/:productId/featured` | Debug route `GET /admin/api/products/test` **removed** in `fix/backend-guard-admin-products-test-route` |
+| `/stripe/account-session` | **Yes** | **Yes** — `authenticate, isBusinessOwner` | Mounted at `/stripe`, not `/api/stripe` |
+| `/stripe/express-login-link` | **Yes** | **Yes** | same |
+| `/stripe/account-balance` | **Yes** | **Yes** | same |
+| `/stripe/last-payout` | **Yes** | **Yes** | same |
+| `/api/admin/users` | **No** | — | Use `/admin/users` |
+| `/api/stripe/account-session` | **No** | — | Finance routes live under `/stripe/*` |
+| `/api/orders/initiate` | **Yes** | **Yes** — `authenticate, isCustomer` | Canonical Connect checkout |
+| `/api/payments/create-payment-intent` | **Yes** | **Yes** — `authenticate, isCustomer` + rate limit | **Legacy**; canonical flow is `orders/initiate` |
+
+---
+
+## Files added or changed
+
+| File | Change |
+| --- | --- |
+| `tests/launch/backend-launch-contract.test.js` | **Added** — 16 launch contract tests |
+| `package.json` | **Added** `test:contract` script |
+| `scripts/smoke-backend.ps1` | **Extended** — P3.0, P3.1, P4.3, P5.0, P6.0 unauth checks |
+| `scripts/smoke-backend.sh` | **Extended** — parity with PowerShell script |
+| `docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md` | **Added** — this file |
+| `docs/backend/BACKEND_P0_P1_RISK_REGISTER.md` | **Added** — risk register |
+| `docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md` | **Updated** — this PR evidence |
+| `docs/README.md` | **Updated** — index links |
+
+---
+
+## What was NOT tested
+
+- Live Stripe PaymentIntent creation or charges
+- Webhook delivery with production signing secrets
+- AWS S3 uploads, SMTP email delivery
+- Elastic Beanstalk deploy
+- `npm run smoke:backend` against production or local running server (no server started in CI for this PR)
+- Authenticated admin HTTP response body audit (empty vs data when wrong role)
+- Full manual P0–P6 production smoke checklist
+- Frontend payment redirect URL behavior
+
+---
+
+## Evidence still needed externally
+
+| Item | Owner |
+| --- | --- |
+| Run extended smoke script against staging/production `API_BASE_URL` | QA / release owner |
+| Production EB env var audit (names only in EB) | AWS / release owner |
+| Stripe Dashboard webhook URLs for five endpoints | Stripe admin |
+| Production `CORS_ORIGINS` value confirmation | AWS EB + frontend |
+| Frontend path audit: `/api/admin/users`, `/api/stripe/account-session` | Frontend team |
+| Whether frontend still calls legacy `POST /api/payments/create-payment-intent` | Frontend team |
+| Go/No-Go launch sign-off | Product / release owner |
+
+---
+
+## Admin products test route fix (2026-06-19)
+
+| Field | Decision |
+| --- | --- |
+| Route | `GET /admin/api/products/test` |
+| Finding | Public debug endpoint; not referenced by smoke scripts, frontend contract, or production UI |
+| Fix | **Removed** from `routes/admin/adminProductRoutes.js` |
+| Tests | `tests/admin/admin-product-routes-guard.test.js`; launch contract test updated |
+| Branch | `fix/backend-guard-admin-products-test-route` |
+
+---
+
+## Recommended next PR (requires approval)
+
+| Item | Severity | Action |
+| --- | --- | --- |
+| Stale frontend paths `/api/admin/users`, `/api/stripe/*` | Medium | Frontend contract diff only — **no backend aliases without approval** |
+| Legacy `create-payment-intent` overlap | Medium | Document deprecation; migrate frontend to `orders/initiate` — **no payment logic change without approval** |
+
+**No payment, webhook, auth, CORS, cookie, middleware-order, schema, deploy, or route-alias changes were made in this PR.**

--- a/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
+++ b/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
@@ -1,0 +1,89 @@
+# Backend P0/P1 Risk Register
+
+**Purpose:** Track launch-blocking and high-priority risks against P0/P1 contracts, with verification status from [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md).
+
+**Evidence date:** 2026-06-19  
+**Branch:** `test/backend-launch-contract-smoke-guards`  
+**Smoke tiers reference:** [production-smoke-checklist.md](../production-smoke-checklist.md)
+
+---
+
+## P0 risks (infrastructure / critical wiring)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P0-R1 | API unreachable after deploy | Static: root + health mounts; smoke script covers `GET /`, `/api/health`, `/api/ready` | EB boot logs, deploy SHA confirmation still manual | Release |
+| P0-R2 | Stripe webhook signature broken by middleware order | **Verified** — static tests assert webhooks before `express.json()` | Dashboard delivery + live sig still manual (P4 tier) | Backend + Stripe admin |
+| P0-R3 | OTP or secrets in application logs | Not tested in this PR | Manual P0.3 after auth smoke | QA |
+| P0-R4 | Wrong featured endpoint breaks marketplace home | **Verified** — canonical `/api/featured-products`; `/api/products/featured` absent | Frontend must not call stale path | Frontend |
+
+---
+
+## P1 risks (auth guards / protected routes)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P1-R1 | Unauthenticated access to vendor business data | **Verified** — `GET /api/business/my` static guard | HTTP 401 smoke needs live API + vendor token | QA |
+| P1-R2 | Unauthenticated admin user/product enumeration | **Verified** — static guards + `isAdmin` unit test; smoke adds unauth 401 checks | Response body when unauth (401 vs empty 200) needs live smoke | QA |
+| P1-R3 | Customer checkout without auth | **Verified** — `POST /api/orders/initiate` static + existing controller tests | Live 401 smoke blocked until API up | QA |
+| P1-R4 | Legacy payment intent abused | **Verified** — static guard + ownership 403 in payment-route-protection | Frontend may still hit legacy route | Frontend |
+| P1-R5 | Vendor Stripe finance routes exposed | **Verified** — `/stripe/*` static guards | Live 401 smoke blocked until API up | QA |
+| P1-R6 | Connect onboarding link/status exposed | **Verified** — connectRoutes static guards | Live vendor-token smoke blocked | QA |
+| P1-R7 | Admin list leaks password/OTP fields | **Verified** — `toAdminUser` allowlist unit test | Full HTTP admin list audit with token | QA |
+| P1-R8 | Stale frontend paths 404 in production | **Documented** — `/api/admin/users`, `/api/stripe/account-session` absent | Frontend must use `/admin/users`, `/stripe/*` | Frontend |
+
+---
+
+## Resolved gaps
+
+| Gap | Location | Resolution | Branch |
+| --- | --- | --- | --- |
+| Unguarded admin products test route | `GET /admin/api/products/test` | **Removed** — debug-only route not used in prod UI or smoke | `fix/backend-guard-admin-products-test-route` |
+
+---
+
+## Known gaps (document only)
+
+| Gap | Location | Severity | Recommended follow-up |
+| --- | --- | --- | --- |
+| Public admin category routes | `GET /api/admin/categories` (see API_SURFACE) | Medium | Separate audit PR — **approval required** |
+| Legacy payment route overlap | `/api/payments/create-payment-intent` vs `/api/orders/initiate` | Medium | Frontend migration plan — **no payment logic change without approval** |
+| No global 404 handler | Express default for unknown routes | Low | Document only; alias PRs **not approved** |
+| Inconsistent error response shapes | Various controllers | Low | Contract normalization deferred |
+
+---
+
+## Stop-for-approval gates
+
+Do **not** proceed without explicit approval for:
+
+- Changing payment logic (checkout, PaymentIntent, Connect charges)
+- Changing webhook handlers or signing behavior
+- Changing auth, CORS, or cookie behavior
+- Adding route aliases (e.g. `/api/products/featured`, `/api/admin/users`)
+- Deleting or reordering routes or middleware
+- Changing database schemas
+- Deploying to EB or production
+
+---
+
+## Verification summary
+
+| Category | Count |
+| --- | --- |
+| P0 contracts verified (repo-local) | 2 of 3 (P0.3 manual) |
+| P1 contracts verified (repo-local) | 10+ static/unit |
+| Smoke extensions added | 5 unauth checks (blocked until live API) |
+| New automated tests | 16 |
+| Business logic changes | **0** |
+
+---
+
+## External evidence checklist
+
+- [ ] Run `npm run smoke:backend` with `API_BASE_URL` set (no secrets printed)
+- [ ] Confirm Stripe Dashboard has five webhook endpoints with correct env secret names
+- [ ] Confirm EB production env has required env var **names** (values in EB only)
+- [ ] Frontend contract diff against [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md)
+- [ ] Full P1–P6 manual smoke with test accounts
+- [ ] Release owner Go/No-Go sign-off

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test tests/**/*.test.js",
+    "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"

--- a/routes/admin/adminProductRoutes.js
+++ b/routes/admin/adminProductRoutes.js
@@ -5,11 +5,6 @@ const isAdmin = require('../../middlewares/isAdmin');
 
 const router = express.Router();
 
-// Test route
-router.get('/test', (req, res) => {
-  res.json({ message: 'Admin product routes working' });
-});
-
 // Get all products (admin only)
 router.get('/', authenticate, isAdmin, getAllProducts);
 

--- a/tests/admin/admin-product-routes-guard.test.js
+++ b/tests/admin/admin-product-routes-guard.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const adminProductRoutesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminProductRoutes.js'
+);
+
+test('admin product routes do not expose unauthenticated /test debug endpoint', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+
+  assert.ok(!source.includes("router.get('/test'"), 'debug /test route must be removed');
+  assert.ok(!source.includes('Admin product routes working'));
+});
+
+test('admin product list and featured toggle remain guarded', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+});
+
+test('admin product routes only register guarded handlers', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+  const routeMatches = [...source.matchAll(/router\.(get|post|put|patch|delete)\(/g)];
+
+  assert.equal(routeMatches.length, 2, 'expected only list and featured-toggle routes');
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -1,0 +1,245 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const root = path.resolve(__dirname, '../..');
+const appPath = path.join(root, 'app.js');
+const featuredRoutesPath = path.join(root, 'routes/featuredProductRoutes.js');
+const businessRoutesPath = path.join(root, 'routes/businessRoutes.js');
+const adminUserRoutesPath = path.join(root, 'routes/admin/userRoutes.js');
+const adminProductRoutesPath = path.join(root, 'routes/admin/adminProductRoutes.js');
+const orderRoutesPath = path.join(root, 'routes/orderRoutes.js');
+const paymentRoutesPath = path.join(root, 'routes/paymentRoutes.js');
+const connectRoutesPath = path.join(root, 'routes/connectRoutes.js');
+const stripeFinanceRoutesPath = path.join(root, 'routes/stripe.routes.js');
+const healthRoutesPath = path.join(root, 'routes/healthRoutes.js');
+const isAdminPath = path.join(root, 'middlewares/isAdmin.js');
+const toAdminUserPath = path.join(root, 'utils/toAdminUser.js');
+
+function readSource(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('app.js mounts launch-critical route prefixes', () => {
+  const source = readSource(appPath);
+
+  const mounts = [
+    "app.use('/api', healthRoutes)",
+    "app.use('/api/business', businessRoutes)",
+    "app.use('/admin/users', adminUserRoutes)",
+    "app.use('/admin/api/products', adminProductRoutes)",
+    "app.use('/api/payments', paymentRoutes)",
+    "app.use('/api/orders', orderRoutes)",
+    "app.use('/api/connect', connectRoutes)",
+    "app.use('/stripe', stripeNewRoutes)",
+    "app.use('/api', featuredProductRoutes)",
+  ];
+
+  for (const mount of mounts) {
+    assert.ok(source.includes(mount), `expected mount: ${mount}`);
+  }
+});
+
+test('GET /api/featured-products is canonical and /api/products/featured is absent', () => {
+  const featuredSource = readSource(featuredRoutesPath);
+  const appSource = readSource(appPath);
+
+  assert.ok(featuredSource.includes("router.get('/featured-products'"));
+  assert.ok(!featuredSource.includes('/products/featured'));
+  assert.ok(!appSource.includes('/api/products/featured'));
+  assert.ok(!appSource.includes('/products/featured'));
+});
+
+test('stale frontend alias paths are not registered', () => {
+  const appSource = readSource(appPath);
+  const routesDir = path.join(root, 'routes');
+  const routeFiles = fs
+    .readdirSync(routesDir, { recursive: true })
+    .filter((file) => typeof file === 'string' && file.endsWith('.js'))
+    .map((file) => readSource(path.join(routesDir, file)));
+
+  assert.ok(!appSource.includes("app.use('/api/admin/users'"));
+  assert.ok(!appSource.includes("app.use('/api/stripe/account-session'"));
+
+  for (const source of routeFiles) {
+    assert.ok(!source.includes('/api/admin/users'), 'route file must not define /api/admin/users');
+    assert.ok(
+      !source.includes("router.post('/api/stripe/account-session'"),
+      'route file must not define /api/stripe/account-session'
+    );
+  }
+});
+
+test('GET /api/business/my requires authenticate and business_owner role', () => {
+  const source = readSource(businessRoutesPath);
+  const myBlock = source.slice(source.indexOf("'/my'"));
+
+  assert.ok(myBlock.includes('authenticate'));
+  assert.ok(myBlock.includes('isBusinessOwner'));
+  assert.ok(myBlock.indexOf('authenticate') < myBlock.indexOf('getMyBusinesses'));
+});
+
+test('admin user routes apply router-level authenticate and isAdmin', () => {
+  const source = readSource(adminUserRoutesPath);
+
+  assert.match(source, /router\.use\(authenticate,\s*isAdmin\)/);
+});
+
+test('admin product list and featured toggle require authenticate and isAdmin', () => {
+  const source = readSource(adminProductRoutesPath);
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+  assert.ok(!source.includes("router.get('/test'"), 'unguarded debug /test route must not exist');
+});
+
+test('isAdmin rejects non-admin users with 403', async () => {
+  const isAdmin = require(isAdminPath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await isAdmin({ user: { role: 'customer' } }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+});
+
+test('toAdminUser strips sensitive fields from admin list responses', () => {
+  const toAdminUser = require(toAdminUserPath);
+  const sanitized = toAdminUser({
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    role: 'admin',
+    passwordHash: 'secret-hash',
+    otp: '123456',
+    sessionVersion: 3,
+  });
+
+  assert.equal(sanitized.passwordHash, undefined);
+  assert.equal(sanitized.otp, undefined);
+  assert.equal(sanitized.sessionVersion, undefined);
+  assert.equal(sanitized.email, 'admin@example.com');
+});
+
+test('POST /api/orders/initiate requires authenticate and customer role', () => {
+  const source = readSource(orderRoutesPath);
+  assert.match(source, /router\.post\('\/initiate', authenticate, isCustomer, initiateOrder\)/);
+});
+
+// Legacy route: canonical checkout is POST /api/orders/initiate (Connect destination charge).
+test('POST /api/payments/create-payment-intent is legacy but guarded', () => {
+  const source = readSource(paymentRoutesPath);
+  const routeBlock = source.slice(source.indexOf("'/create-payment-intent'"));
+
+  assert.ok(routeBlock.includes('authenticate'));
+  assert.ok(routeBlock.includes('isCustomer'));
+  assert.ok(routeBlock.includes('paymentLimiter'));
+  assert.ok(routeBlock.indexOf('authenticate') < routeBlock.indexOf('createPaymentIntent'));
+});
+
+test('app.js keeps Stripe webhook raw-body mounts before express.json', () => {
+  const source = readSource(appPath);
+  const jsonIndex = source.indexOf('app.use(express.json');
+  const mounts = [
+    "app.use('/api/stripe'",
+    "app.use('/api/webhooks'",
+    "app.use('/api/vendor-onboarding/webhook/payment'",
+    "app.use('/api/subscription/webhook'",
+  ];
+
+  assert.ok(jsonIndex > -1, 'express.json middleware must exist in app.js');
+  for (const mount of mounts) {
+    const mountIndex = source.indexOf(mount);
+    assert.ok(mountIndex > -1 && mountIndex < jsonIndex, `${mount} must appear before express.json`);
+  }
+});
+
+test('Connect account-link and status routes require business_owner auth', () => {
+  const source = readSource(connectRoutesPath);
+
+  assert.match(
+    source,
+    /router\.post\('\/:businessId\/account-link', authenticate, isBusinessOwner, createAccountLink\)/
+  );
+  assert.match(
+    source,
+    /router\.get\('\/:businessId\/status', authenticate, isBusinessOwner, getStatus\)/
+  );
+});
+
+test('Stripe finance routes under /stripe require business_owner auth', () => {
+  const source = readSource(stripeFinanceRoutesPath);
+
+  assert.match(source, /router\.post\('\/account-session', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.post\('\/express-login-link', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/account-balance', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/last-payout', authenticate, isBusinessOwner/);
+});
+
+test('health routes are mounted under /api with /health and /ready handlers', () => {
+  const appSource = readSource(appPath);
+  const healthSource = readSource(healthRoutesPath);
+
+  assert.ok(appSource.includes("app.use('/api', healthRoutes)"));
+  assert.ok(healthSource.includes("router.get('/health'"));
+  assert.ok(healthSource.includes("router.get('/ready'"));
+});
+
+test('app.js defines public GET / root handler', () => {
+  const source = readSource(appPath);
+  assert.match(source, /app\.get\('\/',\s*\(req,\s*res\)\s*=>\s*\{/);
+});
+
+test('documented launch paths resolve to expected registration status', () => {
+  const appSource = readSource(appPath);
+  const stripeFinanceSource = readSource(stripeFinanceRoutesPath);
+
+  const expectedPresent = [
+    { label: '/admin/users', needle: "app.use('/admin/users'" },
+    { label: '/admin/api/products', needle: "app.use('/admin/api/products'" },
+    { label: '/api/orders/initiate', needle: "app.use('/api/orders'" },
+    { label: '/api/payments/create-payment-intent', needle: "app.use('/api/payments'" },
+    { label: '/stripe/account-session', needle: "router.post('/account-session'" },
+    { label: '/stripe/express-login-link', needle: "router.post('/express-login-link'" },
+    { label: '/stripe/account-balance', needle: "router.get('/account-balance'" },
+    { label: '/stripe/last-payout', needle: "router.get('/last-payout'" },
+  ];
+
+  for (const entry of expectedPresent) {
+    const haystack = entry.label.startsWith('/stripe/') ? stripeFinanceSource : appSource;
+    assert.ok(haystack.includes(entry.needle), `${entry.label} should be registered`);
+  }
+
+  const expectedAbsent = [
+    "app.use('/api/admin/users'",
+    "app.use('/api/stripe/account-session'",
+    '/api/products/featured',
+  ];
+
+  for (const needle of expectedAbsent) {
+    assert.ok(!appSource.includes(needle), `${needle} should not be registered`);
+  }
+});


### PR DESCRIPTION
## Summary
- **Removed** debug-only `GET /admin/api/products/test` (unused; not referenced by smoke, frontend, or prod UI)
- Added `tests/admin/admin-product-routes-guard.test.js` (+3 tests)
- Updated launch contract verification and risk register docs
- Includes launch contract test suite from #95 with admin-products assertion
- **No** payment, webhook, auth, CORS, cookie, or middleware changes

## Decision
Route was debug-only returning `{ message: 'Admin product routes working' }`. Safest minimal fix: **remove** rather than guard.

## Test results
- `npm test`: 231 pass, 0 fail
- `npm run test:contract`: 16 pass, 0 fail

## Remaining risk
- `GET /api/admin/categories` may still be public (separate audit)
- Live HTTP smoke not run

## Test plan
- [x] `npm test`
- [x] `npm run test:contract`
- [ ] `npm run smoke:backend` (QA with `API_BASE_URL`)