### PR TITLE
Audit: admin orders alias + vendor queue launch blockers

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,7 @@ const foodCategoryRoutes = require('./routes/admin/foodCategoryRoutes')
 const foodSubcategoryRoutes = require('./routes/admin/foodSubcategoryRoutes');
 const adminBusinessRoutes = require('./routes/admin/businessRoutes')
 const adminProductRoutes = require('./routes/admin/adminProductRoutes')
+const adminOrderRoutes = require('./routes/admin/adminOrderRoutes')
 const vendorOnboardVerifyStage1Routes= require("./routes/vendorOnboarding.routes")
 
 
@@ -183,6 +184,7 @@ app.use('/admin/api/blogs', blogRoutes);
 app.use('/admin/api/business', adminBusinessRoutes);
 app.use('/api/admin/business', adminBusinessRoutes);
 app.use('/admin/api/products', adminProductRoutes);
+app.use('/admin/api/orders', adminOrderRoutes);
 app.use('/api/business-profile', businessProfileRoutes);
 app.use('/api/admin/category/product', productCategoryRoutes);
 app.use('/api/admin/category/product-subcategory', productSubcategoryRoutes);

--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -134,6 +134,20 @@ Mount: `/admin/api/products` → [`routes/admin/adminProductRoutes.js`](../route
 
 **Wrong prefix:** `GET /api/admin/products` is **missing**. Admin products live under `/admin/api/products`, not `/api/admin/products`.
 
+### Admin orders
+
+Mount: `/admin/api/orders` → [`routes/admin/adminOrderRoutes.js`](../routes/admin/adminOrderRoutes.js).  
+Canonical alternate: `GET /api/orders/admin` → [`routes/orderRoutes.js`](../routes/orderRoutes.js) (same handler).
+
+| Route | Method | Auth | Role | Frontend screen | Status | Notes |
+|-------|--------|------|------|-----------------|--------|-------|
+| `/admin/api/orders` | GET | Yes | admin | Admin order list (`/admin/orders`) | **valid** | Frontend-compatible alias; filters, pagination, summaries |
+| `/api/orders/admin` | GET | Yes | admin | Admin order list (alternate) | **valid** | Canonical backend path; same handler as alias |
+
+**Response shape:** `{ success, message, data, pagination, summary }` — list key is **`data`**, not `orders` (unlike `GET /api/orders/user` and `GET /api/orders/vendor`).
+
+**Wrong prefix:** `GET /api/admin/orders` is **missing**.
+
 ### Other admin mounts (prefix reference)
 
 | Mount prefix | Purpose | Auth |
@@ -224,6 +238,8 @@ Mount: [`routes/stripeRoutes.js`](../routes/stripeRoutes.js).
 |-------|--------|------|------|-----------------|--------|-------|
 | `/api/orders/initiate` | POST | Yes | customer | Checkout / payment start | **valid** | **Primary** — creates Connect destination PaymentIntent |
 | `/api/orders/retrieve-intent/:id` | GET | Yes | Any authenticated | Payment status poll | **valid** | Poll after initiate |
+| `/admin/api/orders` | GET | Yes | admin | Admin order dashboard | **valid** | Alias for admin list; same as `/api/orders/admin` |
+| `/api/orders/admin` | GET | Yes | admin | Admin order dashboard (alternate) | **valid** | Response list key is `data`, not `orders` |
 | `/api/payments/create-payment-intent` | POST | Yes | customer | Legacy PI creation | **valid** | Secondary; order initiate preferred for marketplace checkout |
 
 ### Webhooks — do not call from frontend

--- a/docs/audit/BACKEND_ADMIN_ORDERS_VENDOR_QUEUE_AUDIT.md
+++ b/docs/audit/BACKEND_ADMIN_ORDERS_VENDOR_QUEUE_AUDIT.md
@@ -1,0 +1,179 @@
+# Backend Admin Orders & Vendor Queue Launch Blocker Audit
+
+**Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
+**Branch:** `audit/backend-admin-orders-vendor-queue-blockers`  
+**Base commit:** `fd59d7fbad6a645327b44656dd3c4000011529f6` (includes PR #101 reconcile fix `d333cbc`)  
+**Evidence date:** 2026-06-20  
+**Production API:** `https://api.mosaicbizhub.com`  
+**Launch frontend:** `https://mosaic-biz-frontend-launch.vercel.app`
+
+No secrets, cookie values, JWTs, OTPs, payment IDs, credentials, or PII in this document.
+
+---
+
+## Executive verdict
+
+| Blocker | Root cause | Owner | Backend P0? |
+| --- | --- | --- | --- |
+| `/admin/orders` broken | Path contract mismatch — frontend expects `GET /admin/api/orders`; backend only had `GET /api/orders/admin` (prod **404** on wrong path) | backend + frontend | **Yes** — missing alias for established admin prefix pattern |
+| Paid vendor not in admin queue | Data-state / flow — payment sets `status=draft`; admin queue filters `status=submitted` only; vendor must call `POST /api/vendor-onboarding/submit` | frontend + vendor flow | **No** — working as designed |
+
+CORS, auth guards, health probes, and full test suite **PASS** on production and locally.
+
+---
+
+## Scope A — Admin orders
+
+### Registered routes (before fix)
+
+| Method | Full path | File | Middleware | Handler |
+| --- | --- | --- | --- | --- |
+| GET | `/api/orders/admin` | `routes/orderRoutes.js:25` | `authenticate` → `isAdmin` | `getAllOrdersAdmin` |
+
+**Not registered (prod 404 confirmed):**
+
+- `GET /admin/api/orders` — documented in `draft.txt:326` as frontend contract
+- `GET /api/admin/orders`
+
+### Auth and response contract
+
+- Unauthenticated → **401** `{ success: false, message: "Authentication required" }`
+- Non-admin → **403** `{ message: "Access denied: Admin only" }`
+- Admin **200** response shape:
+
+```json
+{
+  "success": true,
+  "message": "Orders fetched successfully",
+  "data": [],
+  "pagination": { "page": 1, "limit": 20, "total": 0, "totalPages": 0 },
+  "summary": { "payment": { ... }, "status": { ... } }
+}
+```
+
+**Note:** Admin list uses `data`, not `orders` (unlike `GET /api/orders/user` and `GET /api/orders/vendor`).
+
+### Production probes (pre-fix)
+
+| Probe | Result |
+| --- | --- |
+| `GET /` | **200** |
+| `GET /api/health` | **200** |
+| `GET /api/ready` | **200** (database connected) |
+| CORS OPTIONS `/api/orders/admin` from launch Vercel origin | **204**, ACAO echoes origin, `credentials: true` |
+| `GET /api/orders/admin` (no auth) | **401** |
+| `GET /admin/api/orders` (no auth) | **404** |
+| `GET /api/admin/orders` (no auth) | **404** |
+
+### Root cause — admin orders
+
+**Primary:** Frontend assumes `/admin/api/*` pattern (same as `/admin/api/products`), but orders were implemented at `/api/orders/admin` and omitted from `docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md`.
+
+**Secondary:** Response key is `data`, not `orders` — frontend parsing `response.orders` would fail even after path fix.
+
+**Fix applied:** `GET /admin/api/orders` alias → same `getAllOrdersAdmin` handler. Canonical `GET /api/orders/admin` unchanged.
+
+---
+
+## Scope B — Paid vendor missing from admin queue
+
+### Route contracts
+
+| Method | Path | Auth | Handler |
+| --- | --- | --- | --- |
+| GET | `/api/vendor-onboarding/stage1/payment-status` | `authenticate` + `requireVerifiedVendor` | `getPaymentStatus` |
+| POST | `/api/vendor-onboarding/submit` | `authenticate` + `requireVerifiedVendor` | `submitForReview` |
+| GET | `/api/vendor-onboarding/pending` | `authenticate` + `isAdmin` | `getPendingApplications` |
+
+Duplicate admin mount: `/admin/vendor-onboard-verify-stage1/pending`.
+
+### Pending queue filter
+
+```javascript
+const PENDING_REVIEW_STATUSES = ['submitted'];
+
+VendorOnboarding.find({ status: { $in: PENDING_REVIEW_STATUSES } })
+```
+
+- **Implemented filter:** `status === "submitted"` only
+- **No** `verificationPayment.status === "paid"` filter in query
+- **Effective membership:** paid + submitted (submit requires payment), but payment alone is insufficient
+
+Excluded by design: `draft`, `payment_pending`, `rejected`, `verified`.
+
+### State machine after payment
+
+1. `create-payment` → `payment_pending`
+2. Stripe webhook success → `verificationPayment.status = paid`, `status = draft` (not `submitted`)
+3. `POST /submit` → `status = submitted` → appears in admin pending queue
+
+### Submit + reconcile
+
+- `POST /submit` allows `draft`, `payment_pending`, `rejected`
+- Payment gate: DB `paid` **or** `reconcileVendorVerificationPaymentFromStripe()` (PR #101 on `main`)
+- `GET /stage1/payment-status` does **not** reconcile — `canSubmit` may be `false` while submit would succeed
+
+### Production probes
+
+| Probe | Result |
+| --- | --- |
+| `GET /api/vendor-onboarding/pending` (no auth) | **401** |
+| Credentialed vendor/admin state | **SKIPPED** (no smoke tokens in session) |
+| Production DB snapshot | **SKIPPED** (no vendor identifier) |
+
+### Root cause — vendor queue
+
+**Most likely:** Vendor paid $24.99 but never called `POST /api/vendor-onboarding/submit`. Application remains `draft`; admin queue correctly empty.
+
+**No backend code change** in this audit — frontend must call submit after payment success.
+
+---
+
+## Fix summary (this branch)
+
+| File | Change |
+| --- | --- |
+| `routes/admin/adminOrderRoutes.js` | New — `GET /` → `getAllOrdersAdmin` |
+| `app.js` | Mount `app.use('/admin/api/orders', adminOrderRoutes)` |
+| `tests/launch/backend-launch-contract.test.js` | Assert alias mount + guards |
+| `tests/admin/admin-order-routes-guard.test.js` | Static guard tests |
+| `docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md` | Admin orders path + `data` response key |
+| `docs/backend/BACKEND_ROUTE_REGISTRATION.md` | Register alias route |
+
+---
+
+## Commands run
+
+| Command | Result |
+| --- | --- |
+| `git checkout -b audit/backend-admin-orders-vendor-queue-blockers` | Created from `main` @ `fd59d7f` |
+| `npm test` | See commit — expected 239+ pass |
+| `npm run test:contract` | See commit — expected 16+ pass |
+
+---
+
+## Known risks
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| EB may lag `main` — reconcile fix not live | P2 | Confirm EB version label includes `fd59d7f` before vendor submit testing |
+| Frontend parses `orders` not `data` | P1 | Documented in contract; coordinate frontend if page still broken after alias deploy |
+| `canSubmit: false` after Stripe success | P2 | Frontend should still attempt submit; optional reconcile on payment-status follow-up |
+| No admin smoke account | P2 | Set `SMOKE_TEST_ADMIN_TOKEN` for post-deploy credentialed proof |
+
+---
+
+## What was not tested
+
+- Credentialed `GET /api/orders/admin` or alias with admin JWT/cookie
+- Credentialed `GET /api/vendor-onboarding/pending` with admin session
+- Specific vendor application production state
+- Live $24.99 Stripe charge E2E
+- MongoDB read-only snapshot against production Atlas
+- EB deployed commit SHA confirmation
+
+---
+
+## Rollback
+
+Revert `app.use('/admin/api/orders', ...)` mount and `routes/admin/adminOrderRoutes.js`. Canonical `GET /api/orders/admin` unaffected — zero payment impact.

--- a/docs/audit/BACKEND_ADMIN_ORDERS_VENDOR_QUEUE_AUDIT.md
+++ b/docs/audit/BACKEND_ADMIN_ORDERS_VENDOR_QUEUE_AUDIT.md
@@ -2,6 +2,7 @@
 
 **Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
 **Branch:** `audit/backend-admin-orders-vendor-queue-blockers`  
+**Audit commit:** `d3c5a22`  
 **Base commit:** `fd59d7fbad6a645327b44656dd3c4000011529f6` (includes PR #101 reconcile fix `d333cbc`)  
 **Evidence date:** 2026-06-20  
 **Production API:** `https://api.mosaicbizhub.com`  
@@ -147,8 +148,9 @@ Excluded by design: `draft`, `payment_pending`, `rejected`, `verified`.
 | Command | Result |
 | --- | --- |
 | `git checkout -b audit/backend-admin-orders-vendor-queue-blockers` | Created from `main` @ `fd59d7f` |
-| `npm test` | See commit — expected 239+ pass |
-| `npm run test:contract` | See commit — expected 16+ pass |
+| `npm test` | **243 pass**, 0 fail |
+| `npm run test:contract` | **18 pass**, 0 fail |
+| `GET /admin/api/orders` prod (pre-deploy) | **404** — expect **401** after EB deploy |
 
 ---
 

--- a/docs/backend/BACKEND_ROUTE_REGISTRATION.md
+++ b/docs/backend/BACKEND_ROUTE_REGISTRATION.md
@@ -124,6 +124,8 @@ Mounts: `/api/vendor-onboarding` **and** `/admin/vendor-onboard-verify-stage1` (
 | PUT | `/api/orders/accept/:orderId` | `orderRoutes.js` | `acceptOrder` | JWT | `business_owner` | verified |
 | PUT | `/api/orders/ship/:orderId` | `orderRoutes.js` | `shipOrder` | JWT | `business_owner` | verified |
 | PUT | `/api/orders/deliver/:orderId` | `orderRoutes.js` | `deliverOrder` | JWT | `business_owner` | verified |
+| GET | `/api/orders/admin` | `orderRoutes.js` | `getAllOrdersAdmin` | JWT | `admin` | verified |
+| GET | `/admin/api/orders` | `admin/adminOrderRoutes.js` | `getAllOrdersAdmin` | JWT | `admin` | verified (alias) |
 | POST | `/api/payments/create-payment-intent` | `paymentRoutes.js` | `createPaymentIntent` | JWT + rate limit | `customer` | verified |
 | POST | `/api/stripe/create-checkout-session` | `stripeRoutes.js` | `createCheckoutSession` | JWT | `business_owner` | verified |
 | POST | `/api/connect/:businessId/account-link` | `connectRoutes.js` | `createAccountLink` | JWT | `business_owner` | **verified** |
@@ -164,6 +166,7 @@ All mounted with `express.raw()` before `express.json()` in `app.js`.
 | POST | `/admin/api/business/approve/:id` | `admin/businessRoutes.js` | JWT | admin | verified |
 | GET | `/admin/api/products/` | `admin/adminProductRoutes.js` | JWT | admin | verified |
 | PATCH | `/admin/api/products/:productId/featured` | `admin/adminProductRoutes.js` | JWT | admin | verified |
+| GET | `/admin/api/orders` | `admin/adminOrderRoutes.js` | JWT | admin | verified |
 | GET | `/admin/vendor-onboard-verify-stage1/pending` | `vendorOnboarding.routes.js` | JWT | admin | verified (duplicate prefix) |
 
 ---

--- a/routes/admin/adminOrderRoutes.js
+++ b/routes/admin/adminOrderRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { getAllOrdersAdmin } = require('../../controllers/orderController');
+const authenticate = require('../../middlewares/authenticate');
+const isAdmin = require('../../middlewares/isAdmin');
+
+const router = express.Router();
+
+// Admin order list — alias for GET /api/orders/admin (frontend /admin/api/* pattern)
+router.get('/', authenticate, isAdmin, getAllOrdersAdmin);
+
+module.exports = router;

--- a/tests/admin/admin-order-routes-guard.test.js
+++ b/tests/admin/admin-order-routes-guard.test.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const adminOrderRoutesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminOrderRoutes.js'
+);
+
+test('admin order list route is guarded', () => {
+  const source = fs.readFileSync(adminOrderRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllOrdersAdmin\)/);
+});
+
+test('admin order routes only register guarded list handler', () => {
+  const source = fs.readFileSync(adminOrderRoutesPath, 'utf8');
+  const routeMatches = [...source.matchAll(/router\.(get|post|put|patch|delete)\(/g)];
+
+  assert.equal(routeMatches.length, 1, 'expected only admin order list route');
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -10,6 +10,7 @@ const featuredRoutesPath = path.join(root, 'routes/featuredProductRoutes.js');
 const businessRoutesPath = path.join(root, 'routes/businessRoutes.js');
 const adminUserRoutesPath = path.join(root, 'routes/admin/userRoutes.js');
 const adminProductRoutesPath = path.join(root, 'routes/admin/adminProductRoutes.js');
+const adminOrderRoutesPath = path.join(root, 'routes/admin/adminOrderRoutes.js');
 const orderRoutesPath = path.join(root, 'routes/orderRoutes.js');
 const paymentRoutesPath = path.join(root, 'routes/paymentRoutes.js');
 const connectRoutesPath = path.join(root, 'routes/connectRoutes.js');
@@ -45,6 +46,7 @@ test('app.js mounts launch-critical route prefixes', () => {
     "app.use('/api/business', businessRoutes)",
     "app.use('/admin/users', adminUserRoutes)",
     "app.use('/admin/api/products', adminProductRoutes)",
+    "app.use('/admin/api/orders', adminOrderRoutes)",
     "app.use('/api/payments', paymentRoutes)",
     "app.use('/api/orders', orderRoutes)",
     "app.use('/api/connect', connectRoutes)",
@@ -144,6 +146,17 @@ test('toAdminUser strips sensitive fields from admin list responses', () => {
   assert.equal(sanitized.email, 'admin@example.com');
 });
 
+test('admin order list requires authenticate and isAdmin', () => {
+  const source = readSource(adminOrderRoutesPath);
+
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllOrdersAdmin\)/);
+});
+
+test('GET /api/orders/admin requires authenticate and isAdmin', () => {
+  const source = readSource(orderRoutesPath);
+  assert.match(source, /router\.get\('\/admin', authenticate, isAdmin, getAllOrdersAdmin\)/);
+});
+
 test('POST /api/orders/initiate requires authenticate and customer role', () => {
   const source = readSource(orderRoutesPath);
   assert.match(source, /router\.post\('\/initiate', authenticate, isCustomer, initiateOrder\)/);
@@ -220,6 +233,7 @@ test('documented launch paths resolve to expected registration status', () => {
   const expectedPresent = [
     { label: '/admin/users', needle: "app.use('/admin/users'" },
     { label: '/admin/api/products', needle: "app.use('/admin/api/products'" },
+    { label: '/admin/api/orders', needle: "app.use('/admin/api/orders'" },
     { label: '/api/orders/initiate', needle: "app.use('/api/orders'" },
     { label: '/api/payments/create-payment-intent', needle: "app.use('/api/payments'" },
     { label: '/stripe/account-session', needle: "router.post('/account-session'" },


### PR DESCRIPTION
## Summary
- Audits two production launch blockers: broken admin orders page and paid vendor missing from admin pending queue.
- Adds GET /admin/api/orders alias (authenticate + isAdmin + getAllOrdersAdmin) matching the frontend /admin/api/* pattern; canonical GET /api/orders/admin unchanged.
- Documents vendor queue behavior: admin pending list is status=submitted only; payment alone sets draft until POST /api/vendor-onboarding/submit (no backend P0 for missing queue entry).

## Root cause assessment
| Blocker | Verdict |
| --- | --- |
| /admin/orders broken | Backend path mismatch — prod returned 404 on /admin/api/orders; fixed by alias route |
| Paid vendor not in queue | By design — paid apps stay draft until vendor submits; frontend must call submit after payment |

## Files changed
- routes/admin/adminOrderRoutes.js (new)
- app.js — mount /admin/api/orders
- docs/audit/BACKEND_ADMIN_ORDERS_VENDOR_QUEUE_AUDIT.md (new)
- docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md, docs/backend/BACKEND_ROUTE_REGISTRATION.md
- tests/admin/admin-order-routes-guard.test.js, tests/launch/backend-launch-contract.test.js

## Test plan
- [x] npm test — 243 pass, 0 fail
- [x] npm run test:contract — 18 pass, 0 fail
- [x] Prod unauth GET /api/orders/admin → 401
- [x] Prod CORS OPTIONS from launch Vercel origin → 204
- [ ] Post-deploy: GET /admin/api/orders unauth → 401 (currently 404 pre-deploy)
- [ ] Credentialed admin order list 200 (requires SMOKE_TEST_ADMIN_TOKEN)
- [ ] Frontend confirms response uses data key (not orders)
- [ ] Vendor flow: call POST /api/vendor-onboarding/submit after payment before expecting admin queue entry

Made with [Cursor](https://cursor.com)