### PR TITLE
fix: reconcile vendor verification payment on submit before webhook updates DB

### DIFF
--- a/controllers/vendorOnboarding.controller.js
+++ b/controllers/vendorOnboarding.controller.js
@@ -680,6 +680,52 @@ exports.patchBusinessProfile = async (req, res) => {
 
 
 
+async function reconcileVendorVerificationPaymentFromStripe(onboarding, userId) {
+  if (onboarding.verificationPayment?.status === 'paid') {
+    return true;
+  }
+
+  const paymentIntentId = onboarding.verificationPayment?.paymentIntentId;
+  if (!paymentIntentId) {
+    return false;
+  }
+
+  let paymentIntent;
+  try {
+    paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+  } catch (error) {
+    console.error('Vendor verification payment retrieve failed:', error.message);
+    return false;
+  }
+
+  if (paymentIntent.status !== 'succeeded') {
+    return false;
+  }
+
+  if (paymentIntent.metadata?.type !== 'vendor_verification') {
+    return false;
+  }
+
+  if (paymentIntent.metadata?.userId !== userId.toString()) {
+    return false;
+  }
+
+  if (paymentIntent.id !== paymentIntentId) {
+    return false;
+  }
+
+  onboarding.verificationPayment.status = 'paid';
+  if (!onboarding.verificationPayment.paidAt) {
+    onboarding.verificationPayment.paidAt = new Date();
+  }
+  if (onboarding.status === 'payment_pending') {
+    onboarding.status = 'draft';
+  }
+  await onboarding.save();
+
+  return true;
+}
+
 //payment controllers
 exports.createVerificationPayment = async (req, res) => {
   try {
@@ -934,10 +980,11 @@ if (
     /* ------------------------------
        PAYMENT VALIDATION (MANDATORY)
     ------------------------------ */
-    if (
-      !onboarding.verificationPayment ||
-      onboarding.verificationPayment.status !== "paid"
-    ) {
+    const paymentReady =
+      onboarding.verificationPayment?.status === 'paid' ||
+      (await reconcileVendorVerificationPaymentFromStripe(onboarding, userId));
+
+    if (!paymentReady) {
       return res.status(402).json({
         success: false,
         message: "Verification payment must be completed before submission",

--- a/docs/S3_UPLOAD_CORS.md
+++ b/docs/S3_UPLOAD_CORS.md
@@ -1,0 +1,153 @@
+# S3 Presigned Upload CORS — Production Verification
+
+**Issue:** Vendor onboarding browser upload fails when `PUT`ing directly to S3 pre-signed URL (not Express API CORS).  
+**Evidence date:** 2026-06-19 (UTC)  
+**Production API:** `https://api.mosaicbizhub.com`  
+**Production bucket (from presigned URL host):** `mosaic-biz-hub` · region `us-east-1`
+
+No AWS keys, signed URLs, ETag values, cookies, JWTs, or env values in this document.
+
+---
+
+## Executive verdict
+
+**S3 upload CORS: PASS**
+
+After bucket CORS was updated on `mosaic-biz-hub`, production probes confirm browser-allowed origins, successful OPTIONS preflight, and successful presigned PUT for vendor onboarding Stage 1 documents.
+
+---
+
+## This is not Express CORS
+
+| Layer | Applies to | Config location |
+| --- | --- | --- |
+| **Express CORS** | `https://api.mosaicbizhub.com` | [`utils/corsOrigins.js`](../utils/corsOrigins.js), [`app.js`](../app.js) |
+| **S3 bucket CORS** | `https://{bucket}.s3.{region}.amazonaws.com/...` | AWS S3 Console → bucket → Permissions → CORS |
+
+See also [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md) for API CORS only.
+
+---
+
+## Backend presign flow (unchanged)
+
+| Item | Detail |
+| --- | --- |
+| Route | `GET /api/vendor-onboarding/stage1/upload-url` |
+| Guards | `authenticate` + `requireVerifiedVendor` |
+| Controller | [`controllers/vendorOnboardingUpload.controller.js`](../controllers/vendorOnboardingUpload.controller.js) |
+| Query params | `fileName`, `fileType`, `documentType` |
+| Response | `{ success, uploadUrl, fileUrl, documentType, key }` |
+| Signed fields | `PutObjectCommand` includes `ContentType` (must match browser PUT header) |
+| Key prefix | `vendor-onboarding/stage1/{userId}/...` |
+| Expiry | 300 seconds |
+
+**Allowed MIME types:** JPEG, PNG, WebP, PDF — [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingUploadMimeAllowlist.js)
+
+**Required env var names (values in EB only):** `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_BUCKET`
+
+---
+
+## Required S3 bucket CORS policy
+
+Apply on bucket **`mosaic-biz-hub`** (must match production `AWS_S3_BUCKET`):
+
+```json
+[
+  {
+    "AllowedOrigins": [
+      "https://mosaic-biz-frontend-launch.vercel.app",
+      "https://app.mosaicbizhub.com"
+    ],
+    "AllowedMethods": ["PUT", "GET", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }
+]
+```
+
+**Console:** S3 → `mosaic-biz-hub` → Permissions → Cross-origin resource sharing (CORS)  
+**CLI (release owner):** `aws s3api get-bucket-cors --bucket mosaic-biz-hub --region us-east-1`
+
+---
+
+## Live verification results (2026-06-19)
+
+Probes used credentialed vendor session against production API; signed URL query strings were **not** recorded.
+
+### API presign
+
+| Step | Expected | Result |
+| --- | --- | --- |
+| `GET /api/vendor-onboarding/stage1/upload-url` | 200 | **PASS** — 200, `success: true`, `fileUrl` present |
+| Response host | `mosaic-biz-hub.s3.us-east-1.amazonaws.com` | **PASS** |
+
+### S3 CORS preflight (OPTIONS)
+
+| Origin | Expected ACAO | HTTP | Result |
+| --- | --- | --- | --- |
+| `https://mosaic-biz-frontend-launch.vercel.app` | exact match | **200** | **PASS** |
+| `https://app.mosaicbizhub.com` | exact match | **200** | **PASS** |
+
+Observed on launch origin (sanitized): `Access-Control-Allow-Methods` includes PUT; `Access-Control-Expose-Headers` includes ETag.
+
+### S3 presigned PUT
+
+| Check | Expected | Result |
+| --- | --- | --- |
+| PUT with signed `Content-Type: application/pdf` | 200 | **PASS** |
+| ETag response header | present | **PASS** |
+
+### Frontend form state
+
+| Check | Status |
+| --- | --- |
+| Browser stores `fileUrl` (not `uploadUrl`) in onboarding form | **Manual** — confirm in DevTools / UI after re-test on launch frontend |
+
+---
+
+## Frontend upload contract
+
+1. `GET /api/vendor-onboarding/stage1/upload-url?fileName=...&fileType={file.type}&documentType=...` with vendor cookies.
+2. `PUT` to `uploadUrl` with body = raw file bytes (not `multipart/form-data`).
+3. Header `Content-Type` must **exactly** match the `fileType` query param sent to the API (backend signs this into the URL).
+4. Persist **`fileUrl`** from the API response for draft/submit payloads.
+
+If PUT returns **403 SignatureDoesNotMatch**, check Content-Type mismatch before re-checking CORS.
+
+---
+
+## Automated backend tests
+
+| Command | Result |
+| --- | --- |
+| `npm test` (includes `tests/vendor/vendor-onboarding-upload-mime.test.js`) | **228 pass**, 0 fail |
+
+Unit tests prove MIME allowlist, auth wiring, and `ContentType` on `PutObjectCommand`; they do **not** replace live S3 CORS proof.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| No `Access-Control-Allow-Origin` on S3 PUT | Bucket CORS missing/wrong origin | Re-apply policy above on correct bucket |
+| CORS OK, PUT 403 | Content-Type ≠ signed type | Align `fileType` query with PUT header |
+| `upload-url` 401/403 | Vendor auth / OTP | Express auth — not S3 |
+| PUT OK, file not viewable | Bucket policy / object ACL | Separate from upload CORS |
+
+---
+
+## Out of scope
+
+- Stripe / payment / webhook changes
+- Express API CORS middleware changes
+- Bucket public-read policy (unless upload succeeds but GET of `fileUrl` fails)
+
+---
+
+## Related docs
+
+- [`docs/TEST_MATRIX.md`](TEST_MATRIX.md) — P2.6 upload smoke row
+- [`docs/VENDOR_LIFECYCLE.md`](VENDOR_LIFECYCLE.md) — Stage 1 upload route
+- [`docs/production-smoke-checklist.md`](production-smoke-checklist.md) — P2.6 upload URL check

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -97,7 +97,7 @@ Maps backend features to automated tests (`npm test`), manual smoke checks, and 
 | Upload handler MIME gate | same | `getStage1UploadUrl` returns 400 for unsafe MIME | File content validation (magic bytes) | Yes — P2.6 |
 | Upload auth | same | Upload route blocked without auth; blocks non-vendor | `requireVerifiedVendor` OTP gate live | Yes — P2.6 |
 | documentType allowlist | — | *(tested in controller, not every type)* | All 7 `documentType` values end-to-end | Yes — P2.6 |
-| S3 upload completion | — | *(no automated test)* | Client PUT to presigned URL succeeds | Yes — human |
+| S3 upload completion | — | *(no automated test)* | Client PUT to presigned URL succeeds | Yes — human; live CORS proof in [`S3_UPLOAD_CORS.md`](S3_UPLOAD_CORS.md) (**PASS** 2026-06-19) |
 
 ---
 

--- a/tests/vendor/vendor-verification-payment-submit-reconcile.test.js
+++ b/tests/vendor/vendor-verification-payment-submit-reconcile.test.js
@@ -1,0 +1,273 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const profileFieldsPath = path.resolve(
+  __dirname,
+  '../../utils/vendorOnboardingProfileFields.js'
+);
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/vendorOnboarding.controller.js'
+);
+
+const userId = '507f1f77bcf86cd799439011';
+const paymentIntentId = 'pi_test_reconcile_001';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOnboarding(overrides = {}) {
+  return {
+    userId,
+    applicationId: 'MBH-APP-TEST-001',
+    businessName: 'Test Business',
+    businessType: 'product',
+    primaryContactName: 'Jane Vendor',
+    address: {
+      city: 'Atlanta',
+      state: 'GA',
+      country: 'USA',
+      zipCode: '30301',
+    },
+    acceptedTerms: true,
+    declarationAccepted: true,
+    isMinorityOwned: false,
+    status: 'draft',
+    badge: null,
+    totalVerificationPoints: 0,
+    verificationPayment: {
+      status: 'pending',
+      paymentIntentId,
+      paidAt: null,
+    },
+    toObject() {
+      return { ...this };
+    },
+    save: async () => {},
+    ...overrides,
+  };
+}
+
+function buildSucceededPaymentIntent(metadataOverrides = {}) {
+  return {
+    id: paymentIntentId,
+    status: 'succeeded',
+    metadata: {
+      type: 'vendor_verification',
+      userId: userId.toString(),
+      applicationId: 'MBH-APP-TEST-001',
+      ...metadataOverrides,
+    },
+  };
+}
+
+function loadController(onboarding, { retrieveResult, retrieveError } = {}) {
+  process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+  process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+
+  const retrieveCalls = [];
+  const vendorOnboardingMock = {
+    findOne: async () => onboarding,
+  };
+
+  const userMock = {
+    findById: () => ({
+      select: async () => ({ name: 'Vendor User', email: 'vendor@example.com' }),
+    }),
+  };
+
+  const mailerMock = {
+    sendAdminOnboardingSubmissionEmail: async () => {},
+    sendVendorSubmissionConfirmationEmail: async () => {},
+    sendAdminVendorProfileCompletedEmail: async () => {},
+  };
+
+  const stripeMock = () => ({
+    paymentIntents: {
+      create: async () => ({ id: paymentIntentId }),
+      retrieve: async (id) => {
+        retrieveCalls.push(id);
+        if (retrieveError) {
+          throw retrieveError;
+        }
+        if (typeof retrieveResult === 'function') {
+          return retrieveResult(id);
+        }
+        return retrieveResult;
+      },
+    },
+  });
+
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return stripeMock;
+    }
+    if (request === '../models/VendorOnboardingStage1') {
+      return vendorOnboardingMock;
+    }
+    if (request === '../models/User') {
+      return userMock;
+    }
+    if (request === '../utils/WellcomeMailer') {
+      return mailerMock;
+    }
+    if (request === '../utils/vendorOnboardingEmailDelivery') {
+      return {
+        deliverVendorOnboardingEmails: async () => ({
+          emailSent: true,
+          emailSkipped: false,
+          results: [],
+        }),
+      };
+    }
+    if (request === '../utils/vendorOnboardingProfileFields') {
+      return require(profileFieldsPath);
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const vendorOnboardingPath = path.resolve(
+    __dirname,
+    '../../models/VendorOnboardingStage1.js'
+  );
+
+  delete require.cache[controllerPath];
+  delete require.cache[vendorOnboardingPath];
+
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+
+  require.cache[vendorOnboardingPath] = {
+    id: vendorOnboardingPath,
+    filename: vendorOnboardingPath,
+    loaded: true,
+    exports: vendorOnboardingMock,
+  };
+
+  return { controller: loaded, retrieveCalls };
+}
+
+test('submitForReview reconciles pending DB payment when Stripe PI succeeded', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller, retrieveCalls } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent(),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(retrieveCalls.length, 1);
+  assert.equal(retrieveCalls[0], paymentIntentId);
+  assert.equal(onboarding.verificationPayment.status, 'paid');
+  assert.ok(onboarding.verificationPayment.paidAt instanceof Date);
+  assert.equal(onboarding.status, 'submitted');
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+});
+
+test('submitForReview returns 402 when Stripe PI is not succeeded', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: {
+      id: paymentIntentId,
+      status: 'requires_payment_method',
+      metadata: buildSucceededPaymentIntent().metadata,
+    },
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 402);
+  assert.equal(onboarding.status, 'payment_pending');
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('submitForReview returns 402 when paymentIntentId is missing', async () => {
+  const onboarding = buildOnboarding({
+    verificationPayment: { status: 'pending' },
+  });
+  const { controller, retrieveCalls } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent(),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(retrieveCalls.length, 0);
+  assert.equal(res.statusCode, 402);
+});
+
+test('submitForReview returns 402 when Stripe metadata type is wrong', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent({ type: 'order_payment' }),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 402);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('submitForReview returns 402 when Stripe metadata userId mismatches', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent({
+      userId: '507f1f77bcf86cd799439099',
+    }),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 402);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('submitForReview skips Stripe retrieve when payment already paid in DB', async () => {
+  const onboarding = buildOnboarding({
+    status: 'draft',
+    verificationPayment: { status: 'paid', paidAt: new Date() },
+  });
+  const { controller, retrieveCalls } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent(),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(retrieveCalls.length, 0);
+  assert.equal(res.statusCode, 200);
+  assert.equal(onboarding.status, 'submitted');
+});
+
+test('submitForReview returns 402 when Stripe retrieve throws', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveError: new Error('Stripe unavailable'),
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 402);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});


### PR DESCRIPTION
## Summary
- Fix race where POST /api/vendor-onboarding/submit returned 402 after Stripe client-side payment success because MongoDB still had verificationPayment.status = pending before the webhook fired.
- submitForReview now server-side retrieves the stored PaymentIntent from Stripe when DB is not paid, validates metadata/type/userId, persists paid state, then continues submission.
- Webhook handler and middleware order unchanged; payment requirement not weakened.

## Root cause
submitForReview gated only on MongoDB verificationPayment.status. Webhook updates are async, so immediate frontend submit after Stripe confirmation could hit 402.

## Files changed
- controllers/vendorOnboarding.controller.js — reconcileVendorVerificationPaymentFromStripe helper + submit gate
- tests/vendor/vendor-verification-payment-submit-reconcile.test.js — 7 focused tests

## Test plan
- [x] npm test (235 pass)
- [x] npm run test:contract (16 pass)
- [ ] Manual Stripe test mode: create payment, confirm PI, submit before webhook — expect 200
- [ ] Manual: submit with unpaid PI — expect 402

## Webhook checklist (env var names only)
- STRIPE_SECRET_KEY — Stripe API retrieve
- STRIPE_VENDOR_VERIFICATION_WEBHOOK_SECRET — POST /api/vendor-onboarding/webhook/payment
- Raw body route mounted before express.json in app.js (unchanged)

## Risk / rollback
Low risk: reconcile only runs when DB status is not paid and paymentIntentId exists. Revert commit to restore webhook-only behavior (race returns).

Made with [Cursor](https://cursor.com)