### PR TITLE
chore: backend release identity and Sentry tagging (#171)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,12 @@ LISTING_DEBUG=false
 
 # Sentry (optional — set SENTRY_DSN in EB only; never commit real DSN)
 
+# RELEASE_COMMIT_SHA=local-dev-sha
+
+# RELEASE_ENVIRONMENT=development
+
+# DEPLOYMENT_VERSION_LABEL=mosaic-local
+
 # SENTRY_DSN=
 
 # SENTRY_ENVIRONMENT=production

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Post-deploy readiness probe
         run: |
-          for path in /api/health /api/ready; do
+          for path in /api/health /api/ready /api/build-info; do
             status=$(curl -s -o /dev/null -w "%{http_code}" "${PRODUCTION_API_URL}${path}")
             echo "${path}: HTTP $status"
             if [ "$status" != "200" ]; then
@@ -128,6 +128,14 @@ jobs:
               exit 1
             fi
           done
+          curl -s "${PRODUCTION_API_URL}/api/health" | node -e "
+            const payload = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+            if (!payload.release?.commit || !payload.release?.environment || !payload.release?.deploymentVersion) {
+              console.error('Missing release identity on /api/health');
+              process.exit(1);
+            }
+            console.log('Release identity present on /api/health');
+          "
 
       - name: Post-deploy CORS probe
         env:

--- a/docs/backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md
+++ b/docs/backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md
@@ -86,7 +86,7 @@ Use [`../production-smoke-checklist.md`](../production-smoke-checklist.md) tiers
 
 | Tier | Examples |
 | --- | --- |
-| P0 | `GET /`, `GET /api/health`, `GET /api/ready` |
+| P0 | `GET /`, `GET /api/health`, `GET /api/ready`, `GET /api/build-info`, release identity on health/build-info |
 | P1 | Auth check 401/200, CORS preflight |
 | P4 | Stripe webhook negative tests (unsigned → 400) |
 | P6 | Public search, featured products |
@@ -98,6 +98,8 @@ Wrapper: `npm run smoke:backend` → `scripts/smoke-backend.ps1` / `.sh`
 ## Rollback
 
 See [`../../DEPLOYMENT.md`](../../DEPLOYMENT.md) — EB version rollback via AWS console or redeploy prior version label.
+
+After rollback, realign release identity env vars (`RELEASE_COMMIT_SHA`, `RELEASE_ENVIRONMENT`, `DEPLOYMENT_VERSION_LABEL`, `SENTRY_RELEASE`) to the restored EB version label and verify `/api/health` → `release.deploymentVersion`. Details: [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
 
 ---
 

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -173,3 +173,38 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
+
+---
+
+## Issue #171 — Backend release identity and Sentry tagging (2026-06-21)
+
+**Branch:** `chore/backend-release-identity-sentry`  
+**Base:** `main` @ `80df57008f33c03df8c0a590efa8d573813ff070`
+
+### Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `npm test` | 0 | **265 pass**, 0 fail |
+| `npm run test:contract` | 0 | **18 pass**, 0 fail |
+| `npm run smoke:backend` (local `http://127.0.0.1:3099`) | 0 | **21 pass**, 0 fail |
+
+### Environment variable names (values not logged)
+
+- `RELEASE_COMMIT_SHA`
+- `RELEASE_ENVIRONMENT`
+- `DEPLOYMENT_VERSION_LABEL`
+- `SENTRY_RELEASE` (existing, aligned with deployment label)
+- `SENTRY_ENVIRONMENT` (existing fallback)
+
+See [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
+
+### PR metadata
+
+| Field | Value |
+| --- | --- |
+| Branch | `chore/backend-release-identity-sentry` |
+| Commit SHA | *(pending push)* |
+| PR link | *(pending)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |

--- a/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
+++ b/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
@@ -159,6 +159,18 @@
 
 ---
 
+## Release identity (recommended for EB production)
+
+| Variable | Class |
+| --- | --- |
+| `RELEASE_COMMIT_SHA` | recommended |
+| `RELEASE_ENVIRONMENT` | recommended |
+| `DEPLOYMENT_VERSION_LABEL` | recommended |
+
+See [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
+
+---
+
 ## CI / GitHub Actions (not app runtime)
 
 Set in workflows only — see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml), [`.github/workflows/deploy-eb-production.yml`](../../.github/workflows/deploy-eb-production.yml):

--- a/docs/backend/BACKEND_RELEASE_IDENTITY.md
+++ b/docs/backend/BACKEND_RELEASE_IDENTITY.md
@@ -1,0 +1,132 @@
+# Backend Release Identity and Sentry Tagging
+
+**Issue:** [#171 — Backend release identity](https://github.com/Techware-Hut/mosaic-backend/issues/171)  
+**Related:** Frontend #171, epic #162, backend Sentry review #18
+
+---
+
+## Purpose
+
+Tie the running API, Git commit, Elastic Beanstalk version label, smoke proof, rollback target, and Sentry events to one **safe, non-secret release identity**.
+
+---
+
+## Environment variable names (values set in EB / CI only)
+
+| Variable | Role |
+| --- | --- |
+| `RELEASE_COMMIT_SHA` | Canonical deployed Git commit (7–40 hex chars) |
+| `RELEASE_ENVIRONMENT` | Runtime environment label (`production`, `staging`, `development`, …) |
+| `DEPLOYMENT_VERSION_LABEL` | Elastic Beanstalk version label (e.g. `mosaic-<sha>`) |
+| `SENTRY_RELEASE` | Sentry release string; defaults to deployment label when unset |
+| `SENTRY_ENVIRONMENT` | Legacy Sentry env fallback when `RELEASE_ENVIRONMENT` unset |
+| `SENTRY_DSN` | Sentry project DSN (never exposed in API responses) |
+| `SENTRY_ENABLED` | Optional disable switch |
+
+**Recommended EB production set (names only):**
+
+- `RELEASE_COMMIT_SHA=<deployed-git-sha>`
+- `RELEASE_ENVIRONMENT=production`
+- `DEPLOYMENT_VERSION_LABEL=mosaic-<deployed-git-sha>`
+- `SENTRY_RELEASE=mosaic-<deployed-git-sha>`
+- `SENTRY_ENVIRONMENT=production`
+
+Deploy workflow already publishes EB version label `mosaic-${{ github.sha }}`. Align the four release variables to that label after each deploy.
+
+---
+
+## Public API surfaces
+
+Existing consumers remain compatible. New metadata is additive.
+
+### `GET /api/health`
+
+```json
+{
+  "status": "ok",
+  "service": "mosaic-backend",
+  "timestamp": "2026-06-21T12:00:00.000Z",
+  "uptime": 123.45,
+  "release": {
+    "commit": "80df570",
+    "environment": "production",
+    "deploymentVersion": "mosaic-80df57008f33c03df8c0a590efa8d573813ff070"
+  }
+}
+```
+
+### `GET /api/ready`
+
+Same `release` object added alongside existing `status` / `database` fields.
+
+### `GET /api/build-info`
+
+Dedicated QA/ops endpoint:
+
+```json
+{
+  "service": "mosaic-backend",
+  "timestamp": "2026-06-21T12:00:00.000Z",
+  "release": {
+    "commit": "80df570",
+    "environment": "production",
+    "deploymentVersion": "mosaic-80df57008f33c03df8c0a590efa8d573813ff070"
+  }
+}
+```
+
+When release variables are unset locally, `commit` and `deploymentVersion` fall back to `unknown` / `mosaic-unknown`.
+
+---
+
+## Sentry tagging
+
+Configured in [`instrument.js`](../../instrument.js) via [`utils/releaseIdentity.js`](../../utils/releaseIdentity.js):
+
+- `release` → `SENTRY_RELEASE` or deployment label
+- `environment` → `RELEASE_ENVIRONMENT` → `SENTRY_ENVIRONMENT` → `NODE_ENV`
+- Tags: `deployment_version`, `commit_sha`, `environment`
+- HTTP 5xx capture adds the same release tags
+
+PII scrubbing in `beforeSend` is unchanged.
+
+---
+
+## Smoke verification
+
+```bash
+npm run smoke:backend
+```
+
+Checks:
+
+- `P0.5` — `/api/health` includes safe `release` object
+- `P0.6` — `/api/build-info` includes safe `release` object
+
+Local example:
+
+```bash
+RELEASE_COMMIT_SHA=80df570 RELEASE_ENVIRONMENT=development DEPLOYMENT_VERSION_LABEL=mosaic-80df570 npm start
+API_BASE_URL=http://127.0.0.1:3001 npm run smoke:backend
+```
+
+---
+
+## Rollback notes
+
+1. Roll back EB to prior version label (e.g. `mosaic-<previous-sha>`).
+2. Update **all four** release variables to the rolled-back SHA/label.
+3. Confirm `/api/health` → `release.deploymentVersion` matches the active EB label.
+4. Confirm Sentry events group under the rolled-back `release` string.
+
+---
+
+## Source files
+
+| File | Role |
+| --- | --- |
+| `utils/releaseIdentity.js` | Canonical release resolution + public payload |
+| `routes/healthRoutes.js` | Health/readiness/build-info responses |
+| `instrument.js` | Sentry release/environment/tags |
+| `middlewares/sentryHttpCapture.js` | Release tags on 5xx events |
+| `index.js` | Startup `[release]` log line |

--- a/docs/backend/BACKEND_ROUTE_REGISTRATION.md
+++ b/docs/backend/BACKEND_ROUTE_REGISTRATION.md
@@ -23,6 +23,7 @@
 | GET | `/` | `app.js` inline | inline | Public | — | verified |
 | GET | `/api/health` | `healthRoutes.js` | inline | Public | — | verified |
 | GET | `/api/ready` | `healthRoutes.js` | inline | Public | — | verified |
+| GET | `/api/build-info` | `healthRoutes.js` | inline | Public | — | verified |
 | GET | `/internal/sentry-debug` | `app.js` | throws test error | Public | — | verified (env-gated) |
 
 ---

--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ require('./instrument');
 
 const app = require('./app');
 const connectDB = require('./config/Db');
+const { logReleaseIdentityAtStartup } = require('./utils/releaseIdentity');
 
 const PORT = process.env.PORT || 3001;
 
 const startServer = async () => {
   try {
     await connectDB();
+    logReleaseIdentityAtStartup();
     app.listen(PORT, '0.0.0.0', () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/instrument.js
+++ b/instrument.js
@@ -1,4 +1,9 @@
 const Sentry = require('@sentry/node');
+const {
+  getReleaseEnvironment,
+  getSentryRelease,
+  getSentryTags,
+} = require('./utils/releaseIdentity');
 
 const SENSITIVE_KEYS = [
   'password',
@@ -56,8 +61,8 @@ function isSentryEnabled() {
 if (isSentryEnabled()) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
-    release: process.env.SENTRY_RELEASE,
+    environment: getReleaseEnvironment(),
+    release: getSentryRelease(),
     enabled: true,
     sendDefaultPii: false,
     tracesSampleRate: parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0),
@@ -75,6 +80,11 @@ if (isSentryEnabled()) {
       return event;
     },
   });
+
+  const tags = getSentryTags();
+  for (const [key, value] of Object.entries(tags)) {
+    Sentry.setTag(key, value);
+  }
 }
 
 module.exports = Sentry;

--- a/middlewares/sentryHttpCapture.js
+++ b/middlewares/sentryHttpCapture.js
@@ -1,5 +1,6 @@
 const Sentry = require('../instrument');
 const { isSentryEnabled } = require('../instrument');
+const { getSentryTags } = require('../utils/releaseIdentity');
 
 /**
  * Reports HTTP 5xx responses to Sentry when controllers return errors
@@ -15,6 +16,7 @@ function sentryHttpCapture(req, res, next) {
       Sentry.captureMessage(`HTTP ${res.statusCode} ${req.method} ${req.originalUrl}`, {
         level: 'error',
         tags: {
+          ...getSentryTags(),
           method: req.method,
           path: req.originalUrl,
           status_code: String(res.statusCode),

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const { getPublicReleaseInfo } = require('../utils/releaseIdentity');
 
 const router = express.Router();
 const SERVICE_NAME = 'mosaic-backend';
@@ -10,6 +11,7 @@ router.get('/health', (_req, res) => {
     service: SERVICE_NAME,
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
+    release: getPublicReleaseInfo(),
   });
 });
 
@@ -20,6 +22,15 @@ router.get('/ready', (_req, res) => {
     status: connected ? 'ready' : 'not_ready',
     database: connected ? 'connected' : 'disconnected',
     timestamp: new Date().toISOString(),
+    release: getPublicReleaseInfo(),
+  });
+});
+
+router.get('/build-info', (_req, res) => {
+  res.status(200).json({
+    service: SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+    release: getPublicReleaseInfo(),
   });
 });
 

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -69,6 +69,36 @@ if ($code -eq 200) { Write-SmokePass "P0.2 GET /api/health ($code)" } else { Wri
 $code = Get-StatusCode "$Base/api/ready"
 if ($code -eq 200) { Write-SmokePass "P0.3 GET /api/ready ($code)" } else { Write-SmokeFail "P0.3 GET /api/ready ($code, expected 200)" }
 
+function Test-ReleaseIdentity([string]$Path) {
+    try {
+        $response = Invoke-WebRequest -Uri "$Base$Path" -UseBasicParsing -ErrorAction Stop
+        $json = $response.Content | ConvertFrom-Json
+        if (-not $json.release) { return $false }
+        foreach ($field in @('commit', 'environment', 'deploymentVersion')) {
+            if (-not $json.release.$field) { return $false }
+        }
+        $serialized = ($json.release | ConvertTo-Json -Compress).ToLower()
+        foreach ($bad in @('sk_live_', 'sk_test_', 'whsec_', 'sentry_dsn', 'mongodb', 'password', 'secret')) {
+            if ($serialized.Contains($bad)) { return $false }
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+if (Test-ReleaseIdentity '/api/health') {
+    Write-SmokePass 'P0.5 GET /api/health release identity'
+} else {
+    Write-SmokeFail 'P0.5 GET /api/health release identity missing or unsafe'
+}
+
+if (Test-ReleaseIdentity '/api/build-info') {
+    Write-SmokePass 'P0.6 GET /api/build-info release identity'
+} else {
+    Write-SmokeFail 'P0.6 GET /api/build-info release identity missing or unsafe'
+}
+
 $code = Get-StatusCode "$Base/api/users/auth/check"
 if ($code -eq 401) { Write-SmokePass "P2.1 GET /api/users/auth/check unauth ($code)" } else { Write-SmokeFail "P2.1 GET /api/users/auth/check ($code, expected 401)" }
 

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -41,6 +41,36 @@ if [ "$code" = "200" ]; then pass "P0.2 GET /api/health ($code)"; else fail "P0.
 code=$(http_code "$BASE/api/ready")
 if [ "$code" = "200" ]; then pass "P0.3 GET /api/ready ($code)"; else fail "P0.3 GET /api/ready ($code, expected 200)"; fi
 
+release_identity_ok() {
+  local path="$1"
+  local body
+  body=$(curl -s "$BASE$path")
+  node -e "
+    const payload = JSON.parse(process.argv[1]);
+    const release = payload.release;
+    if (!release) process.exit(1);
+    for (const key of ['commit', 'environment', 'deploymentVersion']) {
+      if (!release[key]) process.exit(1);
+    }
+    const serialized = JSON.stringify(release).toLowerCase();
+    for (const bad of ['sk_live_', 'sk_test_', 'whsec_', 'sentry_dsn', 'mongodb', 'password', 'secret']) {
+      if (serialized.includes(bad)) process.exit(1);
+    }
+  " "$body"
+}
+
+if release_identity_ok "/api/health"; then
+  pass "P0.5 GET /api/health release identity"
+else
+  fail "P0.5 GET /api/health release identity missing or unsafe"
+fi
+
+if release_identity_ok "/api/build-info"; then
+  pass "P0.6 GET /api/build-info release identity"
+else
+  fail "P0.6 GET /api/build-info release identity missing or unsafe"
+fi
+
 # P2.1 Unauthenticated auth check
 code=$(http_code "$BASE/api/users/auth/check")
 if [ "$code" = "401" ]; then pass "P2.1 GET /api/users/auth/check unauth ($code)"; else fail "P2.1 GET /api/users/auth/check ($code, expected 401)"; fi

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -219,6 +219,8 @@ test('health routes are mounted under /api with /health and /ready handlers', ()
   assert.ok(appSource.includes("app.use('/api', healthRoutes)"));
   assert.ok(healthSource.includes("router.get('/health'"));
   assert.ok(healthSource.includes("router.get('/ready'"));
+  assert.ok(healthSource.includes("router.get('/build-info'"));
+  assert.ok(healthSource.includes('getPublicReleaseInfo'));
 });
 
 test('app.js defines public GET / root handler', () => {

--- a/tests/release/healthReleaseInfo.test.js
+++ b/tests/release/healthReleaseInfo.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const mongoose = require('mongoose');
+const healthRoutes = require('../../routes/healthRoutes');
+const {
+  getPublicReleaseInfo,
+  isLikelySafePublicReleasePayload,
+} = require('../../utils/releaseIdentity');
+
+async function withHealthApp(run) {
+  const app = express();
+  app.use('/api', healthRoutes);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test('health and build-info expose safe release metadata without breaking core fields', async () => {
+  await withHealthApp(async (baseUrl) => {
+    const healthRes = await fetch(`${baseUrl}/api/health`);
+    assert.equal(healthRes.status, 200);
+    const health = await healthRes.json();
+    assert.equal(health.status, 'ok');
+    assert.equal(health.service, 'mosaic-backend');
+    assert.ok(health.release);
+    assert.equal(typeof health.release.commit, 'string');
+    assert.equal(typeof health.release.environment, 'string');
+    assert.equal(typeof health.release.deploymentVersion, 'string');
+    assert.equal(isLikelySafePublicReleasePayload(health.release), true);
+
+    const buildInfoRes = await fetch(`${baseUrl}/api/build-info`);
+    assert.equal(buildInfoRes.status, 200);
+    const buildInfo = await buildInfoRes.json();
+    assert.deepEqual(buildInfo.release, getPublicReleaseInfo());
+  });
+});
+
+test('ready preserves database status fields and adds release metadata', async () => {
+  const originalReadyState = mongoose.connection.readyState;
+  Object.defineProperty(mongoose.connection, 'readyState', {
+    configurable: true,
+    get() {
+      return 1;
+    },
+  });
+
+  try {
+    await withHealthApp(async (baseUrl) => {
+      const readyRes = await fetch(`${baseUrl}/api/ready`);
+      assert.equal(readyRes.status, 200);
+      const ready = await readyRes.json();
+      assert.equal(ready.status, 'ready');
+      assert.equal(ready.database, 'connected');
+      assert.ok(ready.release);
+    });
+  } finally {
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      configurable: true,
+      value: originalReadyState,
+    });
+  }
+});

--- a/tests/release/releaseIdentity.test.js
+++ b/tests/release/releaseIdentity.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const releaseIdentityPath = path.resolve(__dirname, '../../utils/releaseIdentity.js');
+
+function withReleaseIdentity(envOverrides, run) {
+  const saved = {};
+  for (const key of [
+    'RELEASE_COMMIT_SHA',
+    'RELEASE_ENVIRONMENT',
+    'DEPLOYMENT_VERSION_LABEL',
+    'SENTRY_RELEASE',
+    'SENTRY_ENVIRONMENT',
+    'NODE_ENV',
+  ]) {
+    saved[key] = process.env[key];
+  }
+
+  for (const key of Object.keys(saved)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+
+  delete require.cache[releaseIdentityPath];
+
+  try {
+    return run(require(releaseIdentityPath));
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    delete require.cache[releaseIdentityPath];
+  }
+}
+
+test('getPublicReleaseInfo prefers explicit release env vars', () => {
+  withReleaseIdentity(
+    {
+      RELEASE_COMMIT_SHA: 'abcdef1234567890abcdef1234567890abcdef12',
+      RELEASE_ENVIRONMENT: 'production',
+      DEPLOYMENT_VERSION_LABEL: 'mosaic-abcdef1',
+    },
+    ({ getPublicReleaseInfo, isLikelySafePublicReleasePayload }) => {
+      const info = getPublicReleaseInfo();
+      assert.deepEqual(info, {
+        commit: 'abcdef1',
+        environment: 'production',
+        deploymentVersion: 'mosaic-abcdef1',
+      });
+      assert.equal(isLikelySafePublicReleasePayload(info), true);
+    }
+  );
+});
+
+test('getSentryRelease falls back to deployment label when SENTRY_RELEASE unset', () => {
+  withReleaseIdentity(
+    {
+      DEPLOYMENT_VERSION_LABEL: 'mosaic-deadbee',
+      RELEASE_ENVIRONMENT: 'staging',
+    },
+    ({ getSentryRelease, getSentryTags }) => {
+      assert.equal(getSentryRelease(), 'mosaic-deadbee');
+      assert.deepEqual(getSentryTags(), {
+        deployment_version: 'mosaic-deadbee',
+        commit_sha: 'deadbee',
+        environment: 'staging',
+      });
+    }
+  );
+});
+
+test('getReleaseCommitSha derives commit from SENTRY_RELEASE mosaic label', () => {
+  withReleaseIdentity(
+    {
+      SENTRY_RELEASE: 'mosaic-1234567890abcdef1234567890abcdef123456',
+    },
+    ({ getShortReleaseCommitSha }) => {
+      assert.equal(getShortReleaseCommitSha(), '1234567');
+    }
+  );
+});
+
+test('unknown commit is returned when no safe release vars are set', () => {
+  withReleaseIdentity(
+    {
+      NODE_ENV: 'test',
+    },
+    ({ getPublicReleaseInfo }) => {
+      assert.deepEqual(getPublicReleaseInfo(), {
+        commit: 'unknown',
+        environment: 'test',
+        deploymentVersion: 'mosaic-unknown',
+      });
+    }
+  );
+});
+
+test('isLikelySafePublicReleasePayload rejects secret-like fragments', () => {
+  withReleaseIdentity({}, ({ isLikelySafePublicReleasePayload }) => {
+    assert.equal(
+      isLikelySafePublicReleasePayload({
+        commit: 'abc1234',
+        environment: 'production',
+        deploymentVersion: 'sk_live_bad',
+      }),
+      false
+    );
+  });
+});

--- a/utils/releaseIdentity.js
+++ b/utils/releaseIdentity.js
@@ -1,0 +1,132 @@
+const SAFE_LABEL_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+const SAFE_SHA_PATTERN = /^[a-f0-9]{7,40}$/i;
+const VERSION_LABEL_PATTERN = /^mosaic-[a-f0-9]{7,40}$/i;
+
+function normalizeOptionalString(value) {
+  if (value == null) return undefined;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeCommitSha(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized || !SAFE_SHA_PATTERN.test(normalized)) {
+    return undefined;
+  }
+  return normalized.toLowerCase();
+}
+
+function extractCommitFromVersionLabel(label) {
+  const normalized = normalizeOptionalString(label);
+  if (!normalized) return undefined;
+
+  const mosaicMatch = normalized.match(/^mosaic-([a-f0-9]{7,40})$/i);
+  if (mosaicMatch) {
+    return sanitizeCommitSha(mosaicMatch[1]);
+  }
+
+  return sanitizeCommitSha(normalized);
+}
+
+function getReleaseCommitSha() {
+  return (
+    sanitizeCommitSha(process.env.RELEASE_COMMIT_SHA)
+    || extractCommitFromVersionLabel(process.env.DEPLOYMENT_VERSION_LABEL)
+    || extractCommitFromVersionLabel(process.env.SENTRY_RELEASE)
+    || 'unknown'
+  );
+}
+
+function getShortReleaseCommitSha() {
+  const sha = getReleaseCommitSha();
+  return sha === 'unknown' ? sha : sha.slice(0, 7);
+}
+
+function getReleaseEnvironment() {
+  return (
+    normalizeOptionalString(process.env.RELEASE_ENVIRONMENT)
+    || normalizeOptionalString(process.env.SENTRY_ENVIRONMENT)
+    || normalizeOptionalString(process.env.NODE_ENV)
+    || 'development'
+  );
+}
+
+function getDeploymentVersionLabel() {
+  const explicit = normalizeOptionalString(process.env.DEPLOYMENT_VERSION_LABEL);
+  if (explicit && SAFE_LABEL_PATTERN.test(explicit)) {
+    return explicit;
+  }
+
+  const sentryRelease = normalizeOptionalString(process.env.SENTRY_RELEASE);
+  if (sentryRelease && SAFE_LABEL_PATTERN.test(sentryRelease)) {
+    return sentryRelease;
+  }
+
+  const shortSha = getShortReleaseCommitSha();
+  if (shortSha !== 'unknown') {
+    return `mosaic-${shortSha}`;
+  }
+
+  return 'mosaic-unknown';
+}
+
+function getSentryRelease() {
+  const sentryRelease = normalizeOptionalString(process.env.SENTRY_RELEASE);
+  if (sentryRelease && SAFE_LABEL_PATTERN.test(sentryRelease)) {
+    return sentryRelease;
+  }
+  return getDeploymentVersionLabel();
+}
+
+function getPublicReleaseInfo() {
+  return {
+    commit: getShortReleaseCommitSha(),
+    environment: getReleaseEnvironment(),
+    deploymentVersion: getDeploymentVersionLabel(),
+  };
+}
+
+function getSentryTags() {
+  return {
+    deployment_version: getDeploymentVersionLabel(),
+    commit_sha: getShortReleaseCommitSha(),
+    environment: getReleaseEnvironment(),
+  };
+}
+
+function logReleaseIdentityAtStartup() {
+  const info = getPublicReleaseInfo();
+  console.log(
+    `[release] env=${info.environment} version=${info.deploymentVersion} commit=${info.commit}`
+  );
+}
+
+function isLikelySafePublicReleasePayload(payload) {
+  if (!payload || typeof payload !== 'object') return false;
+
+  const serialized = JSON.stringify(payload).toLowerCase();
+  const forbiddenFragments = [
+    'sk_live_',
+    'sk_test_',
+    'whsec_',
+    'sentry_dsn',
+    'mongodb',
+    'password',
+    'secret',
+  ];
+
+  return !forbiddenFragments.some((fragment) => serialized.includes(fragment));
+}
+
+module.exports = {
+  VERSION_LABEL_PATTERN,
+  getReleaseCommitSha,
+  getShortReleaseCommitSha,
+  getReleaseEnvironment,
+  getDeploymentVersionLabel,
+  getSentryRelease,
+  getPublicReleaseInfo,
+  getSentryTags,
+  logReleaseIdentityAtStartup,
+  isLikelySafePublicReleasePayload,
+};


### PR DESCRIPTION
## Summary
- Adds `utils/releaseIdentity.js` to resolve safe commit, environment, and EB deployment label from env vars.
- Extends `/api/health` and `/api/ready` with additive `release` metadata and adds public `/api/build-info`.
- Aligns Sentry `release`, `environment`, and tags (`deployment_version`, `commit_sha`, `environment`) with the same identity.
- Extends smoke scripts (P0.5/P0.6) and deploy workflow post-deploy probes for release identity.

## Environment variable names (set in EB only)
- `RELEASE_COMMIT_SHA`
- `RELEASE_ENVIRONMENT`
- `DEPLOYMENT_VERSION_LABEL`
- `SENTRY_RELEASE` (existing; should match deployment label)
- `SENTRY_ENVIRONMENT` (existing fallback)

## Test plan
- [x] `npm test` — 265 pass
- [x] `npm run test:contract` — 18 pass
- [x] `npm run smoke:backend` — 21 pass (local server with release env vars)
- [ ] CI green on PR
- [ ] After EB deploy: confirm production `/api/health` release block matches `mosaic-<sha>` label

Closes #171
Related #162
Review backend #18