### PR TITLE
test: isolated HTTP integration suite (#172)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,9 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Run contract tests
+        run: npm run test:contract
+
+      - name: Run integration tests
+        run: npm run test:integration

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -223,7 +223,7 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | Field | Value |
 | --- | --- |
 | Branch | `test/backend-isolated-integration-suite` |
-| Commit SHA | *(pending push)* |
+| Commit SHA | `8ddc7369e2cc96830709d69a112d9d7a0c5a2392` |
 | PR link | *(pending)* |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -173,3 +173,57 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
+
+---
+
+## Issue #172 — Isolated integration test suite (2026-06-21)
+
+**Branch:** `test/backend-isolated-integration-suite`  
+**Base:** `main` @ `80df57008f33c03df8c0a590efa8d573813ff070`
+
+### Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `npm test` | 0 | **284 pass**, 0 fail (integration excluded via `--test-skip-pattern`) |
+| `npm run test:contract` | 0 | **18 pass**, 0 fail |
+| `npm run test:integration` | 0 | **26 pass**, 0 fail |
+
+### Deliverables
+
+| Path | Purpose |
+| --- | --- |
+| `tests/integration/setup/harness.js` | MongoMemoryServer bootstrap, env, app import |
+| `tests/integration/helpers/` | HTTP client, factories, Stripe/mailer stubs, OTP capture |
+| `tests/integration/*.integration.test.js` | Auth, roles, vendor onboarding, marketplace, commerce, Connect |
+| `docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md` | Runbook + CI notes |
+| `.github/workflows/ci.yml` | Added contract + integration steps |
+| `routes/userRoutes.js` | Skip auth rate limiters when `NODE_ENV=test` |
+
+### Isolation method
+
+- `mongodb-memory-server` — ephemeral URI injected before `require('app')`
+- Collection wipe between tests; memory server stopped per test file process
+- No production/staging/dev Atlas connections
+
+### External stubs
+
+- Stripe (`providerStubs.js`) — dynamic failure toggle for Connect error path
+- Mailer (`providerStubs.js` + `otpCapture.js`) — OTP fixture capture
+- Dummy AWS/Cloudinary env names only
+
+### Known gaps
+
+- `GET /api/connect/:businessId/status` does not enforce business ownership (cross-vendor test uses `account-link` POST instead)
+- Vendor onboarding admin verify step not HTTP-exercised when checklist pre-seeded (finalize-only path covered)
+- WellcomeMailer/Nodemailer may log credential warnings on submit/finalize; emails are not sent in integration runs
+
+### PR metadata (fill on open)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-isolated-integration-suite` |
+| Commit SHA | *(pending push)* |
+| PR link | *(pending)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |

--- a/docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md
+++ b/docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md
@@ -1,0 +1,102 @@
+# Backend Integration Test Runbook
+
+**Repo:** `Techware-Hut/mosaic-backend`  
+**Issue:** [#172 — Isolated integration test suite](https://github.com/Techware-Hut/mosaic-backend/issues/172)  
+**Epic:** Cross-repo workflow reliability (#162)
+
+---
+
+## Purpose
+
+HTTP-level integration tests exercise the real Express app (`app.js`) against a **disposable in-memory MongoDB**. External providers (Stripe, SMTP/mailer) are stubbed at module boundaries only.
+
+Production, staging, and shared development databases are **never** used.
+
+---
+
+## Commands
+
+```bash
+npm test
+npm run test:contract
+npm run test:integration
+```
+
+Integration tests run with `--test-concurrency=1` to share one MongoMemoryServer instance safely.
+
+---
+
+## Database isolation
+
+| Item | Value |
+|------|--------|
+| Engine | `mongodb-memory-server` (ephemeral) |
+| URI | Set at runtime to `process.env.MONGODB_URI` |
+| Cleanup | `deleteMany({})` on all collections between tests |
+| Teardown | Memory server stopped after each test file completes |
+
+---
+
+## External services stubbed
+
+| Provider | Stub location | Notes |
+|----------|---------------|-------|
+| Stripe | `tests/integration/helpers/providerStubs.js` | No live API calls |
+| SMTP / mailer | `tests/integration/helpers/providerStubs.js` | OTP captured for verification tests |
+| AWS S3 / Cloudinary | Dummy env vars only | Upload routes not exercised in baseline suite |
+
+---
+
+## Environment variables (names only)
+
+Set automatically by the harness — do not point at real infrastructure:
+
+- `MONGODB_URI`
+- `JWT_SECRET`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `FRONTEND_URL`
+- `CORS_ORIGINS`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET`
+- `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
+- `SENTRY_ENABLED=false` (Sentry disabled)
+
+Optional live credential variables are **not** used by integration tests.
+
+---
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `tests/integration/setup/harness.js` | Memory Mongo, app bootstrap, reset/teardown |
+| `tests/integration/helpers/client.js` | Supertest agent helpers |
+| `tests/integration/helpers/factories.js` | User/vendor/admin seeding |
+| `tests/integration/helpers/providerStubs.js` | Stripe + mailer stubs |
+| `tests/integration/helpers/otpCapture.js` | Controlled OTP fixture capture |
+| `tests/integration/*.integration.test.js` | Domain coverage specs |
+
+---
+
+## CI
+
+GitHub Actions job **Test** (`.github/workflows/ci.yml`) runs:
+
+1. `npm test`
+2. `npm run test:contract`
+3. `npm run test:integration`
+
+No MongoDB service container is required.
+
+---
+
+## Rollback
+
+Remove `mongodb-memory-server` and `supertest` devDependencies, delete `tests/integration/`, remove `test:integration` script and CI step. Unit/contract tests remain unchanged.
+
+---
+
+## Related docs
+
+- [BACKEND_DOCUMENTATION_EVIDENCE_LOG.md](BACKEND_DOCUMENTATION_EVIDENCE_LOG.md)
+- [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,9 @@
         "xss-clean": "^0.1.4"
       },
       "devDependencies": {
-        "nodemon": "^3.1.10"
+        "mongodb-memory-server": "^11.2.0",
+        "nodemon": "^3.1.10",
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -973,12 +975,25 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
-      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1074,6 +1089,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -2080,6 +2105,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -2090,6 +2122,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -2126,19 +2168,19 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
       "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.2.tgz",
-      "integrity": "sha512-5vn+bdnlCYMwETIm1FqQXDP6TYPbxr2uJd88ve40kr4oPbiTZJVrTNzqA3/4sfWZeWKuQR/RkboBt7qEEDtfMA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -2157,7 +2199,6 @@
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -2167,7 +2208,6 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -2177,7 +2217,6 @@
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
       },
@@ -2192,6 +2231,15 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -2410,6 +2458,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2520,6 +2581,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2600,6 +2678,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -2655,9 +2740,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2708,6 +2793,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -3036,6 +3132,13 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -3116,10 +3219,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3154,16 +3289,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3200,6 +3335,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3603,9 +3756,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3942,6 +4095,19 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -3999,6 +4165,32 @@
         "node": ">=12"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4033,6 +4225,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4156,6 +4371,156 @@
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.0.tgz",
+      "integrity": "sha512-WmjjMEwFwZHmGnAb7wn90MhkiT+mTm4x/rLj7dvAPWfwnVWDXhLun2e+UM88MJoDGW624yzZglVX/zTBy9ZZMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
+      "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongoose": {
@@ -4284,6 +4649,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-cron": {
@@ -4438,6 +4816,45 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -4585,6 +5002,16 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -4635,6 +5062,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/png-js": {
@@ -4765,9 +5205,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4910,9 +5350,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5218,6 +5658,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5246,12 +5722,13 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "trusted marketplace",
   "main": "index.js",
   "scripts": {
-    "test": "node --test tests/**/*.test.js",
+    "test": "node --test tests/**/*.test.js --test-skip-pattern integration",
     "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
+    "test:integration": "node --test --test-concurrency=1 tests/integration/**/*.integration.test.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"
@@ -45,6 +46,8 @@
     "xss-clean": "^0.1.4"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "mongodb-memory-server": "^11.2.0",
+    "nodemon": "^3.1.10",
+    "supertest": "^7.2.2"
   }
 }

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -13,6 +13,7 @@ function buildAuthLimiter(max, message) {
     max,
     standardHeaders: true,
     legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === 'test',
     message: {
       success: false,
       message,

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent, parseCookies } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  registerUser,
+  verifyRegistrationOtp,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('register → OTP verify → login → auth/check → logout session flow', async () => {
+  const agent = createAgent(getApp());
+
+  const { registerRes, email, password } = await registerAndVerify(agent, {
+    role: 'customer',
+  });
+
+  assert.equal(registerRes.status, 201);
+  assert.equal(registerRes.body.success, true);
+
+  const loginRes = await login(agent, email, password);
+  assert.equal(loginRes.status, 200);
+  assert.ok(loginRes.body.token);
+  assert.equal(loginRes.headers['set-cookie']?.some((c) => c.startsWith('token=')), true);
+
+  const authCheck = await agent.get('/api/users/auth/check');
+  assert.equal(authCheck.status, 200);
+  assert.equal(authCheck.body.loggedIn, true);
+  assert.equal(authCheck.body.user.role, 'customer');
+
+  const logoutRes = await agent.post('/api/users/logout');
+  assert.equal(logoutRes.status, 200);
+
+  const afterLogout = await agent.get('/api/users/auth/check');
+  assert.equal(afterLogout.status, 401);
+});
+
+test('OTP verification uses captured fixture OTP from mailer stub', async () => {
+  const agent = createAgent(getApp());
+  const { email } = await registerUser(agent, { role: 'business_owner' });
+
+  const verifyRes = await verifyRegistrationOtp(agent, email);
+  assert.equal(verifyRes.status, 200);
+  assert.equal(verifyRes.body.success, true);
+  assert.equal(verifyRes.body.user.role, 'business_owner');
+});
+
+test('auth check rejects invalidated session after sessionVersion bump', async () => {
+  const agent = createAgent(getApp());
+  const { email, password } = await registerAndVerify(agent, { role: 'customer' });
+
+  await login(agent, email, password);
+  const ok = await agent.get('/api/users/auth/check');
+  assert.equal(ok.status, 200);
+
+  const user = await User.findOne({ email });
+  user.sessionVersion = (user.sessionVersion || 0) + 1;
+  await user.save();
+
+  const stale = await agent.get('/api/users/auth/check');
+  assert.equal(stale.status, 401);
+  assert.match(stale.body.message, /Session expired/i);
+});
+
+test('unauthenticated auth check returns 401', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/users/auth/check');
+  assert.equal(res.status, 401);
+});
+
+test('register sets otpPending cookie', async () => {
+  const agent = createAgent(getApp());
+  const { res, email } = await registerUser(agent, { role: 'customer' });
+  assert.equal(res.status, 201);
+  const cookies = parseCookies(res.headers['set-cookie']);
+  assert.equal(cookies.otpPending, 'true');
+  assert.ok(email);
+});

--- a/tests/integration/commerce.integration.test.js
+++ b/tests/integration/commerce.integration.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('authenticated customer receives cart payload', async () => {
+  const agent = createAgent(getApp());
+  const customer = await registerAndVerify(agent, { role: 'customer' });
+  await login(agent, customer.email, customer.password);
+
+  const res = await agent.get('/api/cart');
+  assert.equal(res.status, 200);
+  assert.ok(Object.prototype.hasOwnProperty.call(res.body, 'cart'));
+});
+
+test('order initiate rejects empty cart for customer', async () => {
+  const agent = createAgent(getApp());
+  const customer = await registerAndVerify(agent, { role: 'customer' });
+  await login(agent, customer.email, customer.password);
+
+  const res = await agent.post('/api/orders/initiate').send({
+    shippingAddress: {
+      fullName: 'Test Customer',
+      phone: '5555550100',
+      addressLine1: '123 Main St',
+      city: 'Atlanta',
+      state: 'GA',
+      country: 'USA',
+      postalCode: '30301',
+    },
+  });
+
+  assert.notEqual(res.status, 200);
+});
+
+test('vendor cannot initiate customer checkout order', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const res = await agent.post('/api/orders/initiate').send({});
+  assert.equal(res.status, 403);
+});
+
+test('admin can list orders; vendor can list vendor orders endpoint', async () => {
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const adminOrders = await adminAgent.get('/api/orders/admin');
+  assert.equal(adminOrders.status, 200);
+
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+  const user = await User.findOne({ email: vendor.email });
+  await seedApprovedBusiness(user);
+
+  const vendorOrders = await vendorAgent.get('/api/orders/vendor');
+  assert.equal(vendorOrders.status, 200);
+});

--- a/tests/integration/connect.integration.test.js
+++ b/tests/integration/connect.integration.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const {
+  setStripeShouldFail,
+  resetStripeStub,
+} = require('./helpers/providerStubs');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  resetStripeStub();
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('connect account-link returns onboarding URL contract', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    stripeConnectAccountId: null,
+  });
+
+  const res = await agent.post(`/api/connect/${business._id}/account-link`);
+  assert.equal(res.status, 200);
+  assert.match(res.body.url, /connect\.stripe\.com/);
+});
+
+test('connect status returns capability summary', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user);
+
+  const res = await agent.get(`/api/connect/${business._id}/status`);
+  assert.equal(res.status, 200);
+  assert.ok(Object.prototype.hasOwnProperty.call(res.body, 'chargesEnabled'));
+});
+
+test('connect account-link surfaces provider failure without live Stripe', async () => {
+  setStripeShouldFail(true);
+
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    stripeConnectAccountId: null,
+  });
+
+  const res = await agent.post(`/api/connect/${business._id}/account-link`);
+  assert.notEqual(res.status, 200);
+});

