### PR TITLE
fix: reconcile vendor payment-status with Stripe before canSubmit

### DIFF
--- a/controllers/vendorOnboarding.controller.js
+++ b/controllers/vendorOnboarding.controller.js
@@ -16,6 +16,29 @@ const { syncBusinessFromOnboarding } = require('../utils/syncBusinessFromOnboard
 const { validateStage1Payload } = require('../utils/vendorOnboardingValidation');
 const { deliverVendorOnboardingEmails } = require('../utils/vendorOnboardingEmailDelivery');
 
+function logVendorOnboardingEvent(endpoint, req, onboarding, { httpStatus, category, message }) {
+  const payload = {
+    endpoint,
+    userId: req?.user?._id ? String(req.user._id) : undefined,
+    applicationId: onboarding?.applicationId || undefined,
+    onboardingStatus: onboarding?.status || undefined,
+    paymentStatus: onboarding?.verificationPayment?.status || 'not_started',
+    httpStatus,
+    category,
+  };
+
+  const requestId = req?.headers?.['x-request-id'];
+  if (requestId) {
+    payload.requestId = requestId;
+  }
+
+  if (message) {
+    payload.message = message;
+  }
+
+  console.info('[vendor-onboarding]', JSON.stringify(payload));
+}
+
 const isNonEmptyString = (value) =>
   typeof value === 'string' && value.trim().length > 0;
 
@@ -903,10 +926,19 @@ exports.getPaymentStatus = async (req, res) => {
     const onboarding = await VendorOnboarding.findOne({ userId });
     
     if (!onboarding) {
+      logVendorOnboardingEvent('GET /stage1/payment-status', req, null, {
+        httpStatus: 404,
+        category: 'not_found',
+        message: 'Onboarding record not found',
+      });
       return res.status(404).json({
         success: false,
         message: "Onboarding record not found"
       });
+    }
+
+    if (onboarding.verificationPayment?.status !== 'paid') {
+      await reconcileVendorVerificationPaymentFromStripe(onboarding, userId);
     }
 
     const paymentData = {
@@ -918,6 +950,11 @@ exports.getPaymentStatus = async (req, res) => {
       canSubmit: onboarding.verificationPayment?.status === 'paid'
     };
 
+    logVendorOnboardingEvent('GET /stage1/payment-status', req, onboarding, {
+      httpStatus: 200,
+      category: 'success',
+    });
+
     return res.status(200).json({
       success: true,
       data: paymentData
@@ -925,6 +962,11 @@ exports.getPaymentStatus = async (req, res) => {
 
   } catch (error) {
     console.error("Get payment status error:", error);
+    logVendorOnboardingEvent('GET /stage1/payment-status', req, null, {
+      httpStatus: 500,
+      category: 'internal',
+      message: error.message,
+    });
     return res.status(500).json({
       success: false,
       message: "Failed to get payment status"
@@ -947,6 +989,11 @@ exports.submitForReview = async (req, res) => {
        BASIC EXISTENCE CHECK
     ------------------------------ */
     if (!onboarding) {
+      logVendorOnboardingEvent('POST /submit', req, null, {
+        httpStatus: 404,
+        category: 'not_found',
+        message: 'Onboarding record not found',
+      });
       return res.status(404).json({
         success: false,
         message: "save Draft before submitting for review",
@@ -958,6 +1005,11 @@ exports.submitForReview = async (req, res) => {
     ------------------------------ */
 // ✅ If already submitted → return success (no error)
 if (onboarding.status === "submitted") {
+  logVendorOnboardingEvent('POST /submit', req, onboarding, {
+    httpStatus: 200,
+    category: 'success',
+    message: 'Idempotent resubmit',
+  });
   return res.status(200).json({
     success: true,
     message: "Application submitted successfully",
@@ -971,6 +1023,11 @@ if (
   onboarding.status !== 'payment_pending' &&
   onboarding.status !== 'rejected'
 ) {
+  logVendorOnboardingEvent('POST /submit', req, onboarding, {
+    httpStatus: 400,
+    category: 'status_lock',
+    message: 'Onboarding cannot be submitted at this stage',
+  });
   return res.status(400).json({
     success: false,
     message: "Onboarding cannot be submitted at this stage",
@@ -985,6 +1042,11 @@ if (
       (await reconcileVendorVerificationPaymentFromStripe(onboarding, userId));
 
     if (!paymentReady) {
+      logVendorOnboardingEvent('POST /submit', req, onboarding, {
+        httpStatus: 402,
+        category: 'payment_required',
+        message: 'Verification payment must be completed before submission',
+      });
       return res.status(402).json({
         success: false,
         message: "Verification payment must be completed before submission",
@@ -997,6 +1059,11 @@ if (
     const validationErrors = validateStage1Payload(onboarding.toObject());
 
     if (validationErrors.length > 0) {
+      logVendorOnboardingEvent('POST /submit', req, onboarding, {
+        httpStatus: 400,
+        category: 'validation',
+        message: 'Validation failed',
+      });
       return res.status(400).json({
         success: false,
         message: "Validation failed",
@@ -1039,6 +1106,11 @@ if (
       },
     ]);
 
+    logVendorOnboardingEvent('POST /submit', req, onboarding, {
+      httpStatus: 200,
+      category: 'success',
+    });
+
     return res.status(200).json({
       success: true,
       message: "Stage 1 submitted successfully for admin verification",
@@ -1048,6 +1120,11 @@ if (
     });
   } catch (error) {
     console.error("Stage-1 submit error:", error);
+    logVendorOnboardingEvent('POST /submit', req, null, {
+      httpStatus: 500,
+      category: 'internal',
+      message: error.message,
+    });
     return res.status(500).json({
       success: false,
       message: "Stage 1 submission failed",

--- a/tests/vendor/vendor-onboarding-submit-guards.test.js
+++ b/tests/vendor/vendor-onboarding-submit-guards.test.js
@@ -1,0 +1,236 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/vendorOnboarding.controller.js'
+);
+const authenticatePath = path.resolve(__dirname, '../../middlewares/authenticate.js');
+const requireVerifiedVendorPath = path.resolve(
+  __dirname,
+  '../../middlewares/requireVerifiedVendor.js'
+);
+
+const userId = '507f1f77bcf86cd799439011';
+const otherUserId = '507f1f77bcf86cd799439099';
+const paymentIntentId = 'pi_test_submit_guards_001';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOnboarding(overrides = {}) {
+  return {
+    userId,
+    applicationId: 'MBH-APP-GUARD-001',
+    businessName: 'Test Business',
+    businessType: 'product',
+    primaryContactName: 'Jane Vendor',
+    address: {
+      city: 'Atlanta',
+      state: 'GA',
+      country: 'USA',
+      zipCode: '30301',
+    },
+    acceptedTerms: true,
+    declarationAccepted: true,
+    isMinorityOwned: false,
+    status: 'draft',
+    verificationPayment: {
+      status: 'paid',
+      paymentIntentId,
+      paidAt: new Date(),
+    },
+    toObject() {
+      return { ...this };
+    },
+    save: async () => {},
+    ...overrides,
+  };
+}
+
+function loadController({ onboarding, findOneQueryLog, findOneImpl } = {}) {
+  process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+  process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
+
+  const queries = findOneQueryLog || [];
+  const vendorOnboardingMock = {
+    findOne: async (query) => {
+      queries.push(query);
+      if (typeof findOneImpl === 'function') {
+        return findOneImpl(query);
+      }
+      return onboarding;
+    },
+  };
+
+  const userMock = {
+    findById: () => ({
+      select: async () => ({ name: 'Vendor User', email: 'vendor@example.com' }),
+    }),
+  };
+
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/VendorOnboardingStage1') {
+      return vendorOnboardingMock;
+    }
+    if (request === '../models/User') {
+      return userMock;
+    }
+    if (request === '../utils/vendorOnboardingEmailDelivery') {
+      return {
+        deliverVendorOnboardingEmails: async () => ({
+          emailSent: true,
+          emailSkipped: false,
+          results: [],
+        }),
+      };
+    }
+    if (request === '../utils/WellcomeMailer') {
+      return {
+        sendAdminOnboardingSubmissionEmail: async () => {},
+        sendVendorSubmissionConfirmationEmail: async () => {},
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+
+  return { controller: loaded, queries };
+}
+
+test('submit route remains blocked without authentication (401)', async () => {
+  const authenticate = require(authenticatePath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await authenticate({ headers: {}, cookies: {} }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.message, 'Authentication required');
+});
+
+test('submit route rejects customer role with 403', async () => {
+  const requireVerifiedVendor = require(requireVerifiedVendorPath);
+  const res = mockResponse();
+  let calledNext = false;
+
+  await requireVerifiedVendor(
+    { user: { role: 'customer', isOtpVerified: true } },
+    res,
+    () => {
+      calledNext = true;
+    }
+  );
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Only vendors allowed');
+});
+
+test('submitForReview returns 404 when vendor has no draft', async () => {
+  const { controller } = loadController({ onboarding: null });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.success, false);
+  assert.match(res.body.message, /draft/i);
+});
+
+test('submitForReview returns 400 with validation errors for incomplete draft', async () => {
+  const onboarding = buildOnboarding({
+    businessName: 'A',
+    primaryContactName: '',
+    address: { city: '', state: '', country: '', zipCode: '' },
+    acceptedTerms: false,
+    declarationAccepted: false,
+  });
+  const { controller } = loadController({ onboarding });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Validation failed');
+  assert.ok(Array.isArray(res.body.errors));
+  assert.ok(res.body.errors.length > 0);
+  assert.equal(onboarding.status, 'draft');
+});
+
+test('submitForReview returns 402 when verification payment is unpaid', async () => {
+  const onboarding = buildOnboarding({
+    verificationPayment: { status: 'pending', paymentIntentId: null, paidAt: null },
+  });
+  const { controller } = loadController({ onboarding });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 402);
+  assert.match(res.body.message, /payment/i);
+});
+
+test('submitForReview is idempotent when already submitted', async () => {
+  const onboarding = buildOnboarding({ status: 'submitted' });
+  const { controller } = loadController({ onboarding });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.applicationId, onboarding.applicationId);
+  assert.equal(onboarding.status, 'submitted');
+});
+
+test('submitForReview findOne uses authenticated userId', async () => {
+  const queries = [];
+  const { controller } = loadController({ onboarding: null, findOneQueryLog: queries });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: userId } }, res);
+
+  assert.equal(queries.length, 1);
+  assert.equal(String(queries[0].userId), userId);
+});
+
+test('submitForReview returns 404 for another vendor when no record matches userId', async () => {
+  const onboarding = buildOnboarding({ status: 'submitted' });
+  const { controller } = loadController({
+    findOneImpl: (query) => {
+      if (String(query.userId) === String(onboarding.userId)) {
+        return onboarding;
+      }
+      return null;
+    },
+  });
+  const res = mockResponse();
+
+  await controller.submitForReview({ user: { _id: otherUserId } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.success, false);
+});

--- a/tests/vendor/vendor-verification-payment-status-reconcile.test.js
+++ b/tests/vendor/vendor-verification-payment-status-reconcile.test.js
@@ -1,0 +1,207 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/vendorOnboarding.controller.js'
+);
+
+const userId = '507f1f77bcf86cd799439011';
+const paymentIntentId = 'pi_test_payment_status_001';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOnboarding(overrides = {}) {
+  return {
+    userId,
+    applicationId: 'MBH-APP-TEST-001',
+    status: 'payment_pending',
+    verificationPayment: {
+      status: 'pending',
+      paymentIntentId,
+      paidAt: null,
+    },
+    save: async () => {},
+    ...overrides,
+  };
+}
+
+function buildSucceededPaymentIntent(metadataOverrides = {}) {
+  return {
+    id: paymentIntentId,
+    status: 'succeeded',
+    metadata: {
+      type: 'vendor_verification',
+      userId: userId.toString(),
+      applicationId: 'MBH-APP-TEST-001',
+      ...metadataOverrides,
+    },
+  };
+}
+
+function loadController(onboarding, { retrieveResult, retrieveError } = {}) {
+  process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+
+  const retrieveCalls = [];
+  const vendorOnboardingMock = {
+    findOne: async () => onboarding,
+  };
+
+  const stripeMock = () => ({
+    paymentIntents: {
+      retrieve: async (id) => {
+        retrieveCalls.push(id);
+        if (retrieveError) {
+          throw retrieveError;
+        }
+        if (typeof retrieveResult === 'function') {
+          return retrieveResult(id);
+        }
+        return retrieveResult;
+      },
+    },
+  });
+
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return stripeMock;
+    }
+    if (request === '../models/VendorOnboardingStage1') {
+      return vendorOnboardingMock;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+
+  return { controller: loaded, retrieveCalls };
+}
+
+test('getPaymentStatus reconciles pending DB payment when Stripe PI succeeded', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller, retrieveCalls } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent(),
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(retrieveCalls.length, 1);
+  assert.equal(retrieveCalls[0], paymentIntentId);
+  assert.equal(onboarding.verificationPayment.status, 'paid');
+  assert.ok(onboarding.verificationPayment.paidAt instanceof Date);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.canSubmit, true);
+  assert.equal(res.body.data.status, 'paid');
+});
+
+test('getPaymentStatus returns canSubmit false when Stripe PI is not succeeded', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: {
+      id: paymentIntentId,
+      status: 'requires_payment_method',
+      metadata: buildSucceededPaymentIntent().metadata,
+    },
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.canSubmit, false);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('getPaymentStatus returns canSubmit false when Stripe retrieve throws', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveError: new Error('Stripe unavailable'),
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.canSubmit, false);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('getPaymentStatus skips Stripe retrieve when payment already paid in DB', async () => {
+  const onboarding = buildOnboarding({
+    status: 'draft',
+    verificationPayment: { status: 'paid', paidAt: new Date(), paymentIntentId },
+  });
+  const { controller, retrieveCalls } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent(),
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(retrieveCalls.length, 0);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.canSubmit, true);
+  assert.equal(res.body.data.status, 'paid');
+});
+
+test('getPaymentStatus returns canSubmit false when Stripe metadata type is wrong', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent({ type: 'order_payment' }),
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.canSubmit, false);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('getPaymentStatus returns canSubmit false when Stripe metadata userId mismatches', async () => {
+  const onboarding = buildOnboarding({ status: 'payment_pending' });
+  const { controller } = loadController(onboarding, {
+    retrieveResult: buildSucceededPaymentIntent({
+      userId: '507f1f77bcf86cd799439099',
+    }),
+  });
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.canSubmit, false);
+  assert.equal(onboarding.verificationPayment.status, 'pending');
+});
+
+test('getPaymentStatus returns 404 when onboarding record is missing', async () => {
+  const { controller } = loadController(null);
+  const res = mockResponse();
+
+  await controller.getPaymentStatus({ user: { _id: userId } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.success, false);
+  assert.match(res.body.message, /not found/i);
+});


### PR DESCRIPTION
## Summary
- Fix Stage 1 submit blocker: \GET /api/vendor-onboarding/stage1/payment-status\ now reconciles verification payments with Stripe (same helper as \POST /submit\) before computing \canSubmit\.
- Add sanitized structured logging for payment-status and submit outcomes (no tokens, PII, or payment secrets).
- Add unit tests for payment-status reconcile paths and submit auth/validation guards.

## Root cause
Frontend polls \canSubmit\ from payment-status before calling submit. Submit already reconciled pending Stripe payments (PR #101), but payment-status was DB-only, so webhook delays left \canSubmit: false\ indefinitely.

## Test plan
- [x] \
pm test\ — 258 pass
- [x] \
pm run test:contract\ — 18 pass
- [x] \
pm run smoke:backend\ — 19 pass (5 blocked: no smoke tokens)
- [x] Unauthenticated \GET /stage1/payment-status\ and \POST /submit\ return 401 locally
- [ ] Credentialed live payment E2E deferred (no live charge in this PR)

Made with [Cursor](https://cursor.com)