### PR TITLE
release: consolidate launch contract, admin guard, and vendor smoke proof

### DIFF
--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -438,7 +438,6 @@ Global `router.use(authenticate, isAdmin)` noted as **admin** below.
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/admin/api/products/test` | — | inline | ⚪ Public | Test endpoint | 🟢 |
 | GET | `/admin/api/products/` | `authenticate`, `isAdmin` | `getAllProducts` | admin | All products | 🟡 |
 | PATCH | `/admin/api/products/:productId/featured` | same | `toggleProductFeatured` | admin | Toggle featured | 🟡 |
 

--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -129,7 +129,8 @@ Mount: `/admin/api/products` → [`routes/admin/adminProductRoutes.js`](../route
 |-------|--------|------|------|-----------------|--------|-------|
 | `/admin/api/products` | GET | Yes | admin | Admin product list / featured mgmt | **valid** | Frontend suspect path confirmed |
 | `/admin/api/products/:productId/featured` | PATCH | Yes | admin | Toggle featured flag | **valid** | Sets `Product.isFeatured` for carousel |
-| `/admin/api/products/test` | GET | No | Public | — | **valid** | Debug-only; no auth — do not use in prod UI |
+
+**Removed (2026-06-19):** `GET /admin/api/products/test` — unauthenticated debug route removed in launch hardening fix.
 
 **Wrong prefix:** `GET /api/admin/products` is **missing**. Admin products live under `/admin/api/products`, not `/api/admin/products`.
 

--- a/docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md
+++ b/docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md
@@ -1,0 +1,213 @@
+# Backend Vendor Auth & Production Smoke Proof
+
+**Purpose:** Launch gate evidence for vendor session persistence and production HTTP smoke — audit-first, no auth/payment logic changes.
+
+**Branch:** `qa/backend-vendor-auth-smoke-proof`  
+**Evidence date:** 2026-06-19  
+**Production API:** `https://api.mosaicbizhub.com`  
+**Main SHA at audit:** `5180b2b`  
+**Related:** [VENDOR_LOGIN_SESSION_AUDIT.md](VENDOR_LOGIN_SESSION_AUDIT.md), [BACKEND_PRODUCTION_SMOKE_PROOF.md](BACKEND_PRODUCTION_SMOKE_PROOF.md), PR [#96](https://github.com/Techware-Hut/mosaic-backend/pull/96)
+
+No secrets, JWTs, cookies, OTPs, passwords, or env values in this document.
+
+---
+
+## PR metadata (fill on merge)
+
+| Field | Value |
+| --- | --- |
+| Branch | `qa/backend-vendor-auth-smoke-proof` |
+| Commit SHA | *(filled at commit time)* |
+| PR link | *(filled when PR opened)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |
+
+---
+
+## PR #96 audit (`fix/backend-guard-admin-products-test-route`)
+
+| Field | Value |
+| --- | --- |
+| State | **OPEN** (mergeable) |
+| URL | https://github.com/Techware-Hut/mosaic-backend/pull/96 |
+| `GET /admin/api/products/test` on `main` (`5180b2b`) | **Present** — unguarded debug route |
+| On PR #96 branch | **Removed** |
+| Production smoke (2026-06-19) | **200** unauth — confirms route live on deployed main |
+
+**Merge before final smoke?** **Recommended yes** — independent hardening, no vendor-auth impact. **Not a blocker** for vendor session diagnosis.
+
+---
+
+## Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull origin main` | 0 | Up to date at `5180b2b` |
+| `git checkout -b qa/backend-vendor-auth-smoke-proof` | 0 | Branch created |
+| `npm test` | 0 | **231 pass**, 0 fail |
+| `npm run test:contract` | 0 | **16 pass**, 0 fail |
+| `node -c app.js` | 0 | **PASS** |
+| `./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com` | 0 | **PASS=14 FAIL=0 SKIP=1 BLOCKED=5** |
+| `./scripts/vendor-login-session-proof.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -FrontendOrigin https://app.mosaicbizhub.com` | 0 | Public tier PASS; credentialed **BLOCKED** (no test credentials in session) |
+
+---
+
+## Production pass/fail matrix
+
+| ID | Probe | Expected | Result | Owner if fail |
+| --- | --- | --- | --- | --- |
+| P0.1 | `GET /` | 200 | **PASS** | Backend / deploy |
+| P0.2 | `GET /api/health` | 200 | **PASS** | Backend / deploy |
+| P0.3 | `GET /api/ready` | 200 | **PASS** | Backend / Mongo |
+| P1 | `GET /api/featured-products` | 200 | **PASS** | Backend |
+| P0.4a | CORS OPTIONS from `https://app.mosaicbizhub.com` | 204 + exact ACAO + credentials | **PASS** | Backend CORS env |
+| P0.4b | CORS OPTIONS from `https://mosaic-biz-frontend-launch.vercel.app` | 204 + exact ACAO + credentials | **PASS** | Backend CORS env |
+| P2.1 | Unauth `GET /api/users/auth/check` | 401 | **PASS** | Backend |
+| P4.2 | Unauth `POST /api/orders/initiate` | 401 | **PASS** | Backend |
+| NOTE | Unauth `GET /api/admin/categories` | 200 (current main) | **PASS (NOTE)** | Hardening backlog — not P0 vendor blocker |
+| NOTE | Unauth `GET /admin/api/products/test` | 200 on main / 404 after PR #96 | **PASS (NOTE)** — 200 on production | Merge PR #96 |
+| V1 | CORS preflight `POST /api/users/login` from app origin | 204 + credentials | **PASS** | Backend CORS |
+| V2 | Credentialed vendor login + cookie chain | 200 + Set-Cookie + auth/check 200 | **BLOCKED** | Release owner — set `SMOKE_TEST_VENDOR_EMAIL` / `SMOKE_TEST_VENDOR_PASSWORD` |
+| V3 | Bearer `SMOKE_TEST_VENDOR_TOKEN` smoke (P2.3–P2.6) | 200 on auth/check, business/my | **BLOCKED** | Release owner — set token env var |
+
+**Prior credentialed production proof (2026-06-18):** [VENDOR_LOGIN_SESSION_AUDIT.md](VENDOR_LOGIN_SESSION_AUDIT.md) — **PASS** for verified vendor cookie chain against production API.
+
+---
+
+## Live smoke commands (safe, no payment)
+
+### Public production smoke (no secrets)
+
+```powershell
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+```
+
+Probes both CORS origins (`app.mosaicbizhub.com` and launch Vercel URL), health, featured-products, admin categories NOTE, admin products test NOTE.
+
+### Credentialed vendor cookie chain (session-only env vars — never commit)
+
+```powershell
+$env:SMOKE_TEST_VENDOR_EMAIL = '<session-only>'
+$env:SMOKE_TEST_VENDOR_PASSWORD = '<session-only>'
+./scripts/vendor-login-session-proof.ps1 `
+  -ApiBaseUrl https://api.mosaicbizhub.com `
+  -FrontendOrigin https://app.mosaicbizhub.com
+```
+
+### Bearer vendor smoke (secondary — does not prove browser cookies)
+
+```powershell
+$env:SMOKE_TEST_VENDOR_TOKEN = '<session-only-jwt>'
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -VendorToken $env:SMOKE_TEST_VENDOR_TOKEN
+```
+
+See [SMOKE_TEST_TOKENS.md](SMOKE_TEST_TOKENS.md).
+
+---
+
+## Vendor auth decision tree
+
+```mermaid
+flowchart TD
+  start[Vendor login attempt] --> loginStatus{POST login status}
+  loginStatus -->|400/401| badCreds[Backend: invalid credentials OR frontend wrong payload]
+  loginStatus -->|403 otpPending| otpState[Test account: OTP not verified]
+  loginStatus -->|200| cookieCheck{Set-Cookie present?}
+  cookieCheck -->|No| cookieMissing[Backend cookie emit OR proxy stripping Set-Cookie]
+  cookieCheck -->|Yes| authCheck{Cookie auth/check}
+  authCheck -->|401| cookieNotSent[Frontend: missing credentials include OR wrong domain/SameSite]
+  authCheck -->|200| vendorRoutes{Vendor endpoints}
+  vendorRoutes -->|401/403| roleOrGuard[Backend guard OR stale JWT OR sessionVersion mismatch]
+  vendorRoutes -->|200/404| uiRedirect{UI still redirects?}
+  uiRedirect -->|Yes| frontendBug[Frontend: role vendor vs business_owner OR 404 treated as logout]
+  uiRedirect -->|No| passGate[Session OK]
+  loginStatus -->|Network/CORS error| corsEnv[Environment: CORS_ORIGINS or browser block]
+```
+
+### Failure ownership guide
+
+| Symptom | Likely owner |
+| --- | --- |
+| Login 400/401 | Backend credentials validation **or** frontend payload |
+| Login 403 `otpPending` | Test account state (OTP not verified) |
+| Login 200, no Set-Cookie | Backend cookie config **or** proxy |
+| auth/check 200, UI redirects | **Frontend** — role string or route guard |
+| auth/check 200, vendor routes 401/403 | Backend guard **or** stale token |
+| onboarding-data 404 after auth/check 200 | **Expected** for fresh vendor — frontend must not treat as logout |
+| Browser CORS/network error | **Environment** — CORS_ORIGINS, mixed content, ad blockers |
+
+---
+
+## `GET /api/admin/categories` audit
+
+| Question | Answer |
+| --- | --- |
+| Registered? | **Yes** — [routes/categoryRoutes.js](../routes/categoryRoutes.js) L30 |
+| Auth middleware? | **No** — public |
+| Production unauth HTTP | **200** (confirmed 2026-06-19) |
+| Response content | Category taxonomy only — no user PII |
+| P0 vendor session blocker? | **No** |
+| Launch blocker? | **Medium** admin hardening backlog |
+| Recommended follow-up | Separate guard PR — **stop for approval** |
+
+Static test: [tests/admin/admin-categories-guard.test.js](../tests/admin/admin-categories-guard.test.js)
+
+---
+
+## Backend diagnosis: vendor session persistence
+
+| Finding | Detail |
+| --- | --- |
+| Backend login path | **Role-agnostic** — same `loginUser` + `setAuthCookies` for `business_owner` and `customer` |
+| Unit tests | [tests/auth/vendor-login-session.test.js](../tests/auth/vendor-login-session.test.js) — verified vendor login 200 + cookies |
+| Production public smoke (this gate) | **PASS** — API reachable, CORS OK, unauth guards OK |
+| Production credentialed smoke (this gate) | **BLOCKED** — no test credentials in CI session |
+| Prior production credentialed proof | **PASS** (2026-06-18) — see [VENDOR_LOGIN_SESSION_AUDIT.md](VENDOR_LOGIN_SESSION_AUDIT.md) |
+
+**Verdict:** No backend regression identified in this gate. Public production probes pass. Prior credentialed cookie-chain proof passed. **Frontend P0 vendor UI redirect failure remains owned by frontend** unless a fresh credentialed re-run fails:
+
+1. Vendor login must use `credentials: 'include'`
+2. Role check must accept **`business_owner`**, not `vendor`
+3. `GET /api/vendor-onboarding/onboarding-data` **404** is normal for fresh vendors — not logout
+
+---
+
+## Files changed (this PR)
+
+| File | Change |
+| --- | --- |
+| `docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md` | **Added** — this document |
+| `scripts/smoke-backend.ps1` | Dual CORS origins + admin categories/products NOTE probes |
+| `scripts/smoke-backend.sh` | Parity with PowerShell |
+| `tests/admin/admin-categories-guard.test.js` | **Added** — documents public admin categories route |
+| `tests/admin/admin-product-routes-guard.test.js` | **Added** — audit tests for main state pending PR #96 |
+| `tests/launch/backend-launch-contract.test.js` | Contract suite (from open PR #95) |
+| `package.json` | `test:contract` script |
+| `docs/README.md` | Index link |
+
+---
+
+## What was NOT tested
+
+- Credentialed vendor login in this session (credentials not available)
+- Live Stripe payments, webhooks, Connect charges
+- Browser DevTools UI flow on `https://app.mosaicbizhub.com`
+- Full OTP register → verify → login end-to-end
+- EB boot logs and deploy SHA confirmation on production
+
+---
+
+## Rollback notes
+
+This PR is **docs + smoke script extensions + audit tests only**. No auth, cookie, CORS, payment, webhook, or middleware logic changed.
+
+Rollback: revert this branch commit. Smoke script changes are additive NOTE rows and dual-origin CORS loop — safe to revert independently.
+
+---
+
+## Recommended next steps
+
+1. **Merge PR #96** — remove debug admin products test route from production
+2. **Re-run credentialed vendor proof** with release-owner test account env vars
+3. **Frontend** — verify `business_owner` role and `credentials: 'include'` on app.mosaicbizhub.com ([#142–#144](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/142))
+4. **Separate PR** — guard `GET /api/admin/categories` (approval required)

--- a/docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md
+++ b/docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md
@@ -17,8 +17,8 @@ No secrets, JWTs, cookies, OTPs, passwords, or env values in this document.
 | Field | Value |
 | --- | --- |
 | Branch | `qa/backend-vendor-auth-smoke-proof` |
-| Commit SHA | *(filled at commit time)* |
-| PR link | *(filled when PR opened)* |
+| Commit SHA | `c84f5ae` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/97 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
 | [backend/STRIPE_PAYMENT_CONNECT_AUDIT.md](backend/STRIPE_PAYMENT_CONNECT_AUDIT.md) | Stripe webhooks, checkout, Connect |
 | [backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md](backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md) | Env var names only |
 | [backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md](backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md) | Deploy/smoke draft runbook |
-
+| [backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md) | P0/P1 contract tests and route verification evidence |
+| [backend/BACKEND_P0_P1_RISK_REGISTER.md](backend/BACKEND_P0_P1_RISK_REGISTER.md) | Launch risk register with approval gates |
 
 ## MVP backend sprint (#26–#35)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
 | --- | --- |
 | **LLM / AI agent** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [LLM_CONTEXT.md](LLM_CONTEXT.md) → [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) → [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) → [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) → [API_SURFACE.md](API_SURFACE.md) |
 | **New backend developer** | [ARCHITECTURE.md](ARCHITECTURE.md) → [SETUP.md](../SETUP.md) → [AUTH_FLOW.md](AUTH_FLOW.md) → [API_SURFACE.md](API_SURFACE.md) |
-| **QA / smoke tester** | [BACKEND_FULL_SMOKE_PROOF_PACK.md](BACKEND_FULL_SMOKE_PROOF_PACK.md) → [production-smoke-checklist.md](production-smoke-checklist.md) → [TEST_MATRIX.md](TEST_MATRIX.md) → [API_SURFACE.md](API_SURFACE.md) |
+| **QA / smoke tester** | [BACKEND_VENDOR_AUTH_SMOKE_PROOF.md](BACKEND_VENDOR_AUTH_SMOKE_PROOF.md) → [BACKEND_FULL_SMOKE_PROOF_PACK.md](BACKEND_FULL_SMOKE_PROOF_PACK.md) → [production-smoke-checklist.md](production-smoke-checklist.md) → [TEST_MATRIX.md](TEST_MATRIX.md) → [API_SURFACE.md](API_SURFACE.md) |
 | **Release / deploy owner** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) → [DEPLOYMENT.md](../DEPLOYMENT.md) → [production-proof-pack-template.md](production-proof-pack-template.md) |
 | **Product / launch reviewer** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md](backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md) → [DECISION_REGISTER.md](DECISION_REGISTER.md) → [launch-readiness-report.md](launch-readiness-report.md) |
 

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -130,3 +130,46 @@ npm test → node --test tests/**/*.test.js
 | PR link | https://github.com/Techware-Hut/mosaic-backend/pull/94 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
+
+---
+
+## Launch contract verification PR (2026-06-19)
+
+**Branch:** `test/backend-launch-contract-smoke-guards`  
+**Purpose:** Automated P0/P1 contract proof from merged as-built docs — tests and smoke extensions only, no business-logic changes.
+
+| File | Purpose |
+| --- | --- |
+| [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md) | Contract matrix, route table, test results |
+| [BACKEND_P0_P1_RISK_REGISTER.md](BACKEND_P0_P1_RISK_REGISTER.md) | Residual risks and stop-for-approval gates |
+| `tests/launch/backend-launch-contract.test.js` | 16 static/unit launch contract tests |
+| `scripts/smoke-backend.ps1` / `.sh` | Extended unauth 401/404 guard checks |
+
+### Commands run (verification PR)
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull origin main` | 0 | Fast-forward to docs pack |
+| `git checkout -b test/backend-launch-contract-smoke-guards` | 0 | Branch created |
+| `npm test` | 0 | **228 pass**, 0 fail |
+| `npm run test:contract` | 0 | **16 pass**, 0 fail |
+| `npm run smoke:backend` | **Not run** | Requires live `API_BASE_URL` |
+
+### Test delta
+
+```
+Baseline (docs pack): 212 tests
+This PR:              +16 contract tests → 228 total, 0 fail
+```
+
+**Full verification report:** [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md)
+
+### PR metadata (verification PR — fill on merge)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-launch-contract-smoke-guards` |
+| Commit SHA | *(filled at commit time)* |
+| PR link | *(filled when PR opened)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -169,7 +169,7 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | Field | Value |
 | --- | --- |
 | Branch | `test/backend-launch-contract-smoke-guards` |
-| Commit SHA | *(filled at commit time)* |
-| PR link | *(filled when PR opened)* |
+| Commit SHA | `c074888` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -1,0 +1,145 @@
+# Backend Launch Contract Verification
+
+**Purpose:** Automated and smoke-script proof that P0/P1 launch contracts from the merged as-built documentation pack are registered, guarded, and test-ready — without changing payment, auth, webhook, or middleware logic.
+
+**Branch:** `test/backend-launch-contract-smoke-guards`  
+**Evidence date:** 2026-06-19  
+**Baseline docs:** [BACKEND_ROUTE_REGISTRATION.md](BACKEND_ROUTE_REGISTRATION.md), [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md), [AUTH_CORS_COOKIE_AUDIT.md](AUTH_CORS_COOKIE_AUDIT.md), [STRIPE_PAYMENT_CONNECT_AUDIT.md](STRIPE_PAYMENT_CONNECT_AUDIT.md)
+
+**Related:** [BACKEND_P0_P1_RISK_REGISTER.md](BACKEND_P0_P1_RISK_REGISTER.md)
+
+---
+
+## PR metadata (fill on merge)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-launch-contract-smoke-guards` |
+| Commit SHA | *(filled at commit time)* |
+| PR link | *(filled when PR opened)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |
+
+---
+
+## Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull origin main` | 0 | Fast-forward to docs pack on main |
+| `git checkout -b test/backend-launch-contract-smoke-guards` | 0 | Branch created |
+| `npm test` | 0 | **228 pass**, 0 fail |
+| `npm run test:contract` | 0 | **16 pass**, 0 fail |
+| `npm run smoke:backend` | **Not run** | Requires live API (`API_BASE_URL`); see smoke script extensions below |
+
+### Test summary
+
+```
+npm test → node --test tests/**/*.test.js
+ℹ tests 228
+ℹ pass 228
+ℹ fail 0
+
+npm run test:contract → node --test tests/launch/backend-launch-contract.test.js
+ℹ tests 16
+ℹ pass 16
+ℹ fail 0
+```
+
+**Delta from docs pack baseline:** +16 contract tests (212 → 228 total).
+
+---
+
+## P0/P1 contract matrix
+
+| ID | Contract | Evidence | Result | Type |
+| --- | --- | --- | --- | --- |
+| P0.1 | `GET /`, `GET /api/health`, `GET /api/ready` registered and public | `tests/launch/backend-launch-contract.test.js`, `tests/health/health-readiness.test.js` | **PASS** | static + unit |
+| P0.2 | Stripe webhooks mounted before `express.json()` | `tests/launch/backend-launch-contract.test.js`, `tests/stripe/stripe-webhook-routing-signature.test.js`, `tests/stripe/payment-route-protection.test.js` | **PASS** | static |
+| P0.3 | Log hygiene (no OTP in logs) | Existing auth tests | **Not in scope** | manual |
+| P0.4 | CORS preflight on featured-products | `scripts/smoke-backend.ps1` / `.sh` | **BLOCKED** (smoke not run) | smoke |
+| P1 featured | `GET /api/featured-products` canonical public endpoint | Contract test + `tests/marketplace/featured-products-response.test.js` + `tests/stripe/checkout-approval-paymentintent-safety.test.js` | **PASS** | static + unit |
+| P1 absent | `GET /api/products/featured` not registered | Contract test + checkout-approval test | **PASS** | static |
+| P1 business | `GET /api/business/my` requires `authenticate` + `isBusinessOwner` | Contract test | **PASS** | static |
+| P1 admin users | `/admin/users/*` requires admin auth | Contract test + `tests/admin/admin-users-response.test.js` | **PASS** | static + unit |
+| P1 admin products | `/admin/api/products/` list + featured PATCH require admin | Contract test | **PASS** | static |
+| P1 admin leak | Admin DTO strips sensitive fields; non-admin gets 403 | Contract test + admin-users-response | **PASS** | unit |
+| P1 orders | `POST /api/orders/initiate` requires customer auth | Contract test + `tests/stripe/order-initiate-connect.test.js` + smoke P4.2 | **PASS** (static); smoke **BLOCKED** | static + smoke |
+| P1 legacy payment | `POST /api/payments/create-payment-intent` guarded (legacy; canonical is `orders/initiate`) | Contract test + `tests/stripe/payment-route-protection.test.js` | **PASS** | static + unit |
+| P1 Connect | `/api/connect/:businessId/account-link` and `/status` guarded | Contract test | **PASS** | static |
+| P1 Stripe finance | `/stripe/account-session`, `/express-login-link`, `/account-balance`, `/last-payout` guarded | Contract test + payment-route-protection | **PASS** | static |
+| P3 admin smoke | Unauthenticated admin list returns 401 | Smoke P3.0, P3.1 | **BLOCKED** (smoke not run) | smoke |
+| P4 payment smoke | Unauthenticated legacy payment intent returns 401 | Smoke P4.3 | **BLOCKED** (smoke not run) | smoke |
+| P5 finance smoke | Unauthenticated `/stripe/account-balance` returns 401 | Smoke P5.0 | **BLOCKED** (smoke not run) | smoke |
+| P6 absent smoke | `GET /api/products/featured` returns 404 | Smoke P6.0 | **BLOCKED** (smoke not run) | smoke |
+
+---
+
+## Route inspection table (task-specific paths)
+
+| Path | Registered | Guarded | Notes |
+| --- | --- | --- | --- |
+| `/admin/users` | **Yes** | **Yes** — `router.use(authenticate, isAdmin)` | Mount: `app.js` → `routes/admin/userRoutes.js` |
+| `/admin/api/products` | **Yes** | **Yes** — per-route `authenticate, isAdmin` on `/` and `/:productId/featured` | Unguarded debug route: `GET /admin/api/products/test` |
+| `/stripe/account-session` | **Yes** | **Yes** — `authenticate, isBusinessOwner` | Mounted at `/stripe`, not `/api/stripe` |
+| `/stripe/express-login-link` | **Yes** | **Yes** | same |
+| `/stripe/account-balance` | **Yes** | **Yes** | same |
+| `/stripe/last-payout` | **Yes** | **Yes** | same |
+| `/api/admin/users` | **No** | — | Use `/admin/users` |
+| `/api/stripe/account-session` | **No** | — | Finance routes live under `/stripe/*` |
+| `/api/orders/initiate` | **Yes** | **Yes** — `authenticate, isCustomer` | Canonical Connect checkout |
+| `/api/payments/create-payment-intent` | **Yes** | **Yes** — `authenticate, isCustomer` + rate limit | **Legacy**; canonical flow is `orders/initiate` |
+
+---
+
+## Files added or changed
+
+| File | Change |
+| --- | --- |
+| `tests/launch/backend-launch-contract.test.js` | **Added** — 16 launch contract tests |
+| `package.json` | **Added** `test:contract` script |
+| `scripts/smoke-backend.ps1` | **Extended** — P3.0, P3.1, P4.3, P5.0, P6.0 unauth checks |
+| `scripts/smoke-backend.sh` | **Extended** — parity with PowerShell script |
+| `docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md` | **Added** — this file |
+| `docs/backend/BACKEND_P0_P1_RISK_REGISTER.md` | **Added** — risk register |
+| `docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md` | **Updated** — this PR evidence |
+| `docs/README.md` | **Updated** — index links |
+
+---
+
+## What was NOT tested
+
+- Live Stripe PaymentIntent creation or charges
+- Webhook delivery with production signing secrets
+- AWS S3 uploads, SMTP email delivery
+- Elastic Beanstalk deploy
+- `npm run smoke:backend` against production or local running server (no server started in CI for this PR)
+- Authenticated admin HTTP response body audit (empty vs data when wrong role)
+- Full manual P0–P6 production smoke checklist
+- Frontend payment redirect URL behavior
+
+---
+
+## Evidence still needed externally
+
+| Item | Owner |
+| --- | --- |
+| Run extended smoke script against staging/production `API_BASE_URL` | QA / release owner |
+| Production EB env var audit (names only in EB) | AWS / release owner |
+| Stripe Dashboard webhook URLs for five endpoints | Stripe admin |
+| Production `CORS_ORIGINS` value confirmation | AWS EB + frontend |
+| Frontend path audit: `/api/admin/users`, `/api/stripe/account-session` | Frontend team |
+| Whether frontend still calls legacy `POST /api/payments/create-payment-intent` | Frontend team |
+| Go/No-Go launch sign-off | Product / release owner |
+
+---
+
+## Recommended next PR (requires approval)
+
+| Item | Severity | Action |
+| --- | --- | --- |
+| `GET /admin/api/products/test` unguarded | Low | Guard or remove test route — **stop for approval** |
+| Stale frontend paths `/api/admin/users`, `/api/stripe/*` | Medium | Frontend contract diff only — **no backend aliases without approval** |
+| Legacy `create-payment-intent` overlap | Medium | Document deprecation; migrate frontend to `orders/initiate` — **no payment logic change without approval** |
+
+**No payment, webhook, auth, CORS, cookie, middleware-order, schema, deploy, or route-alias changes were made in this PR.**

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -14,9 +14,9 @@
 
 | Field | Value |
 | --- | --- |
-| Branch | `test/backend-launch-contract-smoke-guards` |
-| Commit SHA | `c074888` |
-| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
+| Branch | `fix/backend-guard-admin-products-test-route` |
+| Commit SHA | `728d059` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/96 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
 

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -15,8 +15,8 @@
 | Field | Value |
 | --- | --- |
 | Branch | `test/backend-launch-contract-smoke-guards` |
-| Commit SHA | *(filled at commit time)* |
-| PR link | *(filled when PR opened)* |
+| Commit SHA | `c074888` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
 

--- a/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
+++ b/docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md
@@ -1,0 +1,156 @@
+# Backend Launch Contract Verification
+
+**Purpose:** Automated and smoke-script proof that P0/P1 launch contracts from the merged as-built documentation pack are registered, guarded, and test-ready — without changing payment, auth, webhook, or middleware logic.
+
+**Branch:** `test/backend-launch-contract-smoke-guards` (verification); `fix/backend-guard-admin-products-test-route` (hardening fix)  
+**Evidence date:** 2026-06-19  
+**Baseline docs:** [BACKEND_ROUTE_REGISTRATION.md](BACKEND_ROUTE_REGISTRATION.md), [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md), [AUTH_CORS_COOKIE_AUDIT.md](AUTH_CORS_COOKIE_AUDIT.md), [STRIPE_PAYMENT_CONNECT_AUDIT.md](STRIPE_PAYMENT_CONNECT_AUDIT.md)
+
+**Related:** [BACKEND_P0_P1_RISK_REGISTER.md](BACKEND_P0_P1_RISK_REGISTER.md)
+
+---
+
+## PR metadata (fill on merge)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-launch-contract-smoke-guards` |
+| Commit SHA | `c074888` |
+| PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |
+
+---
+
+## Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull origin main` | 0 | Fast-forward to docs pack on main |
+| `git checkout -b test/backend-launch-contract-smoke-guards` | 0 | Branch created |
+| `npm test` | 0 | **228 pass**, 0 fail |
+| `npm run test:contract` | 0 | **16 pass**, 0 fail |
+| `npm run smoke:backend` | **Not run** | Requires live API (`API_BASE_URL`); see smoke script extensions below |
+
+### Test summary
+
+```
+npm test → node --test tests/**/*.test.js
+ℹ tests 228
+ℹ pass 228
+ℹ fail 0
+
+npm run test:contract → node --test tests/launch/backend-launch-contract.test.js
+ℹ tests 16
+ℹ pass 16
+ℹ fail 0
+```
+
+**Delta from docs pack baseline:** +16 contract tests (212 → 228 total).
+
+---
+
+## P0/P1 contract matrix
+
+| ID | Contract | Evidence | Result | Type |
+| --- | --- | --- | --- | --- |
+| P0.1 | `GET /`, `GET /api/health`, `GET /api/ready` registered and public | `tests/launch/backend-launch-contract.test.js`, `tests/health/health-readiness.test.js` | **PASS** | static + unit |
+| P0.2 | Stripe webhooks mounted before `express.json()` | `tests/launch/backend-launch-contract.test.js`, `tests/stripe/stripe-webhook-routing-signature.test.js`, `tests/stripe/payment-route-protection.test.js` | **PASS** | static |
+| P0.3 | Log hygiene (no OTP in logs) | Existing auth tests | **Not in scope** | manual |
+| P0.4 | CORS preflight on featured-products | `scripts/smoke-backend.ps1` / `.sh` | **BLOCKED** (smoke not run) | smoke |
+| P1 featured | `GET /api/featured-products` canonical public endpoint | Contract test + `tests/marketplace/featured-products-response.test.js` + `tests/stripe/checkout-approval-paymentintent-safety.test.js` | **PASS** | static + unit |
+| P1 absent | `GET /api/products/featured` not registered | Contract test + checkout-approval test | **PASS** | static |
+| P1 business | `GET /api/business/my` requires `authenticate` + `isBusinessOwner` | Contract test | **PASS** | static |
+| P1 admin users | `/admin/users/*` requires admin auth | Contract test + `tests/admin/admin-users-response.test.js` | **PASS** | static + unit |
+| P1 admin products | `/admin/api/products/` list + featured PATCH require admin | Contract test | **PASS** | static |
+| P1 admin leak | Admin DTO strips sensitive fields; non-admin gets 403 | Contract test + admin-users-response | **PASS** | unit |
+| P1 orders | `POST /api/orders/initiate` requires customer auth | Contract test + `tests/stripe/order-initiate-connect.test.js` + smoke P4.2 | **PASS** (static); smoke **BLOCKED** | static + smoke |
+| P1 legacy payment | `POST /api/payments/create-payment-intent` guarded (legacy; canonical is `orders/initiate`) | Contract test + `tests/stripe/payment-route-protection.test.js` | **PASS** | static + unit |
+| P1 Connect | `/api/connect/:businessId/account-link` and `/status` guarded | Contract test | **PASS** | static |
+| P1 Stripe finance | `/stripe/account-session`, `/express-login-link`, `/account-balance`, `/last-payout` guarded | Contract test + payment-route-protection | **PASS** | static |
+| P3 admin smoke | Unauthenticated admin list returns 401 | Smoke P3.0, P3.1 | **BLOCKED** (smoke not run) | smoke |
+| P4 payment smoke | Unauthenticated legacy payment intent returns 401 | Smoke P4.3 | **BLOCKED** (smoke not run) | smoke |
+| P5 finance smoke | Unauthenticated `/stripe/account-balance` returns 401 | Smoke P5.0 | **BLOCKED** (smoke not run) | smoke |
+| P6 absent smoke | `GET /api/products/featured` returns 404 | Smoke P6.0 | **BLOCKED** (smoke not run) | smoke |
+
+---
+
+## Route inspection table (task-specific paths)
+
+| Path | Registered | Guarded | Notes |
+| --- | --- | --- | --- |
+| `/admin/users` | **Yes** | **Yes** — `router.use(authenticate, isAdmin)` | Mount: `app.js` → `routes/admin/userRoutes.js` |
+| `/admin/api/products` | **Yes** | **Yes** — per-route `authenticate, isAdmin` on `/` and `/:productId/featured` | Debug route `GET /admin/api/products/test` **removed** in `fix/backend-guard-admin-products-test-route` |
+| `/stripe/account-session` | **Yes** | **Yes** — `authenticate, isBusinessOwner` | Mounted at `/stripe`, not `/api/stripe` |
+| `/stripe/express-login-link` | **Yes** | **Yes** | same |
+| `/stripe/account-balance` | **Yes** | **Yes** | same |
+| `/stripe/last-payout` | **Yes** | **Yes** | same |
+| `/api/admin/users` | **No** | — | Use `/admin/users` |
+| `/api/stripe/account-session` | **No** | — | Finance routes live under `/stripe/*` |
+| `/api/orders/initiate` | **Yes** | **Yes** — `authenticate, isCustomer` | Canonical Connect checkout |
+| `/api/payments/create-payment-intent` | **Yes** | **Yes** — `authenticate, isCustomer` + rate limit | **Legacy**; canonical flow is `orders/initiate` |
+
+---
+
+## Files added or changed
+
+| File | Change |
+| --- | --- |
+| `tests/launch/backend-launch-contract.test.js` | **Added** — 16 launch contract tests |
+| `package.json` | **Added** `test:contract` script |
+| `scripts/smoke-backend.ps1` | **Extended** — P3.0, P3.1, P4.3, P5.0, P6.0 unauth checks |
+| `scripts/smoke-backend.sh` | **Extended** — parity with PowerShell script |
+| `docs/backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md` | **Added** — this file |
+| `docs/backend/BACKEND_P0_P1_RISK_REGISTER.md` | **Added** — risk register |
+| `docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md` | **Updated** — this PR evidence |
+| `docs/README.md` | **Updated** — index links |
+
+---
+
+## What was NOT tested
+
+- Live Stripe PaymentIntent creation or charges
+- Webhook delivery with production signing secrets
+- AWS S3 uploads, SMTP email delivery
+- Elastic Beanstalk deploy
+- `npm run smoke:backend` against production or local running server (no server started in CI for this PR)
+- Authenticated admin HTTP response body audit (empty vs data when wrong role)
+- Full manual P0–P6 production smoke checklist
+- Frontend payment redirect URL behavior
+
+---
+
+## Evidence still needed externally
+
+| Item | Owner |
+| --- | --- |
+| Run extended smoke script against staging/production `API_BASE_URL` | QA / release owner |
+| Production EB env var audit (names only in EB) | AWS / release owner |
+| Stripe Dashboard webhook URLs for five endpoints | Stripe admin |
+| Production `CORS_ORIGINS` value confirmation | AWS EB + frontend |
+| Frontend path audit: `/api/admin/users`, `/api/stripe/account-session` | Frontend team |
+| Whether frontend still calls legacy `POST /api/payments/create-payment-intent` | Frontend team |
+| Go/No-Go launch sign-off | Product / release owner |
+
+---
+
+## Admin products test route fix (2026-06-19)
+
+| Field | Decision |
+| --- | --- |
+| Route | `GET /admin/api/products/test` |
+| Finding | Public debug endpoint; not referenced by smoke scripts, frontend contract, or production UI |
+| Fix | **Removed** from `routes/admin/adminProductRoutes.js` |
+| Tests | `tests/admin/admin-product-routes-guard.test.js`; launch contract test updated |
+| Branch | `fix/backend-guard-admin-products-test-route` |
+
+---
+
+## Recommended next PR (requires approval)
+
+| Item | Severity | Action |
+| --- | --- | --- |
+| Stale frontend paths `/api/admin/users`, `/api/stripe/*` | Medium | Frontend contract diff only — **no backend aliases without approval** |
+| Legacy `create-payment-intent` overlap | Medium | Document deprecation; migrate frontend to `orders/initiate` — **no payment logic change without approval** |
+
+**No payment, webhook, auth, CORS, cookie, middleware-order, schema, deploy, or route-alias changes were made in this PR.**

--- a/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
+++ b/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
@@ -1,0 +1,82 @@
+# Backend P0/P1 Risk Register
+
+**Purpose:** Track launch-blocking and high-priority risks against P0/P1 contracts, with verification status from [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md).
+
+**Evidence date:** 2026-06-19  
+**Branch:** `test/backend-launch-contract-smoke-guards`  
+**Smoke tiers reference:** [production-smoke-checklist.md](../production-smoke-checklist.md)
+
+---
+
+## P0 risks (infrastructure / critical wiring)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P0-R1 | API unreachable after deploy | Static: root + health mounts; smoke script covers `GET /`, `/api/health`, `/api/ready` | EB boot logs, deploy SHA confirmation still manual | Release |
+| P0-R2 | Stripe webhook signature broken by middleware order | **Verified** — static tests assert webhooks before `express.json()` | Dashboard delivery + live sig still manual (P4 tier) | Backend + Stripe admin |
+| P0-R3 | OTP or secrets in application logs | Not tested in this PR | Manual P0.3 after auth smoke | QA |
+| P0-R4 | Wrong featured endpoint breaks marketplace home | **Verified** — canonical `/api/featured-products`; `/api/products/featured` absent | Frontend must not call stale path | Frontend |
+
+---
+
+## P1 risks (auth guards / protected routes)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P1-R1 | Unauthenticated access to vendor business data | **Verified** — `GET /api/business/my` static guard | HTTP 401 smoke needs live API + vendor token | QA |
+| P1-R2 | Unauthenticated admin user/product enumeration | **Verified** — static guards + `isAdmin` unit test; smoke adds unauth 401 checks | Response body when unauth (401 vs empty 200) needs live smoke | QA |
+| P1-R3 | Customer checkout without auth | **Verified** — `POST /api/orders/initiate` static + existing controller tests | Live 401 smoke blocked until API up | QA |
+| P1-R4 | Legacy payment intent abused | **Verified** — static guard + ownership 403 in payment-route-protection | Frontend may still hit legacy route | Frontend |
+| P1-R5 | Vendor Stripe finance routes exposed | **Verified** — `/stripe/*` static guards | Live 401 smoke blocked until API up | QA |
+| P1-R6 | Connect onboarding link/status exposed | **Verified** — connectRoutes static guards | Live vendor-token smoke blocked | QA |
+| P1-R7 | Admin list leaks password/OTP fields | **Verified** — `toAdminUser` allowlist unit test | Full HTTP admin list audit with token | QA |
+| P1-R8 | Stale frontend paths 404 in production | **Documented** — `/api/admin/users`, `/api/stripe/account-session` absent | Frontend must use `/admin/users`, `/stripe/*` | Frontend |
+
+---
+
+## Known gaps (document only — no fix in verification PR)
+
+| Gap | Location | Severity | Recommended follow-up |
+| --- | --- | --- | --- |
+| Unguarded admin products test route | `GET /admin/api/products/test` | Low | Guard or remove — **approval required** |
+| Public admin category routes | `GET /api/admin/categories` (see API_SURFACE) | Medium | Separate audit PR — **approval required** |
+| Legacy payment route overlap | `/api/payments/create-payment-intent` vs `/api/orders/initiate` | Medium | Frontend migration plan — **no payment logic change without approval** |
+| No global 404 handler | Express default for unknown routes | Low | Document only; alias PRs **not approved** |
+| Inconsistent error response shapes | Various controllers | Low | Contract normalization deferred |
+
+---
+
+## Stop-for-approval gates
+
+Do **not** proceed without explicit approval for:
+
+- Changing payment logic (checkout, PaymentIntent, Connect charges)
+- Changing webhook handlers or signing behavior
+- Changing auth, CORS, or cookie behavior
+- Adding route aliases (e.g. `/api/products/featured`, `/api/admin/users`)
+- Deleting or reordering routes or middleware
+- Changing database schemas
+- Deploying to EB or production
+
+---
+
+## Verification summary
+
+| Category | Count |
+| --- | --- |
+| P0 contracts verified (repo-local) | 2 of 3 (P0.3 manual) |
+| P1 contracts verified (repo-local) | 10+ static/unit |
+| Smoke extensions added | 5 unauth checks (blocked until live API) |
+| New automated tests | 16 |
+| Business logic changes | **0** |
+
+---
+
+## External evidence checklist
+
+- [ ] Run `npm run smoke:backend` with `API_BASE_URL` set (no secrets printed)
+- [ ] Confirm Stripe Dashboard has five webhook endpoints with correct env secret names
+- [ ] Confirm EB production env has required env var **names** (values in EB only)
+- [ ] Frontend contract diff against [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md)
+- [ ] Full P1–P6 manual smoke with test accounts
+- [ ] Release owner Go/No-Go sign-off

--- a/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
+++ b/docs/backend/BACKEND_P0_P1_RISK_REGISTER.md
@@ -1,0 +1,89 @@
+# Backend P0/P1 Risk Register
+
+**Purpose:** Track launch-blocking and high-priority risks against P0/P1 contracts, with verification status from [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md).
+
+**Evidence date:** 2026-06-19  
+**Branch:** `test/backend-launch-contract-smoke-guards`  
+**Smoke tiers reference:** [production-smoke-checklist.md](../production-smoke-checklist.md)
+
+---
+
+## P0 risks (infrastructure / critical wiring)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P0-R1 | API unreachable after deploy | Static: root + health mounts; smoke script covers `GET /`, `/api/health`, `/api/ready` | EB boot logs, deploy SHA confirmation still manual | Release |
+| P0-R2 | Stripe webhook signature broken by middleware order | **Verified** — static tests assert webhooks before `express.json()` | Dashboard delivery + live sig still manual (P4 tier) | Backend + Stripe admin |
+| P0-R3 | OTP or secrets in application logs | Not tested in this PR | Manual P0.3 after auth smoke | QA |
+| P0-R4 | Wrong featured endpoint breaks marketplace home | **Verified** — canonical `/api/featured-products`; `/api/products/featured` absent | Frontend must not call stale path | Frontend |
+
+---
+
+## P1 risks (auth guards / protected routes)
+
+| ID | Risk | Verification in this PR | Residual risk | Owner |
+| --- | --- | --- | --- | --- |
+| P1-R1 | Unauthenticated access to vendor business data | **Verified** — `GET /api/business/my` static guard | HTTP 401 smoke needs live API + vendor token | QA |
+| P1-R2 | Unauthenticated admin user/product enumeration | **Verified** — static guards + `isAdmin` unit test; smoke adds unauth 401 checks | Response body when unauth (401 vs empty 200) needs live smoke | QA |
+| P1-R3 | Customer checkout without auth | **Verified** — `POST /api/orders/initiate` static + existing controller tests | Live 401 smoke blocked until API up | QA |
+| P1-R4 | Legacy payment intent abused | **Verified** — static guard + ownership 403 in payment-route-protection | Frontend may still hit legacy route | Frontend |
+| P1-R5 | Vendor Stripe finance routes exposed | **Verified** — `/stripe/*` static guards | Live 401 smoke blocked until API up | QA |
+| P1-R6 | Connect onboarding link/status exposed | **Verified** — connectRoutes static guards | Live vendor-token smoke blocked | QA |
+| P1-R7 | Admin list leaks password/OTP fields | **Verified** — `toAdminUser` allowlist unit test | Full HTTP admin list audit with token | QA |
+| P1-R8 | Stale frontend paths 404 in production | **Documented** — `/api/admin/users`, `/api/stripe/account-session` absent | Frontend must use `/admin/users`, `/stripe/*` | Frontend |
+
+---
+
+## Resolved gaps
+
+| Gap | Location | Resolution | Branch |
+| --- | --- | --- | --- |
+| Unguarded admin products test route | `GET /admin/api/products/test` | **Removed** — debug-only route not used in prod UI or smoke | `fix/backend-guard-admin-products-test-route` |
+
+---
+
+## Known gaps (document only)
+
+| Gap | Location | Severity | Recommended follow-up |
+| --- | --- | --- | --- |
+| Public admin category routes | `GET /api/admin/categories` (see API_SURFACE) | Medium | Separate audit PR — **approval required** |
+| Legacy payment route overlap | `/api/payments/create-payment-intent` vs `/api/orders/initiate` | Medium | Frontend migration plan — **no payment logic change without approval** |
+| No global 404 handler | Express default for unknown routes | Low | Document only; alias PRs **not approved** |
+| Inconsistent error response shapes | Various controllers | Low | Contract normalization deferred |
+
+---
+
+## Stop-for-approval gates
+
+Do **not** proceed without explicit approval for:
+
+- Changing payment logic (checkout, PaymentIntent, Connect charges)
+- Changing webhook handlers or signing behavior
+- Changing auth, CORS, or cookie behavior
+- Adding route aliases (e.g. `/api/products/featured`, `/api/admin/users`)
+- Deleting or reordering routes or middleware
+- Changing database schemas
+- Deploying to EB or production
+
+---
+
+## Verification summary
+
+| Category | Count |
+| --- | --- |
+| P0 contracts verified (repo-local) | 2 of 3 (P0.3 manual) |
+| P1 contracts verified (repo-local) | 10+ static/unit |
+| Smoke extensions added | 5 unauth checks (blocked until live API) |
+| New automated tests | 16 |
+| Business logic changes | **0** |
+
+---
+
+## External evidence checklist
+
+- [ ] Run `npm run smoke:backend` with `API_BASE_URL` set (no secrets printed)
+- [ ] Confirm Stripe Dashboard has five webhook endpoints with correct env secret names
+- [ ] Confirm EB production env has required env var **names** (values in EB only)
+- [ ] Frontend contract diff against [API_CONTRACT_AS_BUILT.md](API_CONTRACT_AS_BUILT.md)
+- [ ] Full P1–P6 manual smoke with test accounts
+- [ ] Release owner Go/No-Go sign-off

--- a/docs/smoke/BACKEND_MVP_LAUNCH_ACTIVATION_CHECKOUT_EMAIL_ADMIN.md
+++ b/docs/smoke/BACKEND_MVP_LAUNCH_ACTIVATION_CHECKOUT_EMAIL_ADMIN.md
@@ -1,0 +1,268 @@
+# Backend MVP Launch Activation — Checkout / Email / Admin Smoke Proof
+
+**Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
+**Branch:** `audit/backend-mvp-launch-activation-checkout-email-admin`  
+**Evidence date:** 2026-06-19 (UTC)  
+**Production API:** `https://api.mosaicbizhub.com`  
+**Frontend origins tested:**
+
+| Origin | Role |
+| --- | --- |
+| `https://mosaic-biz-frontend-launch.vercel.app` | **Active** — current frontend testing origin |
+| `https://app.mosaicbizhub.com` | **Prepared** — future production frontend domain |
+
+No secrets, cookie values, JWTs, passwords, OTPs, tester email, or PII in this document.
+
+---
+
+## 1. Executive verdict
+
+**BACKEND MVP ACTIVATION: PARTIAL**
+
+Public health, CORS, unauth guards, vendor session chain, role-based admin guards, and automated Stripe/checkout contract tests **PASS**. Checkout live payment, admin credentialed approval flows, Connect status on a linked business, and inbox email delivery remain **BLOCKED** or **NOT RUN** by policy (no live charges; no admin smoke account; test vendor has zero business records).
+
+---
+
+## 2. P0 blockers
+
+| ID | Finding | Status |
+| --- | --- | --- |
+| — | None identified in this audit | **No P0** |
+
+Public routes, payment route auth, webhook signature rejection, Connect checkout guards (unit tests), and non-admin → admin route denial all behave as expected on deployed production @ `ef83e24`.
+
+---
+
+## 3. P1 / P2 risks
+
+| Sev | Risk | Evidence |
+| --- | --- | --- |
+| **P1** | `GET /api/admin/categories` is **public** (no `authenticate` / `isAdmin`) | Live **200** unauthenticated; returns aggregated category metadata |
+| **P1** | Email sender uses **Gmail SMTP** (`MAIL_USER` / `MAIL_PASSWORD`); From header is `"Mosaic Biz Hub" <MAIL_USER>` | Code: [`utils/mailer.js`](../../utils/mailer.js). Production may send from personal/dev Gmail if `MAIL_USER` is not a transactional domain |
+| **P1** | Admin credentialed smoke **BLOCKED** — no dedicated `SMOKE_TEST_ADMIN_*` account | Cannot live-verify approval queue, finalize, or admin order list with admin role |
+| **P1** | Customer checkout initiate dry-run **BLOCKED** — only vendor test account available | `POST /api/orders/initiate` requires `customer` role; vendor session correctly returns **403** |
+| **P2** | Legacy `POST /api/payments/create-payment-intent` exists without Connect destination split | Canonical marketplace flow is `POST /api/orders/initiate`; legacy route guarded but documented |
+| **P2** | Deployed EB runtime **3 commits behind** local `main` | Deploy `ef83e24`; `main` HEAD `5180b2b` |
+| **P2** | `npm run test:contract` **not wired on `main`** | Open [PR #98](https://github.com/Techware-Hut/mosaic-backend/pull/98); contract tests run locally from branch file (16 pass) |
+| **P2** | [`scripts/smoke-backend.ps1`](../../scripts/smoke-backend.ps1) fails to parse on Windows (encoding/em-dash) | Used [`scripts/vendor-login-session-proof.ps1`](../../scripts/vendor-login-session-proof.ps1) + manual probes instead |
+
+---
+
+## 4. Checkout / payment / order status
+
+**Verdict: PARTIAL** — code + unit tests + unauth/role guards PASS; live end-to-end payment NOT RUN.
+
+### Canonical route inventory
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| GET | `/api/cart/` | customer | Read cart |
+| POST | `/api/cart/add` | customer | Add to cart |
+| **POST** | **`/api/orders/initiate`** | **customer** | Create order + Connect destination PaymentIntent |
+| GET | `/api/orders/retrieve-intent/:id` | customer | Poll PI + order after payment |
+| GET | `/api/orders/user` | customer | Customer order history |
+| GET | `/api/orders/vendor` | business_owner | Vendor paid/refunded orders |
+| GET | `/api/orders/admin` | admin | Admin order list |
+| POST | `/api/webhooks/stripe` | Stripe sig | Order status: paid / failed / refunded |
+| POST | `/api/stripe/payment/webhook` | Stripe sig | Post-payment enrichment, fee/transfer IDs, emails |
+| POST | `/api/payments/create-payment-intent` | customer | **Legacy** — no Connect split |
+
+### Code inspection (audit-only)
+
+| Check | Result |
+| --- | --- |
+| Webhook routes mounted **before** `express.json()` in [`app.js`](../../app.js) | **PASS** |
+| `application_fee_amount` + `transfer_data.destination` in `initiateOrder` | **PASS** — [`controllers/orderController.js`](../../controllers/orderController.js) |
+| Checkout guards block unapproved / inactive / unconnected vendor | **PASS** — [`utils/checkoutGuards.js`](../../utils/checkoutGuards.js) |
+| Refunds use `reverse_transfer` + `refund_application_fee` | **PASS** — orderController |
+| Payment does not bypass platform (Connect destination charge) | **PASS** — canonical path only |
+
+### Automated tests
+
+| Suite | Result |
+| --- | --- |
+| `npm test` | **228 pass**, 0 fail |
+| Launch contract (PR #98 file, run via `node --test tests/launch/backend-launch-contract.test.js`) | **16 pass**, 0 fail |
+| Stripe Connect checkout / webhook / email safety tests | Included in full suite — **PASS** |
+
+### Live production probes
+
+| Method | Path | Expected | HTTP | Result |
+| --- | --- | --- | --- | --- |
+| POST | `/api/orders/initiate` | 401 unauth | **401** | **PASS** |
+| POST | `/api/payments/create-payment-intent` | 401 unauth | **401** | **PASS** |
+| POST | `/api/webhooks/stripe` | 400 without signature | **400** | **PASS** |
+| POST | `/api/orders/initiate` | 403 vendor role | **403** | **PASS** |
+| GET | `/api/orders/vendor` | 200 vendor session | **200** | **PASS** |
+| GET | `/api/orders/user` | 200 or 403 by role | **200** | **PASS** (vendor account allowed read) |
+| POST | `/api/orders/initiate` | 201 with cart + connected vendor | — | **NOT RUN** — no customer account + no live charge policy |
+
+---
+
+## 5. Stripe Connect status
+
+**Verdict: PARTIAL** — routes and guards verified; Connect status on test vendor **BLOCKED** (zero businesses).
+
+### Route inventory
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| POST | `/api/connect/:businessId/account-link` | business_owner | Stripe Account Link onboarding |
+| GET | `/api/connect/:businessId/status` | business_owner | Poll + sync Connect state |
+| GET | `/api/connect/return` | public | Redirect to frontend return |
+| GET | `/api/connect/refresh` | public | Redirect to frontend refresh |
+| POST | `/stripe/account-session` | business_owner | Embedded Connect dashboard session |
+| POST | `/stripe/express-login-link` | business_owner | Express Dashboard login link |
+
+### Live probes
+
+| Method | Path | Expected | HTTP | Result |
+| --- | --- | --- | --- | --- |
+| POST | `/api/connect/:businessId/account-link` | 401 unauth | **401** | **PASS** |
+| POST | `/stripe/account-session` | 401 unauth | **401** | **PASS** |
+| GET | `/api/connect/:businessId/status` | 200 credentialed vendor | — | **BLOCKED** — `GET /api/business/my` returned `count: 0` (no businessId) |
+| POST | `/api/connect/:businessId/account-link` | 200 credentialed | — | **BLOCKED** — same |
+
+### Required env var names (values never recorded)
+
+`STRIPE_SECRET_KEY`, `PLATFORM_FEE_CENTS`, `FRONTEND_URL`, `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH`, `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL`, `STRIPE_BUSINESS_DRAFT_WEBHOOK_SECRET`, `STRIPE_ORDER_WEBHOOK_SECRET`, `STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET`
+
+### Unconnected vendor behavior (code + unit tests)
+
+`getBusinessCheckoutBlock` returns **400** `"Vendor is not connected to Stripe."` when `stripeConnectAccountId` is missing; `initiateOrder` additionally live-retrieves Stripe account and blocks incomplete onboarding.
+
+---
+
+## 6. Email / OTP / rate-limit status
+
+**Verdict: PARTIAL** — configuration audited; inbox delivery and OTP content **NOT RUN**.
+
+| Item | Finding |
+| --- | --- |
+| Provider | Nodemailer + Gmail SMTP (`MAIL_USER`, `MAIL_PASSWORD`) |
+| From display | `"Mosaic Biz Hub" <MAIL_USER>` |
+| OTP | 6 digits, 10 min expiry, bcrypt hash; login may return **403** + `otpPending` for unverified users |
+| Rate limits (15 min window) | register **5**, login **15**, verify-otp **10**, resend-otp **5**, forgot-password **5**, reset-password **10** |
+| Live login during smoke | **200** — no **429** rate-limit observed |
+| Production sender risk | **P1** if `MAIL_USER` is personal Gmail — recommend transactional provider + verified domain |
+| Inbox / OTP receipt | **NOT RUN** — no OTP values or email bodies logged |
+
+**Env var names:** `MAIL_USER`, `MAIL_PASSWORD`, `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL`
+
+---
+
+## 7. Admin / vendor approval status
+
+**Verdict: PARTIAL** — unauth and non-admin guards PASS; admin credentialed tier **BLOCKED**.
+
+| Method | Path | Session | Expected | HTTP | Result |
+| --- | --- | --- | --- | --- | --- |
+| POST | `/api/users/login` | — | 200 vendor | **200** | **PASS** |
+| GET | `/api/users/auth/check` | vendor cookies | 200 | **200** | **PASS** |
+| GET | `/api/vendor-onboarding/pending` | none | 401 | **401** | **PASS** |
+| GET | `/api/vendor-onboarding/pending` | vendor | 403 | **403** | **PASS** |
+| GET | `/api/orders/admin` | none | 401 | **401** | **PASS** |
+| GET | `/api/orders/admin` | vendor | 403 | **403** | **PASS** |
+| POST | `/api/vendor-onboarding/:id/finalize` | vendor | 403 | **403** | **PASS** |
+| GET | `/admin/users` | none | 401 | **401** | **PASS** |
+| POST | `/api/admin/category/product` | none | 401 | **401** | **PASS** |
+| GET | `/api/admin/categories` | none | 200 public | **200** | **PASS** (P1 public exposure note) |
+| GET | `/api/vendor-onboarding/pending` | admin | 200 | — | **BLOCKED** — no admin credentials |
+| POST | `/api/vendor-onboarding/:id/finalize` | admin | 200 | — | **NOT RUN** |
+
+Admin login uses same `POST /api/users/login` as other roles; admin routes use `authenticate` + `isAdmin`.
+
+---
+
+## 8. Route inventory — tested areas (A–F)
+
+### A. Health / public
+
+| Method | Path | HTTP | Result |
+| --- | --- | --- | --- |
+| GET | `/` | **200** | **PASS** |
+| GET | `/api/health` | **200** | **PASS** |
+| GET | `/api/ready` | **200** | **PASS** |
+| GET | `/api/featured-products` | **200** | **PASS** |
+| GET | `/api/admin/categories` | **200** | **PASS** (public) |
+
+### F. CORS / cookies
+
+| Origin | Path | Method | ACAO | Credentials | Result |
+| --- | --- | --- | --- | --- | --- |
+| launch Vercel | `/api/featured-products` | OPTIONS | exact match | **true** | **PASS** |
+| launch Vercel | `/api/users/login` | OPTIONS | exact match | **true** | **PASS** |
+| app.mosaicbizhub.com | `/api/featured-products` | OPTIONS | exact match | **true** | **PASS** |
+| app.mosaicbizhub.com | `/api/users/login` | OPTIONS | exact match | **true** | **PASS** |
+
+**Cookie attributes (vendor login, names/flags only):** `token` HttpOnly, Secure, SameSite=None, Domain=.mosaicbizhub.com, Path=/; `user_session` Secure, SameSite=None; `user_gender` present.
+
+**CORS env var names:** `CORS_ORIGINS`, `FRONTEND_URL`, `NODE_ENV`  
+**Cookie env var names:** `COOKIE_DOMAIN`, `COOKIE_SECURE`, `COOKIE_SAMESITE`
+
+---
+
+## 9. Commands run and results
+
+| Command | Exit | Result |
+| --- | --- | --- |
+| `git fetch origin main && git checkout main && git pull` | 0 | Up to date @ `5180b2b` |
+| `git checkout -b audit/backend-mvp-launch-activation-checkout-email-admin` | 0 | Branch created |
+| `npm test` | 0 | **228 pass**, 0 fail |
+| `node --test tests/launch/backend-launch-contract.test.js` | 0 | **16 pass** (PR #98 file; not on `main` script yet) |
+| `gh run list --workflow "Deploy to Elastic Beanstalk" --limit 1` | 0 | Deploy SHA **`ef83e24`** |
+| Manual public + unauth probes | 0 | Health/CORS/unauth **PASS** |
+| `./scripts/vendor-login-session-proof.ps1` (launch origin) | 0 | Vendor cookie chain **PASS** |
+| Credentialed role-guard + Connect probes | 0 | Guards **PASS**; Connect **BLOCKED** (no business) |
+| `./scripts/smoke-backend.ps1` | 1 | **SKIP** — PowerShell parse error (encoding) |
+
+---
+
+## Deployed commit SHA
+
+| Field | Value |
+| --- | --- |
+| **`main` HEAD (local)** | `5180b2b` — Merge PR #94 (docs as-built pack) |
+| **Latest EB production deploy (GHA)** | `ef83e24` — Merge PR #93 (vendor login session cookie smoke fix) |
+| **GHA deploy run** | [27798326208](https://github.com/Techware-Hut/mosaic-backend/actions/runs/27798326208) (2026-06-19T00:43:44Z, success) |
+| **Commits on `main` not yet deployed** | **3** (`ef83e24..5180b2b`) |
+| **Open PR #98** | Not merged — launch contract script + additional smoke guards |
+
+Live probes reflect **deployed** runtime @ `ef83e24`.
+
+---
+
+## 10. What was not tested
+
+- Live Stripe payment / charge confirmation (policy: no real charges on production)
+- Webhook happy-path with valid Stripe signature
+- Customer `POST /api/orders/initiate` with populated cart and connected vendor
+- Email inbox delivery (OTP, order confirmation, vendor approval emails)
+- Admin credentialed: pending queue, finalize approve/deny, admin order list
+- Connect account-link / status with vendor that has a business + Stripe account
+- `POST /api/stripe/create-checkout-session` (business-draft subscription flow)
+- Vendor verification fee payment (`/api/vendor-onboarding/stage1/create-payment`)
+
+---
+
+## 11. Recommended next steps
+
+1. **Merge PR #98** — wire `npm run test:contract` on `main` and deploy.
+2. **Provision smoke accounts** — dedicated customer + admin (`SMOKE_TEST_*`); vendor with at least one business + Connect onboarding for Connect status probes.
+3. **Email sender hardening** — move from Gmail SMTP to transactional provider; set production `MAIL_USER` to verified domain address.
+4. **Decide on `GET /api/admin/categories`** — add `authenticate` + `isAdmin` if aggregate admin shape should not be public (P1).
+5. **Fix `smoke-backend.ps1` encoding** on Windows (replace smart quotes/em-dashes) for repeatable CI/local smoke.
+6. **Deploy `main`** to EB when ready so production matches latest docs/tests.
+7. **Rotate** any credentials used for this smoke session.
+
+---
+
+## 12. PR needed?
+
+**Yes — docs-only PR** on branch `audit/backend-mvp-launch-activation-checkout-email-admin` containing this evidence file only. No `.env`, no payment/webhook logic changes, no middleware reorder.
+
+---
+
+## Gate reference
+
+Prior vendor auth/session proof: [`BACKEND_VENDOR_AUTH_SESSION_SMOKE_GATE_3.md`](BACKEND_VENDOR_AUTH_SESSION_SMOKE_GATE_3.md) — **PASS** (2026-06-19).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node --test tests/**/*.test.js",
+    "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"

--- a/routes/admin/adminProductRoutes.js
+++ b/routes/admin/adminProductRoutes.js
@@ -5,11 +5,6 @@ const isAdmin = require('../../middlewares/isAdmin');
 
 const router = express.Router();
 
-// Test route
-router.get('/test', (req, res) => {
-  res.json({ message: 'Admin product routes working' });
-});
-
 // Get all products (admin only)
 router.get('/', authenticate, isAdmin, getAllProducts);
 

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -84,21 +84,45 @@ foreach ($p in $paths) {
     if ($code -eq 200) { Write-SmokePass "P1 GET $p ($code)" } else { Write-SmokeFail "P1 GET $p ($code, expected 200)" }
 }
 
-$corsOrigin = if ($env:FRONTEND_ORIGIN) { $env:FRONTEND_ORIGIN } else { 'https://mosaic-biz-frontend-launch.vercel.app' }
-try {
-    $corsHeaders = @{
-        Origin                         = $corsOrigin
-        'Access-Control-Request-Method' = 'GET'
+$corsOrigins = @(
+    'https://app.mosaicbizhub.com',
+    'https://mosaic-biz-frontend-launch.vercel.app'
+)
+if ($env:FRONTEND_ORIGIN) {
+    $corsOrigins = @($env:FRONTEND_ORIGIN)
+}
+foreach ($corsOrigin in $corsOrigins) {
+    try {
+        $corsHeaders = @{
+            Origin                         = $corsOrigin
+            'Access-Control-Request-Method' = 'GET'
+        }
+        $cors = Invoke-WebRequest -Uri "$Base/api/featured-products" -Method OPTIONS -Headers $corsHeaders -UseBasicParsing -ErrorAction Stop
+        $allowOrigin = $cors.Headers['Access-Control-Allow-Origin']
+        if ($cors.StatusCode -in 200, 204 -and $allowOrigin -eq $corsOrigin) {
+            Write-SmokePass "P0.4 CORS preflight ($($cors.StatusCode), Origin=$corsOrigin)"
+        } else {
+            Write-SmokeFail "P0.4 CORS preflight ($($cors.StatusCode), Allow-Origin=$allowOrigin, expected $corsOrigin)"
+        }
+    } catch {
+        Write-SmokeFail "P0.4 CORS preflight Origin=$corsOrigin - $($_.Exception.Message)"
     }
-    $cors = Invoke-WebRequest -Uri "$Base/api/featured-products" -Method OPTIONS -Headers $corsHeaders -UseBasicParsing -ErrorAction Stop
-    $allowOrigin = $cors.Headers['Access-Control-Allow-Origin']
-    if ($cors.StatusCode -in 200, 204 -and $allowOrigin -eq $corsOrigin) {
-        Write-SmokePass "P0.4 CORS preflight ($($cors.StatusCode), Origin=$corsOrigin)"
-    } else {
-        Write-SmokeFail "P0.4 CORS preflight ($($cors.StatusCode), Allow-Origin=$allowOrigin, expected $corsOrigin)"
-    }
-} catch {
-    Write-SmokeFail "P0.4 CORS preflight - $($_.Exception.Message)"
+}
+
+$code = Get-StatusCode "$Base/api/admin/categories"
+if ($code -eq 200) {
+    Write-SmokePass "NOTE GET /api/admin/categories unauth ($code) - public exposure documented"
+} else {
+    Write-SmokeFail "NOTE GET /api/admin/categories $code - expected 200 on current main"
+}
+
+$code = Get-StatusCode "$Base/admin/api/products/test"
+if ($code -eq 200) {
+    Write-SmokePass "NOTE GET /admin/api/products/test unauth ($code) - debug route pending PR 96 removal"
+} elseif ($code -eq 404) {
+    Write-SmokePass "NOTE GET /admin/api/products/test absent ($code) - PR 96 fix deployed"
+} else {
+    Write-SmokeFail "NOTE GET /admin/api/products/test $code - expected 200 on main or 404 after PR 96"
 }
 
 $code = Get-StatusCode -Uri "$Base/api/orders/initiate" -Method POST -Body '{}'
@@ -124,7 +148,7 @@ if ($env:SMOKE_TEST_VENDOR_TOKEN) {
     if ($code -in 200, 404) {
         Write-SmokePass "P2.6 vendor GET /api/vendor-onboarding/onboarding-data ($code, 404 OK for fresh vendor)"
     } elseif ($code -eq 401) {
-        Write-SmokeFail "P2.6 vendor onboarding-data ($code, expected 200 or 404 — not 401)"
+        Write-SmokeFail "P2.6 vendor onboarding-data $code - expected 200 or 404 not 401"
     } else {
         Write-SmokeFail "P2.6 vendor onboarding-data ($code, expected 200 or 404)"
     }

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -104,6 +104,21 @@ try {
 $code = Get-StatusCode -Uri "$Base/api/orders/initiate" -Method POST -Body '{}'
 if ($code -eq 401) { Write-SmokePass "P4.2 POST /api/orders/initiate unauth ($code)" } else { Write-SmokeFail "P4.2 POST /api/orders/initiate ($code, expected 401)" }
 
+$code = Get-StatusCode "$Base/api/products/featured"
+if ($code -eq 404) { Write-SmokePass "P6.0 GET /api/products/featured absent ($code)" } else { Write-SmokeFail "P6.0 GET /api/products/featured ($code, expected 404)" }
+
+$code = Get-StatusCode "$Base/admin/users"
+if ($code -eq 401) { Write-SmokePass "P3.0 GET /admin/users unauth ($code)" } else { Write-SmokeFail "P3.0 GET /admin/users ($code, expected 401)" }
+
+$code = Get-StatusCode "$Base/admin/api/products"
+if ($code -eq 401) { Write-SmokePass "P3.1 GET /admin/api/products unauth ($code)" } else { Write-SmokeFail "P3.1 GET /admin/api/products ($code, expected 401)" }
+
+$code = Get-StatusCode -Uri "$Base/api/payments/create-payment-intent" -Method POST -Body '{}'
+if ($code -eq 401) { Write-SmokePass "P4.3 POST /api/payments/create-payment-intent unauth ($code)" } else { Write-SmokeFail "P4.3 POST /api/payments/create-payment-intent ($code, expected 401)" }
+
+$code = Get-StatusCode "$Base/stripe/account-balance"
+if ($code -eq 401) { Write-SmokePass "P5.0 GET /stripe/account-balance unauth ($code)" } else { Write-SmokeFail "P5.0 GET /stripe/account-balance ($code, expected 401)" }
+
 if ($env:SMOKE_TEST_CUSTOMER_TOKEN) {
     $hdr = @{ Authorization = (Get-AuthHeader $env:SMOKE_TEST_CUSTOMER_TOKEN) }
     $code = Get-StatusCode -Uri "$Base/api/users/auth/check" -Headers $hdr

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -79,6 +79,22 @@ auth_header() {
 code=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" "$BASE/api/orders/initiate")
 if [ "$code" = "401" ]; then pass "P4.2 POST /api/orders/initiate unauth ($code)"; else fail "P4.2 POST /api/orders/initiate ($code, expected 401)"; fi
 
+# Launch contract guards (unauthenticated only)
+code=$(http_code "$BASE/api/products/featured")
+if [ "$code" = "404" ]; then pass "P6.0 GET /api/products/featured absent ($code)"; else fail "P6.0 GET /api/products/featured ($code, expected 404)"; fi
+
+code=$(http_code "$BASE/admin/users")
+if [ "$code" = "401" ]; then pass "P3.0 GET /admin/users unauth ($code)"; else fail "P3.0 GET /admin/users ($code, expected 401)"; fi
+
+code=$(http_code "$BASE/admin/api/products")
+if [ "$code" = "401" ]; then pass "P3.1 GET /admin/api/products unauth ($code)"; else fail "P3.1 GET /admin/api/products ($code, expected 401)"; fi
+
+code=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Content-Type: application/json" "$BASE/api/payments/create-payment-intent")
+if [ "$code" = "401" ]; then pass "P4.3 POST /api/payments/create-payment-intent unauth ($code)"; else fail "P4.3 POST /api/payments/create-payment-intent ($code, expected 401)"; fi
+
+code=$(http_code "$BASE/stripe/account-balance")
+if [ "$code" = "401" ]; then pass "P5.0 GET /stripe/account-balance unauth ($code)"; else fail "P5.0 GET /stripe/account-balance ($code, expected 401)"; fi
+
 if [ -n "${SMOKE_TEST_CUSTOMER_TOKEN:-}" ]; then
   hdr=$(auth_header "$SMOKE_TEST_CUSTOMER_TOKEN")
   code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $hdr" "$BASE/api/users/auth/check")

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -57,15 +57,39 @@ do
   if [ "$code" = "200" ]; then pass "P1 GET $path ($code)"; else fail "P1 GET $path ($code, expected 200)"; fi
 done
 
-CORS_ORIGIN="${FRONTEND_ORIGIN:-https://mosaic-biz-frontend-launch.vercel.app}"
-cors_headers=$(curl -s -D - -o /dev/null -X OPTIONS \
-  -H "Origin: $CORS_ORIGIN" \
-  -H "Access-Control-Request-Method: GET" \
-  "$BASE/api/featured-products")
-if echo "$cors_headers" | grep -qi "access-control-allow-origin: $CORS_ORIGIN"; then
-  pass "P0.4 CORS preflight (Origin=$CORS_ORIGIN)"
+CORS_ORIGINS=(
+  "https://app.mosaicbizhub.com"
+  "https://mosaic-biz-frontend-launch.vercel.app"
+)
+if [ -n "${FRONTEND_ORIGIN:-}" ]; then
+  CORS_ORIGINS=("$FRONTEND_ORIGIN")
+fi
+for CORS_ORIGIN in "${CORS_ORIGINS[@]}"; do
+  cors_headers=$(curl -s -D - -o /dev/null -X OPTIONS \
+    -H "Origin: $CORS_ORIGIN" \
+    -H "Access-Control-Request-Method: GET" \
+    "$BASE/api/featured-products")
+  if echo "$cors_headers" | grep -qi "access-control-allow-origin: $CORS_ORIGIN"; then
+    pass "P0.4 CORS preflight (Origin=$CORS_ORIGIN)"
+  else
+    fail "P0.4 CORS preflight (Origin=$CORS_ORIGIN)"
+  fi
+done
+
+code=$(http_code "$BASE/api/admin/categories")
+if [ "$code" = "200" ]; then
+  pass "NOTE GET /api/admin/categories unauth ($code) — public exposure documented"
 else
-  fail "P0.4 CORS preflight (Origin=$CORS_ORIGIN)"
+  fail "NOTE GET /api/admin/categories ($code, expected 200 on current main)"
+fi
+
+code=$(http_code "$BASE/admin/api/products/test")
+if [ "$code" = "200" ]; then
+  pass "NOTE GET /admin/api/products/test unauth ($code) — debug route pending PR #96 removal"
+elif [ "$code" = "404" ]; then
+  pass "NOTE GET /admin/api/products/test absent ($code) — PR #96 fix deployed"
+else
+  fail "NOTE GET /admin/api/products/test ($code, expected 200 on main or 404 after PR #96)"
 fi
 
 # Optional auth probes

--- a/tests/admin/admin-categories-guard.test.js
+++ b/tests/admin/admin-categories-guard.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const categoryRoutesPath = path.resolve(__dirname, '../../routes/categoryRoutes.js');
+
+test('GET /api/admin/categories is registered without auth middleware (documented public exposure)', () => {
+  const source = fs.readFileSync(categoryRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/admin\/categories', getAllCategoriesAdmin\)/);
+  const adminBlock = source.slice(source.indexOf("router.get('/admin/categories'"));
+  assert.ok(!adminBlock.includes('authenticate'), 'no authenticate on admin categories route');
+  assert.ok(!adminBlock.includes('isAdmin'), 'no isAdmin on admin categories route');
+});

--- a/tests/admin/admin-product-routes-guard.test.js
+++ b/tests/admin/admin-product-routes-guard.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const adminProductRoutesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminProductRoutes.js'
+);
+
+test('admin product routes do not expose unauthenticated /test debug endpoint', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+
+  assert.ok(!source.includes("router.get('/test'"), 'debug /test route must be removed');
+  assert.ok(!source.includes('Admin product routes working'));
+});
+
+test('admin product list and featured toggle remain guarded', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+});
+
+test('admin product routes only register guarded handlers', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+  const routeMatches = [...source.matchAll(/router\.(get|post|put|patch|delete)\(/g)];
+
+  assert.equal(routeMatches.length, 2, 'expected only list and featured-toggle routes');
+});

--- a/tests/admin/admin-product-routes-guard.test.js
+++ b/tests/admin/admin-product-routes-guard.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const adminProductRoutesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminProductRoutes.js'
+);
+
+test('admin product list and featured toggle remain guarded', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+});
+
+test('admin product debug /test route audit documents main state pending PR #96', () => {
+  const source = fs.readFileSync(adminProductRoutesPath, 'utf8');
+  const hasDebugRoute = source.includes("router.get('/test'");
+
+  // On main the unguarded debug route exists until PR #96 merges.
+  assert.equal(
+    hasDebugRoute,
+    true,
+    'expected unguarded /test on main — remove assertion after PR #96 merge'
+  );
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -1,0 +1,244 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const root = path.resolve(__dirname, '../..');
+const appPath = path.join(root, 'app.js');
+const featuredRoutesPath = path.join(root, 'routes/featuredProductRoutes.js');
+const businessRoutesPath = path.join(root, 'routes/businessRoutes.js');
+const adminUserRoutesPath = path.join(root, 'routes/admin/userRoutes.js');
+const adminProductRoutesPath = path.join(root, 'routes/admin/adminProductRoutes.js');
+const orderRoutesPath = path.join(root, 'routes/orderRoutes.js');
+const paymentRoutesPath = path.join(root, 'routes/paymentRoutes.js');
+const connectRoutesPath = path.join(root, 'routes/connectRoutes.js');
+const stripeFinanceRoutesPath = path.join(root, 'routes/stripe.routes.js');
+const healthRoutesPath = path.join(root, 'routes/healthRoutes.js');
+const isAdminPath = path.join(root, 'middlewares/isAdmin.js');
+const toAdminUserPath = path.join(root, 'utils/toAdminUser.js');
+
+function readSource(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('app.js mounts launch-critical route prefixes', () => {
+  const source = readSource(appPath);
+
+  const mounts = [
+    "app.use('/api', healthRoutes)",
+    "app.use('/api/business', businessRoutes)",
+    "app.use('/admin/users', adminUserRoutes)",
+    "app.use('/admin/api/products', adminProductRoutes)",
+    "app.use('/api/payments', paymentRoutes)",
+    "app.use('/api/orders', orderRoutes)",
+    "app.use('/api/connect', connectRoutes)",
+    "app.use('/stripe', stripeNewRoutes)",
+    "app.use('/api', featuredProductRoutes)",
+  ];
+
+  for (const mount of mounts) {
+    assert.ok(source.includes(mount), `expected mount: ${mount}`);
+  }
+});
+
+test('GET /api/featured-products is canonical and /api/products/featured is absent', () => {
+  const featuredSource = readSource(featuredRoutesPath);
+  const appSource = readSource(appPath);
+
+  assert.ok(featuredSource.includes("router.get('/featured-products'"));
+  assert.ok(!featuredSource.includes('/products/featured'));
+  assert.ok(!appSource.includes('/api/products/featured'));
+  assert.ok(!appSource.includes('/products/featured'));
+});
+
+test('stale frontend alias paths are not registered', () => {
+  const appSource = readSource(appPath);
+  const routesDir = path.join(root, 'routes');
+  const routeFiles = fs
+    .readdirSync(routesDir, { recursive: true })
+    .filter((file) => typeof file === 'string' && file.endsWith('.js'))
+    .map((file) => readSource(path.join(routesDir, file)));
+
+  assert.ok(!appSource.includes("app.use('/api/admin/users'"));
+  assert.ok(!appSource.includes("app.use('/api/stripe/account-session'"));
+
+  for (const source of routeFiles) {
+    assert.ok(!source.includes('/api/admin/users'), 'route file must not define /api/admin/users');
+    assert.ok(
+      !source.includes("router.post('/api/stripe/account-session'"),
+      'route file must not define /api/stripe/account-session'
+    );
+  }
+});
+
+test('GET /api/business/my requires authenticate and business_owner role', () => {
+  const source = readSource(businessRoutesPath);
+  const myBlock = source.slice(source.indexOf("'/my'"));
+
+  assert.ok(myBlock.includes('authenticate'));
+  assert.ok(myBlock.includes('isBusinessOwner'));
+  assert.ok(myBlock.indexOf('authenticate') < myBlock.indexOf('getMyBusinesses'));
+});
+
+test('admin user routes apply router-level authenticate and isAdmin', () => {
+  const source = readSource(adminUserRoutesPath);
+
+  assert.match(source, /router\.use\(authenticate,\s*isAdmin\)/);
+});
+
+test('admin product list and featured toggle require authenticate and isAdmin', () => {
+  const source = readSource(adminProductRoutesPath);
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+});
+
+test('isAdmin rejects non-admin users with 403', async () => {
+  const isAdmin = require(isAdminPath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await isAdmin({ user: { role: 'customer' } }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+});
+
+test('toAdminUser strips sensitive fields from admin list responses', () => {
+  const toAdminUser = require(toAdminUserPath);
+  const sanitized = toAdminUser({
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    role: 'admin',
+    passwordHash: 'secret-hash',
+    otp: '123456',
+    sessionVersion: 3,
+  });
+
+  assert.equal(sanitized.passwordHash, undefined);
+  assert.equal(sanitized.otp, undefined);
+  assert.equal(sanitized.sessionVersion, undefined);
+  assert.equal(sanitized.email, 'admin@example.com');
+});
+
+test('POST /api/orders/initiate requires authenticate and customer role', () => {
+  const source = readSource(orderRoutesPath);
+  assert.match(source, /router\.post\('\/initiate', authenticate, isCustomer, initiateOrder\)/);
+});
+
+// Legacy route: canonical checkout is POST /api/orders/initiate (Connect destination charge).
+test('POST /api/payments/create-payment-intent is legacy but guarded', () => {
+  const source = readSource(paymentRoutesPath);
+  const routeBlock = source.slice(source.indexOf("'/create-payment-intent'"));
+
+  assert.ok(routeBlock.includes('authenticate'));
+  assert.ok(routeBlock.includes('isCustomer'));
+  assert.ok(routeBlock.includes('paymentLimiter'));
+  assert.ok(routeBlock.indexOf('authenticate') < routeBlock.indexOf('createPaymentIntent'));
+});
+
+test('app.js keeps Stripe webhook raw-body mounts before express.json', () => {
+  const source = readSource(appPath);
+  const jsonIndex = source.indexOf('app.use(express.json');
+  const mounts = [
+    "app.use('/api/stripe'",
+    "app.use('/api/webhooks'",
+    "app.use('/api/vendor-onboarding/webhook/payment'",
+    "app.use('/api/subscription/webhook'",
+  ];
+
+  assert.ok(jsonIndex > -1, 'express.json middleware must exist in app.js');
+  for (const mount of mounts) {
+    const mountIndex = source.indexOf(mount);
+    assert.ok(mountIndex > -1 && mountIndex < jsonIndex, `${mount} must appear before express.json`);
+  }
+});
+
+test('Connect account-link and status routes require business_owner auth', () => {
+  const source = readSource(connectRoutesPath);
+
+  assert.match(
+    source,
+    /router\.post\('\/:businessId\/account-link', authenticate, isBusinessOwner, createAccountLink\)/
+  );
+  assert.match(
+    source,
+    /router\.get\('\/:businessId\/status', authenticate, isBusinessOwner, getStatus\)/
+  );
+});
+
+test('Stripe finance routes under /stripe require business_owner auth', () => {
+  const source = readSource(stripeFinanceRoutesPath);
+
+  assert.match(source, /router\.post\('\/account-session', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.post\('\/express-login-link', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/account-balance', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/last-payout', authenticate, isBusinessOwner/);
+});
+
+test('health routes are mounted under /api with /health and /ready handlers', () => {
+  const appSource = readSource(appPath);
+  const healthSource = readSource(healthRoutesPath);
+
+  assert.ok(appSource.includes("app.use('/api', healthRoutes)"));
+  assert.ok(healthSource.includes("router.get('/health'"));
+  assert.ok(healthSource.includes("router.get('/ready'"));
+});
+
+test('app.js defines public GET / root handler', () => {
+  const source = readSource(appPath);
+  assert.match(source, /app\.get\('\/',\s*\(req,\s*res\)\s*=>\s*\{/);
+});
+
+test('documented launch paths resolve to expected registration status', () => {
+  const appSource = readSource(appPath);
+  const stripeFinanceSource = readSource(stripeFinanceRoutesPath);
+
+  const expectedPresent = [
+    { label: '/admin/users', needle: "app.use('/admin/users'" },
+    { label: '/admin/api/products', needle: "app.use('/admin/api/products'" },
+    { label: '/api/orders/initiate', needle: "app.use('/api/orders'" },
+    { label: '/api/payments/create-payment-intent', needle: "app.use('/api/payments'" },
+    { label: '/stripe/account-session', needle: "router.post('/account-session'" },
+    { label: '/stripe/express-login-link', needle: "router.post('/express-login-link'" },
+    { label: '/stripe/account-balance', needle: "router.get('/account-balance'" },
+    { label: '/stripe/last-payout', needle: "router.get('/last-payout'" },
+  ];
+
+  for (const entry of expectedPresent) {
+    const haystack = entry.label.startsWith('/stripe/') ? stripeFinanceSource : appSource;
+    assert.ok(haystack.includes(entry.needle), `${entry.label} should be registered`);
+  }
+
+  const expectedAbsent = [
+    "app.use('/api/admin/users'",
+    "app.use('/api/stripe/account-session'",
+    '/api/products/featured',
+  ];
+
+  for (const needle of expectedAbsent) {
+    assert.ok(!appSource.includes(needle), `${needle} should not be registered`);
+  }
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -1,0 +1,245 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const root = path.resolve(__dirname, '../..');
+const appPath = path.join(root, 'app.js');
+const featuredRoutesPath = path.join(root, 'routes/featuredProductRoutes.js');
+const businessRoutesPath = path.join(root, 'routes/businessRoutes.js');
+const adminUserRoutesPath = path.join(root, 'routes/admin/userRoutes.js');
+const adminProductRoutesPath = path.join(root, 'routes/admin/adminProductRoutes.js');
+const orderRoutesPath = path.join(root, 'routes/orderRoutes.js');
+const paymentRoutesPath = path.join(root, 'routes/paymentRoutes.js');
+const connectRoutesPath = path.join(root, 'routes/connectRoutes.js');
+const stripeFinanceRoutesPath = path.join(root, 'routes/stripe.routes.js');
+const healthRoutesPath = path.join(root, 'routes/healthRoutes.js');
+const isAdminPath = path.join(root, 'middlewares/isAdmin.js');
+const toAdminUserPath = path.join(root, 'utils/toAdminUser.js');
+
+function readSource(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('app.js mounts launch-critical route prefixes', () => {
+  const source = readSource(appPath);
+
+  const mounts = [
+    "app.use('/api', healthRoutes)",
+    "app.use('/api/business', businessRoutes)",
+    "app.use('/admin/users', adminUserRoutes)",
+    "app.use('/admin/api/products', adminProductRoutes)",
+    "app.use('/api/payments', paymentRoutes)",
+    "app.use('/api/orders', orderRoutes)",
+    "app.use('/api/connect', connectRoutes)",
+    "app.use('/stripe', stripeNewRoutes)",
+    "app.use('/api', featuredProductRoutes)",
+  ];
+
+  for (const mount of mounts) {
+    assert.ok(source.includes(mount), `expected mount: ${mount}`);
+  }
+});
+
+test('GET /api/featured-products is canonical and /api/products/featured is absent', () => {
+  const featuredSource = readSource(featuredRoutesPath);
+  const appSource = readSource(appPath);
+
+  assert.ok(featuredSource.includes("router.get('/featured-products'"));
+  assert.ok(!featuredSource.includes('/products/featured'));
+  assert.ok(!appSource.includes('/api/products/featured'));
+  assert.ok(!appSource.includes('/products/featured'));
+});
+
+test('stale frontend alias paths are not registered', () => {
+  const appSource = readSource(appPath);
+  const routesDir = path.join(root, 'routes');
+  const routeFiles = fs
+    .readdirSync(routesDir, { recursive: true })
+    .filter((file) => typeof file === 'string' && file.endsWith('.js'))
+    .map((file) => readSource(path.join(routesDir, file)));
+
+  assert.ok(!appSource.includes("app.use('/api/admin/users'"));
+  assert.ok(!appSource.includes("app.use('/api/stripe/account-session'"));
+
+  for (const source of routeFiles) {
+    assert.ok(!source.includes('/api/admin/users'), 'route file must not define /api/admin/users');
+    assert.ok(
+      !source.includes("router.post('/api/stripe/account-session'"),
+      'route file must not define /api/stripe/account-session'
+    );
+  }
+});
+
+test('GET /api/business/my requires authenticate and business_owner role', () => {
+  const source = readSource(businessRoutesPath);
+  const myBlock = source.slice(source.indexOf("'/my'"));
+
+  assert.ok(myBlock.includes('authenticate'));
+  assert.ok(myBlock.includes('isBusinessOwner'));
+  assert.ok(myBlock.indexOf('authenticate') < myBlock.indexOf('getMyBusinesses'));
+});
+
+test('admin user routes apply router-level authenticate and isAdmin', () => {
+  const source = readSource(adminUserRoutesPath);
+
+  assert.match(source, /router\.use\(authenticate,\s*isAdmin\)/);
+});
+
+test('admin product list and featured toggle require authenticate and isAdmin', () => {
+  const source = readSource(adminProductRoutesPath);
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllProducts\)/);
+  assert.match(
+    source,
+    /router\.patch\('\/:productId\/featured', authenticate, isAdmin, toggleProductFeatured\)/
+  );
+  assert.ok(!source.includes("router.get('/test'"), 'unguarded debug /test route must not exist');
+});
+
+test('isAdmin rejects non-admin users with 403', async () => {
+  const isAdmin = require(isAdminPath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await isAdmin({ user: { role: 'customer' } }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+});
+
+test('toAdminUser strips sensitive fields from admin list responses', () => {
+  const toAdminUser = require(toAdminUserPath);
+  const sanitized = toAdminUser({
+    _id: '507f1f77bcf86cd799439011',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    role: 'admin',
+    passwordHash: 'secret-hash',
+    otp: '123456',
+    sessionVersion: 3,
+  });
+
+  assert.equal(sanitized.passwordHash, undefined);
+  assert.equal(sanitized.otp, undefined);
+  assert.equal(sanitized.sessionVersion, undefined);
+  assert.equal(sanitized.email, 'admin@example.com');
+});
+
+test('POST /api/orders/initiate requires authenticate and customer role', () => {
+  const source = readSource(orderRoutesPath);
+  assert.match(source, /router\.post\('\/initiate', authenticate, isCustomer, initiateOrder\)/);
+});
+
+// Legacy route: canonical checkout is POST /api/orders/initiate (Connect destination charge).
+test('POST /api/payments/create-payment-intent is legacy but guarded', () => {
+  const source = readSource(paymentRoutesPath);
+  const routeBlock = source.slice(source.indexOf("'/create-payment-intent'"));
+
+  assert.ok(routeBlock.includes('authenticate'));
+  assert.ok(routeBlock.includes('isCustomer'));
+  assert.ok(routeBlock.includes('paymentLimiter'));
+  assert.ok(routeBlock.indexOf('authenticate') < routeBlock.indexOf('createPaymentIntent'));
+});
+
+test('app.js keeps Stripe webhook raw-body mounts before express.json', () => {
+  const source = readSource(appPath);
+  const jsonIndex = source.indexOf('app.use(express.json');
+  const mounts = [
+    "app.use('/api/stripe'",
+    "app.use('/api/webhooks'",
+    "app.use('/api/vendor-onboarding/webhook/payment'",
+    "app.use('/api/subscription/webhook'",
+  ];
+
+  assert.ok(jsonIndex > -1, 'express.json middleware must exist in app.js');
+  for (const mount of mounts) {
+    const mountIndex = source.indexOf(mount);
+    assert.ok(mountIndex > -1 && mountIndex < jsonIndex, `${mount} must appear before express.json`);
+  }
+});
+
+test('Connect account-link and status routes require business_owner auth', () => {
+  const source = readSource(connectRoutesPath);
+
+  assert.match(
+    source,
+    /router\.post\('\/:businessId\/account-link', authenticate, isBusinessOwner, createAccountLink\)/
+  );
+  assert.match(
+    source,
+    /router\.get\('\/:businessId\/status', authenticate, isBusinessOwner, getStatus\)/
+  );
+});
+
+test('Stripe finance routes under /stripe require business_owner auth', () => {
+  const source = readSource(stripeFinanceRoutesPath);
+
+  assert.match(source, /router\.post\('\/account-session', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.post\('\/express-login-link', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/account-balance', authenticate, isBusinessOwner/);
+  assert.match(source, /router\.get\('\/last-payout', authenticate, isBusinessOwner/);
+});
+
+test('health routes are mounted under /api with /health and /ready handlers', () => {
+  const appSource = readSource(appPath);
+  const healthSource = readSource(healthRoutesPath);
+
+  assert.ok(appSource.includes("app.use('/api', healthRoutes)"));
+  assert.ok(healthSource.includes("router.get('/health'"));
+  assert.ok(healthSource.includes("router.get('/ready'"));
+});
+
+test('app.js defines public GET / root handler', () => {
+  const source = readSource(appPath);
+  assert.match(source, /app\.get\('\/',\s*\(req,\s*res\)\s*=>\s*\{/);
+});
+
+test('documented launch paths resolve to expected registration status', () => {
+  const appSource = readSource(appPath);
+  const stripeFinanceSource = readSource(stripeFinanceRoutesPath);
+
+  const expectedPresent = [
+    { label: '/admin/users', needle: "app.use('/admin/users'" },
+    { label: '/admin/api/products', needle: "app.use('/admin/api/products'" },
+    { label: '/api/orders/initiate', needle: "app.use('/api/orders'" },
+    { label: '/api/payments/create-payment-intent', needle: "app.use('/api/payments'" },
+    { label: '/stripe/account-session', needle: "router.post('/account-session'" },
+    { label: '/stripe/express-login-link', needle: "router.post('/express-login-link'" },
+    { label: '/stripe/account-balance', needle: "router.get('/account-balance'" },
+    { label: '/stripe/last-payout', needle: "router.get('/last-payout'" },
+  ];
+
+  for (const entry of expectedPresent) {
+    const haystack = entry.label.startsWith('/stripe/') ? stripeFinanceSource : appSource;
+    assert.ok(haystack.includes(entry.needle), `${entry.label} should be registered`);
+  }
+
+  const expectedAbsent = [
+    "app.use('/api/admin/users'",
+    "app.use('/api/stripe/account-session'",
+    '/api/products/featured',
+  ];
+
+  for (const needle of expectedAbsent) {
+    assert.ok(!appSource.includes(needle), `${needle} should not be registered`);
+  }
+});


### PR DESCRIPTION
## Summary

Consolidates all pending launch-readiness work from open PRs **#95**, **#96**, and **#97** into a single merge to `main`:

- **Launch contract verification** — 16 static contract tests (`npm run test:contract`), P0/P1 evidence docs, extended smoke script unauth checks
- **Admin products hardening** — removes unauthenticated debug route `GET /admin/api/products/test`; adds guard tests
- **Vendor auth smoke proof** — production smoke evidence doc, dual CORS origin support in smoke scripts, admin categories exposure audit

**No payment, webhook, auth middleware, CORS, cookie, or deploy logic changes** beyond removing the debug-only admin products test route.

## Supersedes

| PR | Branch | Action after merge |
| --- | --- | --- |
| #95 | `test/backend-launch-contract-smoke-guards` | Close (superseded) |
| #96 | `fix/backend-guard-admin-products-test-route` | Close (superseded) |
| #97 | `qa/backend-vendor-auth-smoke-proof` | Close (superseded) |

## Test plan

- [x] `npm test` — **232 pass**, 0 fail
- [x] `npm run test:contract` — **16 pass**, 0 fail
- [ ] `npm run smoke:backend` against `https://api.mosaicbizhub.com` (both CORS origins)
- [ ] Confirm `GET /admin/api/products/test` returns **404** after deploy
- [ ] Re-run production smoke proof from `docs/BACKEND_VENDOR_AUTH_SMOKE_PROOF.md`
- [ ] Credentialed vendor session smoke (requires `SMOKE_TEST_VENDOR_EMAIL` / `PASSWORD`)

## Post-merge follow-ups (not in this PR)

- Guard or document public `GET /api/admin/categories` (medium — backlog)
- Frontend path audit: `/api/admin/users`, `/api/stripe/*` aliases
- EB Sentry env vars + optional debug route verification