--- a/tests/integration/helpers/client.js
+++ b/tests/integration/helpers/client.js
@@ -1,0 +1,25 @@
+const supertest = require('supertest');
+
+function createAgent(app) {
+  return supertest.agent(app);
+}
+
+function parseCookies(setCookieHeader) {
+  const headers = Array.isArray(setCookieHeader)
+    ? setCookieHeader
+    : setCookieHeader
+      ? [setCookieHeader]
+      : [];
+
+  return headers.reduce((acc, header) => {
+    const [pair] = header.split(';');
+    const idx = pair.indexOf('=');
+    if (idx === -1) {
+      return acc;
+    }
+    acc[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
+    return acc;
+  }, {});
+}
+
+module.exports = { createAgent, parseCookies };

--- a/tests/integration/helpers/factories.js
+++ b/tests/integration/helpers/factories.js
@@ -1,0 +1,186 @@
+const bcrypt = require('bcryptjs');
+const mongoose = require('mongoose');
+const User = require('../../../models/User');
+const Business = require('../../../models/Business');
+const Product = require('../../../models/Product');
+const Subscription = require('../../../models/Subscription');
+const SubscriptionPlan = require('../../../models/SubscriptionPlan');
+const VendorOnboarding = require('../../../models/VendorOnboardingStage1');
+const { getCapturedOtp } = require('./otpCapture');
+
+function uniqueEmail(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}@example.test`;
+}
+
+let mobileCounter = 0;
+
+function uniqueMobile() {
+  mobileCounter += 1;
+  return `+1415555${String(mobileCounter).padStart(4, '0')}`;
+}
+
+const validStage1Draft = {
+  businessName: 'Integration Test Business LLC',
+  businessType: 'product',
+  primaryContactName: 'Integration Vendor',
+  address: {
+    city: 'Atlanta',
+    state: 'GA',
+    country: 'USA',
+    zipCode: '30301',
+  },
+  acceptedTerms: true,
+  declarationAccepted: true,
+  isMinorityOwned: false,
+};
+
+async function registerUser(agent, { role = 'customer', password = 'Secret123!' } = {}) {
+  const email = uniqueEmail(role);
+  const mobile = uniqueMobile();
+
+  const res = await agent.post('/api/users/register').send({
+    name: `${role} Integration`,
+    email,
+    password,
+    mobile,
+    role,
+  });
+
+  if (res.status !== 201) {
+    throw new Error(
+      `Register failed (${res.status}): ${JSON.stringify(res.body)}`
+    );
+  }
+
+  return { res, email, password, mobile };
+}
+
+async function verifyRegistrationOtp(agent, email) {
+  const otp = getCapturedOtp(email);
+  if (!otp) {
+    throw new Error(`No captured OTP for ${email}`);
+  }
+
+  return agent.post('/api/users/verify-otp').send({ email, otp });
+}
+
+async function registerAndVerify(agent, options = {}) {
+  const { res: registerRes, email, password } = await registerUser(agent, options);
+  const verifyRes = await verifyRegistrationOtp(agent, email);
+  return { registerRes, verifyRes, email, password };
+}
+
+async function login(agent, email, password) {
+  return agent.post('/api/users/login').send({ email, password });
+}
+
+async function createAdminDirect() {
+  const email = uniqueEmail('admin');
+  const password = 'AdminSecret123!';
+  const user = await User.create({
+    name: 'Integration Admin',
+    email,
+    mobile: uniqueMobile(),
+    passwordHash: await bcrypt.hash(password, 12),
+    role: 'admin',
+    isOtpVerified: true,
+  });
+
+  return { user, email, password };
+}
+
+async function ensureSubscriptionPlan() {
+  let plan = await SubscriptionPlan.findOne({ name: 'Silver Plan' });
+  if (!plan) {
+    plan = await SubscriptionPlan.create({
+      name: 'Silver Plan',
+      price: 0,
+      limits: {
+        productListings: 10,
+        serviceListings: 10,
+        foodListings: 10,
+        imageLimit: 100,
+        videoLimit: 10,
+      },
+    });
+  }
+  return plan;
+}
+
+async function seedApprovedBusiness(ownerUser, overrides = {}) {
+  const owner =
+    ownerUser && ownerUser._id
+      ? ownerUser
+      : await User.findById(ownerUser);
+
+  if (!owner) {
+    throw new Error('seedApprovedBusiness requires a valid owner User');
+  }
+
+  const plan = await ensureSubscriptionPlan();
+  const subscription = await Subscription.create({
+    userId: owner._id,
+    subscriptionPlanId: plan._id,
+    stripeSubscriptionId: `sub_int_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    paymentStatus: 'COMPLETED',
+    startDate: new Date(),
+    endDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    status: 'active',
+  });
+
+  return Business.create({
+    owner: owner._id,
+    businessName: 'Integration Vendor Shop',
+    email: owner.email,
+    isApproved: overrides.isApproved ?? true,
+    isActive: overrides.isActive ?? true,
+    stripeConnectAccountId: overrides.stripeConnectAccountId ?? 'acct_integration_test',
+    listingType: 'product',
+    subscriptionId: subscription._id,
+    subscriptionPlanId: plan._id,
+    ...overrides,
+  });
+}
+
+async function seedPublishedProduct(business, ownerUser) {
+  return Product.create({
+    title: 'Integration Test Product',
+    description: 'Integration test product description',
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: ownerUser._id,
+    businessId: business._id,
+    isPublished: true,
+    price: 1999,
+    coverImage: 'https://example.test/product.png',
+    slug: `integration-product-${Date.now()}`,
+  });
+}
+
+async function seedVendorOnboarding(user, overrides = {}) {
+  return VendorOnboarding.create({
+    userId: user._id,
+    applicationId: overrides.applicationId || `MBH-INT-${Date.now()}`,
+    businessName: validStage1Draft.businessName,
+    status: overrides.status || 'draft',
+    isMinorityOwned: overrides.isMinorityOwned ?? false,
+    verificationPayment: overrides.verificationPayment || {
+      status: 'paid',
+      paymentIntentId: 'pi_integration_test',
+    },
+    ...overrides,
+  });
+}
+
+module.exports = {
+  validStage1Draft,
+  registerUser,
+  verifyRegistrationOtp,
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+  seedPublishedProduct,
+  seedVendorOnboarding,
+  uniqueEmail,
+};

--- a/tests/integration/helpers/otpCapture.js
+++ b/tests/integration/helpers/otpCapture.js
@@ -1,0 +1,15 @@
+const otpByEmail = new Map();
+
+function captureOtp(email, otp) {
+  otpByEmail.set(String(email).toLowerCase(), String(otp));
+}
+
+function getCapturedOtp(email) {
+  return otpByEmail.get(String(email).toLowerCase());
+}
+
+function resetOtpCapture() {
+  otpByEmail.clear();
+}
+
+module.exports = { captureOtp, getCapturedOtp, resetOtpCapture };

--- a/tests/integration/helpers/providerStubs.js
+++ b/tests/integration/helpers/providerStubs.js
@@ -1,0 +1,123 @@
+const Module = require('module');
+const path = require('path');
+const { captureOtp } = require('./otpCapture');
+
+let originalLoad = null;
+let stripeShouldFail = false;
+
+function setStripeShouldFail(value) {
+  stripeShouldFail = Boolean(value);
+}
+
+function createStripeClient() {
+  const failIfRequested = () => {
+    if (stripeShouldFail) {
+      const err = new Error('Stripe provider unavailable (integration stub)');
+      err.type = 'StripeConnectionError';
+      throw err;
+    }
+  };
+
+  return {
+    paymentIntents: {
+      create: async (params) => {
+        failIfRequested();
+        return {
+          id: 'pi_integration_test',
+          client_secret: 'pi_integration_test_secret',
+          status: 'requires_payment_method',
+          amount: params?.amount ?? 2000,
+          currency: params?.currency || 'usd',
+          metadata: params?.metadata || {},
+        };
+      },
+      retrieve: async (id) => {
+        failIfRequested();
+        return {
+          id: id || 'pi_integration_test',
+          status: 'succeeded',
+          amount: 2000,
+          currency: 'usd',
+          metadata: { type: 'vendor_verification' },
+        };
+      },
+    },
+    accounts: {
+      create: async () => {
+        failIfRequested();
+        return { id: 'acct_integration_test' };
+      },
+      retrieve: async () => {
+        failIfRequested();
+        return {
+          id: 'acct_integration_test',
+          charges_enabled: true,
+          payouts_enabled: true,
+          capabilities: { transfers: 'active' },
+          requirements: { currently_due: [] },
+        };
+      },
+    },
+    accountLinks: {
+      create: async () => {
+        failIfRequested();
+        return { url: 'https://connect.stripe.com/setup/test/integration' };
+      },
+    },
+    webhooks: {
+      constructEvent: () => ({ type: 'test.event' }),
+    },
+  };
+}
+
+function createMailerStub() {
+  return {
+    sendOtpEmail: async (email, otp) => {
+      captureOtp(email, otp);
+    },
+    sendWelcomeEmail: async () => {},
+    sendPasswordResetOtpEmail: async () => {},
+    sendVendorOnboardingAdminNotification: async () => {},
+    sendVendorOnboardingVendorConfirmation: async () => {},
+  };
+}
+
+function installProviderStubs() {
+  if (originalLoad) {
+    return;
+  }
+
+  originalLoad = Module._load;
+  const mailerPath = path.normalize(
+    path.join(__dirname, '../../../utils/mailer.js')
+  );
+
+  Module._load = function integrationMockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      function StripeMock() {
+        return createStripeClient();
+      }
+      StripeMock.Stripe = StripeMock;
+      return StripeMock;
+    }
+
+    try {
+      const resolved = Module._resolveFilename(request, parent);
+      if (path.normalize(resolved) === mailerPath) {
+        return createMailerStub();
+      }
+    } catch {
+      // fall through
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+module.exports = {
+  installProviderStubs,
+  setStripeShouldFail,
+  resetStripeStub: () => {
+    stripeShouldFail = false;
+  },
+};

--- a/tests/integration/marketplace.integration.test.js
+++ b/tests/integration/marketplace.integration.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+  seedPublishedProduct,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('GET /api/featured-products returns safe empty payload', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/featured-products');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.products));
+});
+
+test('GET /api/products/list returns list wrapper', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/products/list');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.data));
+});
+
+test('GET /api/public/product/:id returns product detail when seeded', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user);
+  const product = await seedPublishedProduct(business, user);
+
+  const res = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.data.title, 'Integration Test Product');
+});
+
+test('GET /api/services/list and /api/food/list return safe empty arrays', async () => {
+  const agent = createAgent(getApp());
+
+  const services = await agent.get('/api/services/list');
+  assert.equal(services.status, 200);
+
+  const foods = await agent.get('/api/food/list');
+  assert.equal(foods.status, 200);
+});
+
+test('missing product detail returns 404', async () => {
+  const agent = createAgent(getApp());
+  const missingId = '507f1f77bcf86cd799439011';
+  const res = await agent.get(`/api/public/product/${missingId}`);
+  assert.equal(res.status, 404);
+});

--- a/tests/integration/roles.integration.test.js
+++ b/tests/integration/roles.integration.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('customer can access cart; vendor receives 403 on admin orders', async () => {
+  const customerAgent = createAgent(getApp());
+  const { email, password } = await registerAndVerify(customerAgent, {
+    role: 'customer',
+  });
+  await login(customerAgent, email, password);
+
+  const cartRes = await customerAgent.get('/api/cart');
+  assert.equal(cartRes.status, 200);
+
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+
+  const adminOrders = await vendorAgent.get('/api/orders/admin');
+  assert.equal(adminOrders.status, 403);
+});
+
+test('admin can access admin orders list', async () => {
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const res = await adminAgent.get('/api/orders/admin');
+  assert.equal(res.status, 200);
+});
+
+test('business_owner can access business/my scoped to own account', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  await seedApprovedBusiness(user);
+
+  const myBusiness = await vendorAgent.get('/api/business/my');
+  assert.equal(myBusiness.status, 200);
+  assert.ok(Array.isArray(myBusiness.body.businesses));
+});
+
+test('cross-vendor connect account-link rejects foreign businessId', async () => {
+  const vendorA = createAgent(getApp());
+  const vendorB = createAgent(getApp());
+
+  const a = await registerAndVerify(vendorA, { role: 'business_owner' });
+  const b = await registerAndVerify(vendorB, { role: 'business_owner' });
+  await login(vendorA, a.email, a.password);
+  await login(vendorB, b.email, b.password);
+
+  const bUser = await User.findOne({ email: b.email });
+  const businessB = await seedApprovedBusiness(bUser);
+
+  const foreignLink = await vendorA.post(
+    `/api/connect/${businessB._id}/account-link`
+  );
+  assert.equal(foreignLink.status, 403);
+});

--- a/tests/integration/setup/harness.js
+++ b/tests/integration/setup/harness.js
@@ -1,0 +1,95 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const {
+  installProviderStubs,
+  resetStripeStub,
+} = require('../helpers/providerStubs');
+const { resetOtpCapture } = require('../helpers/otpCapture');
+
+let mongoServer = null;
+let app = null;
+let started = false;
+
+function applyIntegrationEnv(mongoUri) {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGODB_URI = mongoUri;
+  process.env.JWT_SECRET =
+    process.env.JWT_SECRET || 'integration-test-jwt-secret-min-32-chars';
+  process.env.STRIPE_SECRET_KEY =
+    process.env.STRIPE_SECRET_KEY || 'sk_test_integration_mock_key_000000000';
+  process.env.STRIPE_WEBHOOK_SECRET =
+    process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_integration_mock';
+  process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:3000';
+  process.env.CORS_ORIGINS =
+    process.env.CORS_ORIGINS || 'http://127.0.0.1:3000';
+  process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'test';
+  process.env.AWS_SECRET_ACCESS_KEY =
+    process.env.AWS_SECRET_ACCESS_KEY || 'test';
+  process.env.AWS_REGION = process.env.AWS_REGION || 'us-east-1';
+  process.env.AWS_S3_BUCKET = process.env.AWS_S3_BUCKET || 'integration-test-bucket';
+  process.env.CLOUDINARY_CLOUD_NAME =
+    process.env.CLOUDINARY_CLOUD_NAME || 'integration-test';
+  process.env.CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY || 'test';
+  process.env.CLOUDINARY_API_SECRET =
+    process.env.CLOUDINARY_API_SECRET || 'test';
+  delete process.env.SENTRY_DSN;
+  process.env.SENTRY_ENABLED = 'false';
+}
+
+async function startHarness() {
+  if (started && app) {
+    return app;
+  }
+
+  installProviderStubs();
+  mongoServer = await MongoMemoryServer.create();
+  applyIntegrationEnv(mongoServer.getUri());
+
+  await mongoose.connect(process.env.MONGODB_URI, {
+    serverSelectionTimeoutMS: 10000,
+  });
+
+  // eslint-disable-next-line global-require
+  app = require('../../../app');
+  started = true;
+  return app;
+}
+
+async function resetDatabase() {
+  resetOtpCapture();
+  resetStripeStub();
+
+  if (mongoose.connection.readyState !== 1) {
+    return;
+  }
+
+  for (const collection of Object.values(mongoose.connection.collections)) {
+    await collection.deleteMany({});
+  }
+}
+
+async function stopHarness() {
+  if (mongoose.connection.readyState !== 0) {
+    await mongoose.disconnect();
+  }
+  if (mongoServer) {
+    await mongoServer.stop();
+    mongoServer = null;
+  }
+  app = null;
+  started = false;
+}
+
+function getApp() {
+  if (!app) {
+    throw new Error('Integration harness not started. Call startHarness() first.');
+  }
+  return app;
+}
+
+module.exports = {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+};

--- a/tests/integration/vendor-onboarding.integration.test.js
+++ b/tests/integration/vendor-onboarding.integration.test.js
@@ -1,0 +1,144 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  validStage1Draft,
+  seedVendorOnboarding,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const VendorOnboarding = require('../../models/VendorOnboardingStage1');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('vendor can save and retrieve onboarding draft', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const saveRes = await agent.post('/api/vendor-onboarding/draft').send(validStage1Draft);
+  assert.equal(saveRes.status, 200);
+
+  const getRes = await agent.get('/api/vendor-onboarding/draft');
+  assert.equal(getRes.status, 200);
+  assert.equal(getRes.body.data.businessName, validStage1Draft.businessName);
+});
+
+test('payment-pending onboarding reports pending payment status', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  await seedVendorOnboarding(user, {
+    status: 'draft',
+    verificationPayment: { status: 'pending', paymentIntentId: 'pi_integration_test' },
+  });
+
+  const statusRes = await agent.get('/api/vendor-onboarding/stage1/payment-status');
+  assert.equal(statusRes.status, 200);
+  assert.equal(statusRes.body.data.status, 'pending');
+});
+
+test('submit moves application to submitted when payment is paid', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  await agent.post('/api/vendor-onboarding/draft').send(validStage1Draft);
+
+  const user = await User.findOne({ email: vendor.email });
+  const onboarding = await VendorOnboarding.findOneAndUpdate(
+    { userId: user._id },
+    {
+      verificationPayment: {
+        status: 'paid',
+        paymentIntentId: 'pi_integration_test',
+      },
+    },
+    { new: true }
+  );
+
+  const submitRes = await agent.post('/api/vendor-onboarding/submit');
+  assert.equal(submitRes.status, 200);
+
+  const refreshed = await VendorOnboarding.findOne({ _id: onboarding._id });
+  assert.equal(refreshed.status, 'submitted');
+});
+
+test('admin verify and finalize progression', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+  const user = await User.findOne({ email: vendor.email });
+
+  const onboarding = await seedVendorOnboarding(user, {
+    status: 'submitted',
+    totalVerificationPoints: 50,
+    verificationPayment: { status: 'paid', paymentIntentId: 'pi_integration_test' },
+    verificationChecklist: {
+      minorityDocs: true,
+      taxDocs: true,
+      businessLicense: true,
+      website: true,
+      facebook: false,
+      instagram: false,
+      linkedin: false,
+      tiktok: false,
+    },
+  });
+
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const finalizeRes = await adminAgent.post(
+    `/api/vendor-onboarding/${onboarding.applicationId}/finalize`
+  );
+  assert.equal(finalizeRes.status, 200);
+
+  const statusRes = await adminAgent.get(
+    `/api/vendor-onboarding/${onboarding.applicationId}`
+  );
+  assert.equal(statusRes.status, 200);
+  assert.equal(statusRes.body.data.status, 'verified');
+});
+
+test('rejected application state is readable by admin', async () => {
+  const vendor = await registerAndVerify(createAgent(getApp()), {
+    role: 'business_owner',
+  });
+  const user = await User.findOne({ email: vendor.email });
+  const onboarding = await seedVendorOnboarding(user, {
+    status: 'rejected',
+    rejectionReason: 'Integration test rejection',
+  });
+
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const detail = await adminAgent.get(
+    `/api/vendor-onboarding/${onboarding.applicationId}`
+  );
+  assert.equal(detail.status, 200);
+  assert.equal(detail.body.data.status, 'rejected');
+});


### PR DESCRIPTION
## Summary
- Adds HTTP-level integration tests against the real Express app using `mongodb-memory-server` (never prod/dev Atlas).
- Stubs Stripe and mailer at module boundaries; captures OTP fixtures for auth verification flows.
- Covers auth, roles/ownership, vendor onboarding, marketplace, commerce, and Stripe Connect contracts.
- CI runs `npm run test:contract` and `npm run test:integration`; unit tests skip integration specs.

## Test plan
- [x] `npm test` — 284 pass
- [x] `npm run test:contract` — 18 pass
- [x] `npm run test:integration` — 26 pass
- [ ] CI green on PR (pending)

Closes #172
Related #162