### PR TITLE
Launch consolidation: integration tests, release identity, audits (#104-106, #169)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,12 @@ LISTING_DEBUG=false
 
 # Sentry (optional — set SENTRY_DSN in EB only; never commit real DSN)
 
+# RELEASE_COMMIT_SHA=local-dev-sha
+
+# RELEASE_ENVIRONMENT=development
+
+# DEPLOYMENT_VERSION_LABEL=mosaic-local
+
 # SENTRY_DSN=
 
 # SENTRY_ENVIRONMENT=production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,9 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Run contract tests
+        run: npm run test:contract
+
+      - name: Run integration tests
+        run: npm run test:integration

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Post-deploy readiness probe
         run: |
-          for path in /api/health /api/ready; do
+          for path in /api/health /api/ready /api/build-info; do
             status=$(curl -s -o /dev/null -w "%{http_code}" "${PRODUCTION_API_URL}${path}")
             echo "${path}: HTTP $status"
             if [ "$status" != "200" ]; then
@@ -128,6 +128,14 @@ jobs:
               exit 1
             fi
           done
+          curl -s "${PRODUCTION_API_URL}/api/health" | node -e "
+            const payload = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+            if (!payload.release?.commit || !payload.release?.environment || !payload.release?.deploymentVersion) {
+              console.error('Missing release identity on /api/health');
+              process.exit(1);
+            }
+            console.log('Release identity present on /api/health');
+          "
 
       - name: Post-deploy CORS probe
         env:

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ const foodSubcategoryRoutes = require('./routes/admin/foodSubcategoryRoutes');
 const adminBusinessRoutes = require('./routes/admin/businessRoutes')
 const adminProductRoutes = require('./routes/admin/adminProductRoutes')
 const adminOrderRoutes = require('./routes/admin/adminOrderRoutes')
+const adminAuditRoutes = require('./routes/admin/adminAuditRoutes')
 const vendorOnboardVerifyStage1Routes= require("./routes/vendorOnboarding.routes")
 
 
@@ -86,6 +87,7 @@ const enquiryRoutes = require('./routes/enquiryRoutes');
 const mongoSanitize = require('express-mongo-sanitize');
 const { clean: xssClean } = require('xss-clean/lib/xss');
 const sentryHttpCapture = require('./middlewares/sentryHttpCapture');
+const requestIdMiddleware = require('./middlewares/requestId');
 const { isSentryEnabled } = require('./instrument');
 const { getAllowedOrigins } = require('./utils/corsOrigins');
 
@@ -93,6 +95,7 @@ const app = express();
 
 const allowedOrigins = getAllowedOrigins();
 app.set('trust proxy', 1);
+app.use(requestIdMiddleware);
 app.use(sentryHttpCapture);
 app.use(cors({
   origin: function (origin, callback) {
@@ -185,6 +188,7 @@ app.use('/admin/api/business', adminBusinessRoutes);
 app.use('/api/admin/business', adminBusinessRoutes);
 app.use('/admin/api/products', adminProductRoutes);
 app.use('/admin/api/orders', adminOrderRoutes);
+app.use('/admin/api/audit-events', adminAuditRoutes);
 app.use('/api/business-profile', businessProfileRoutes);
 app.use('/api/admin/category/product', productCategoryRoutes);
 app.use('/api/admin/category/product-subcategory', productSubcategoryRoutes);

--- a/controllers/admin/adminAudit.controller.js
+++ b/controllers/admin/adminAudit.controller.js
@@ -1,0 +1,75 @@
+const AdminAuditEvent = require('../../models/AdminAuditEvent');
+
+exports.listAdminAuditEvents = async (req, res) => {
+  try {
+    const page = Math.max(parseInt(req.query.page, 10) || 1, 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 25, 1), 100);
+    const skip = (page - 1) * limit;
+
+    const filter = {};
+    if (req.query.actionCode) filter.actionCode = String(req.query.actionCode).trim();
+    if (req.query.targetType) filter.targetType = String(req.query.targetType).trim();
+    if (req.query.targetId) filter.targetId = String(req.query.targetId).trim();
+    if (req.query.requestId) filter.requestId = String(req.query.requestId).trim();
+    if (req.query.outcome === 'success' || req.query.outcome === 'failure') {
+      filter.outcome = req.query.outcome;
+    }
+
+    const [events, total] = await Promise.all([
+      AdminAuditEvent.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .select(
+          'eventId createdAt actorUserId actorRole actionCode targetType targetId changeSummary requestId outcome note'
+        )
+        .lean(),
+      AdminAuditEvent.countDocuments(filter),
+    ]);
+
+    return res.status(200).json({
+      success: true,
+      data: events,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit) || 1,
+      },
+    });
+  } catch (error) {
+    console.error('listAdminAuditEvents error:', error.message);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to fetch admin audit events',
+    });
+  }
+};
+
+exports.getAdminAuditEventByEventId = async (req, res) => {
+  try {
+    const event = await AdminAuditEvent.findOne({ eventId: req.params.eventId })
+      .select(
+        'eventId createdAt actorUserId actorRole actionCode targetType targetId changeSummary requestId outcome note'
+      )
+      .lean();
+
+    if (!event) {
+      return res.status(404).json({
+        success: false,
+        message: 'Audit event not found',
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: event,
+    });
+  } catch (error) {
+    console.error('getAdminAuditEventByEventId error:', error.message);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to fetch audit event',
+    });
+  }
+};

--- a/controllers/admin/adminProduct.controller.js
+++ b/controllers/admin/adminProduct.controller.js
@@ -1,4 +1,12 @@
 const Product = require('../../models/Product');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  buildFieldChangeSummary,
+} = require('../../services/adminAuditService');
 
 // Toggle product featured status
 exports.toggleProductFeatured = async (req, res) => {
@@ -25,8 +33,22 @@ exports.toggleProductFeatured = async (req, res) => {
       nextFeaturedValue = !existingProduct.isFeatured;
     }
 
+    const previousFeatured = existingProduct.isFeatured;
     existingProduct.isFeatured = nextFeaturedValue;
     await existingProduct.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: nextFeaturedValue
+        ? ADMIN_AUDIT_ACTIONS.PRODUCT_FEATURE
+        : ADMIN_AUDIT_ACTIONS.PRODUCT_UNFEATURE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.PRODUCT,
+      targetId: existingProduct._id,
+      changeSummary: buildFieldChangeSummary(
+        { isFeatured: previousFeatured },
+        { isFeatured: existingProduct.isFeatured },
+        ['isFeatured']
+      ),
+    });
 
     res.status(200).json({
       message: `Product ${nextFeaturedValue ? 'featured' : 'unfeatured'} successfully`,

--- a/controllers/admin/business.Controller.js
+++ b/controllers/admin/business.Controller.js
@@ -1,6 +1,15 @@
 // controllers/businessController.js
 const Business = require("../../models/Business");
 const { sendBusinessStatusEmail } = require("../../utils/approvalMail");
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require("../../utils/audit/actionRegistry");
+const {
+  recordAdminAuditSuccess,
+  recordAdminAuditFailure,
+  buildFieldChangeSummary,
+} = require("../../services/adminAuditService");
 
 const parseBoolean = (value) => {
   if (value === true || value === "true" || value === 1 || value === "1") return true;
@@ -86,11 +95,24 @@ exports.toggleBusinessStatus = async (req, res) => {
     }
 
     const nextIsApproved = !business.isApproved;
+    const previousIsApproved = business.isApproved;
+    const previousIsActive = business.isActive;
 
     // ✅ Only allow toggling to APPROVED if onboardingStatus === 'completed'
     if (nextIsApproved) {
       const onboarding = String(business.onboardingStatus || "").toLowerCase();
       if (onboarding !== "completed") {
+        await recordAdminAuditFailure(req, {
+          actionCode: ADMIN_AUDIT_ACTIONS.BUSINESS_APPROVE,
+          targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+          targetId: business._id,
+          note: "Cannot approve this business until onboarding is completed.",
+          changeSummary: buildFieldChangeSummary(
+            {},
+            { onboardingStatus: business.onboardingStatus || null },
+            ["onboardingStatus"]
+          ),
+        });
         return res.status(400).json({
           success: false,
           message: "Cannot approve this business until onboarding is completed.",
@@ -138,6 +160,20 @@ exports.toggleBusinessStatus = async (req, res) => {
       // don't fail API due to email issues
     }
     // ---------------------------------------------------------
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: nextIsApproved
+        ? ADMIN_AUDIT_ACTIONS.BUSINESS_APPROVE
+        : ADMIN_AUDIT_ACTIONS.BUSINESS_DISAPPROVE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+      targetId: business._id,
+      changeSummary: buildFieldChangeSummary(
+        { isApproved: previousIsApproved, isActive: previousIsActive },
+        { isApproved: business.isApproved, isActive: business.isActive },
+        ["isApproved", "isActive"]
+      ),
+      note: !nextIsApproved ? req.body?.reason || req.body?.adminNote || null : null,
+    });
 
     return res.status(200).json({
       success: true,
@@ -219,6 +255,20 @@ exports.patchBusinessActivationStatus = async (req, res) => {
         console.error("Email send failed (patchBusinessActivationStatus):", mailErr);
       }
     }
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: nextIsActive
+        ? ADMIN_AUDIT_ACTIONS.BUSINESS_ACTIVATE
+        : ADMIN_AUDIT_ACTIONS.BUSINESS_DEACTIVATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+      targetId: business._id,
+      changeSummary: buildFieldChangeSummary(
+        { isActive: previousIsActive },
+        { isActive: business.isActive },
+        ["isActive"]
+      ),
+      note: remark || null,
+    });
 
     return res.status(200).json({
       success: true,

--- a/controllers/admin/productCategoryController.js
+++ b/controllers/admin/productCategoryController.js
@@ -1,6 +1,14 @@
 const ProductCategory = require('../../models/ProductCategory');
 const ProductSubcategory = require('../../models/ProductSubcategory');
 const deleteCloudinaryFile = require('../../utils/deleteCloudinaryFile');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  buildFieldChangeSummary,
+} = require('../../services/adminAuditService');
 
 // ✅ Create Product Category
 exports.createProductCategory = async (req, res) => {
@@ -19,6 +27,14 @@ exports.createProductCategory = async (req, res) => {
     });
 
     await category.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.CATEGORY_CREATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATEGORY,
+      targetId: category._id,
+      changeSummary: buildFieldChangeSummary({}, { name: category.name }, ['name']),
+    });
+
     return res.status(201).json({ success: true, data: category });
   } catch (err) {
     console.error('Create Product Category Error:', err);
@@ -36,11 +52,20 @@ exports.updateProductCategory = async (req, res) => {
       return res.status(404).json({ success: false, message: 'Category not found' });
     }
 
+    const beforeName = category.name;
     category.name = name || category.name;
     category.description = description || category.description;
     category.img = img || category.img;
 
     await category.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.CATEGORY_UPDATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATEGORY,
+      targetId: category._id,
+      changeSummary: buildFieldChangeSummary({ name: beforeName }, { name: category.name }, ['name']),
+    });
+
     return res.status(200).json({ success: true, data: category });
   } catch (err) {
     console.error('Update Product Category Error:', err);
@@ -66,6 +91,13 @@ exports.deleteProductCategory = async (req, res) => {
 
     // Finally, delete the category itself
     await category.deleteOne();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.CATEGORY_DELETE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATEGORY,
+      targetId: category._id,
+      changeSummary: buildFieldChangeSummary({ name: category.name }, {}, ['name']),
+    });
 
     return res.status(200).json({ success: true, message: 'Category and related subcategories deleted successfully' });
   } catch (err) {

--- a/controllers/admin/user.controller.js
+++ b/controllers/admin/user.controller.js
@@ -2,6 +2,15 @@ const User = require("../../models/User");
 const bcrypt = require("bcryptjs");
 const { validationResult } = require("express-validator");
 const toAdminUser = require("../../utils/toAdminUser");
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require("../../utils/audit/actionRegistry");
+const {
+  recordAdminAuditSuccess,
+  recordAdminAuditFailure,
+  buildFieldChangeSummary,
+} = require("../../services/adminAuditService");
 
 // POST /admin/users/admins
 exports.createAdminUser = async (req, res) => {
@@ -146,6 +155,17 @@ exports.deleteUserByAdmin = async (req, res) => {
         .json({ success: false, message: "User not found" });
     }
 
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.USER_SOFT_DELETE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.USER,
+      targetId: user._id,
+      changeSummary: buildFieldChangeSummary(
+        { isDeleted: false },
+        { isDeleted: true },
+        ["isDeleted"]
+      ),
+    });
+
     res.status(200).json({
       success: true,
       message: "User soft deleted successfully",
@@ -167,8 +187,22 @@ exports.toggleBlockUser = async (req, res) => {
         .json({ success: false, message: "User not found" });
     }
 
+    const wasBlocked = user.isBlocked;
     user.isBlocked = !user.isBlocked;
     await user.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: user.isBlocked
+        ? ADMIN_AUDIT_ACTIONS.USER_BLOCK
+        : ADMIN_AUDIT_ACTIONS.USER_UNBLOCK,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.USER,
+      targetId: user._id,
+      changeSummary: buildFieldChangeSummary(
+        { isBlocked: wasBlocked },
+        { isBlocked: user.isBlocked },
+        ["isBlocked"]
+      ),
+    });
 
     res.status(200).json({
       success: true,

--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -7,6 +7,15 @@ const {
   sendVendorTrustBadgeAssignedEmail
 } = require('../../utils/WellcomeMailer');
 const { deliverVendorOnboardingEmails } = require('../../utils/vendorOnboardingEmailDelivery');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  recordAdminAuditFailure,
+  buildFieldChangeSummary,
+} = require('../../services/adminAuditService');
 
 // Admin pending queue contains only applications that have completed vendor
 // submission and are waiting for stage-1 review. Rejected resubmissions re-enter
@@ -157,6 +166,12 @@ exports.verifyAndAllocatePoints = async (req, res) => {
     ];
 
     if (!validVerificationTypes.includes(verificationType)) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: applicationId,
+        note: 'Invalid verificationType',
+      });
       return res.status(400).json({
         success: false,
         message: 'Invalid verificationType'
@@ -166,6 +181,12 @@ exports.verifyAndAllocatePoints = async (req, res) => {
     const application = await VendorOnboarding.findOne({ applicationId });
     
     if (!application) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: applicationId,
+        note: 'Application not found',
+      });
       return res.status(404).json({
         success: false,
         message: 'Application not found'
@@ -178,9 +199,23 @@ exports.verifyAndAllocatePoints = async (req, res) => {
     if (verificationType === 'minority-proof' && !hasMinorityProofDocuments) {
       const autoAddedPoints = await autoVerifyMinorityDocsIfMissing(application);
 
+      await recordAdminAuditSuccess(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        changeSummary: buildFieldChangeSummary(
+          {},
+          {
+            verificationType: 'minority-proof',
+            isVerified: true,
+            totalVerificationPoints: application.totalVerificationPoints,
+          },
+          ['verificationType', 'isVerified', 'totalVerificationPoints']
+        ),
+        note: 'Auto-verified minority proof',
+      });
+
       return res.status(200).json({
-        success: true,
-        message: 'Minority proof not uploaded. Auto-verified with 10 points.',
         data: {
           totalPoints: application.totalVerificationPoints,
           pointsAdded: autoAddedPoints,
@@ -319,6 +354,17 @@ exports.verifyAndAllocatePoints = async (req, res) => {
     }
 
     if (missingField) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        note: `${missingField} is missing and cannot be verified`,
+        changeSummary: buildFieldChangeSummary(
+          {},
+          { verificationType, isVerified: Boolean(isVerified), missingField },
+          ['verificationType', 'isVerified', 'missingField']
+        ),
+      });
       return res.status(400).json({
         success: false,
         message: `${missingField} is missing and cannot be verified`
@@ -380,6 +426,17 @@ exports.verifyAndAllocatePoints = async (req, res) => {
 
     // Return error if already verified
     if (alreadyVerified) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        note: `${verificationType} is already verified`,
+        changeSummary: buildFieldChangeSummary(
+          {},
+          { verificationType, isVerified: Boolean(isVerified) },
+          ['verificationType', 'isVerified']
+        ),
+      });
       return res.status(400).json({
         success: false,
         message: `${verificationType} is already verified`,
@@ -392,12 +449,31 @@ exports.verifyAndAllocatePoints = async (req, res) => {
     }
 
     // Update points
+    const previousPoints = application.totalVerificationPoints - pointsToAdd;
     application.totalVerificationPoints += pointsToAdd;
 
     await application.save();
 
     // Keep Business points in sync with stage-1 onboarding points
     await syncBusinessPoints(application);
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_VERIFY_ITEM,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+      targetId: application.applicationId,
+      changeSummary: buildFieldChangeSummary(
+        {
+          totalVerificationPoints: previousPoints,
+        },
+        {
+          totalVerificationPoints: application.totalVerificationPoints,
+          verificationType,
+          isVerified: Boolean(isVerified),
+          pointsAdded: pointsToAdd,
+        },
+        ['totalVerificationPoints', 'verificationType', 'isVerified', 'pointsAdded']
+      ),
+    });
 
     return res.status(200).json({
       success: true,
@@ -431,6 +507,12 @@ exports.finalizeVerification = async (req, res) => {
       .populate('userId', 'name email');
 
     if (!application) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_FINALIZE_FAILED,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: applicationId,
+        note: 'Application not found',
+      });
       return res.status(404).json({
         success: false,
         message: 'Application not found'
@@ -438,6 +520,17 @@ exports.finalizeVerification = async (req, res) => {
     }
 
     if (application.status !== 'submitted') {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_FINALIZE_FAILED,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        note: 'Application must be in submitted status to finalize',
+        changeSummary: buildFieldChangeSummary(
+          {},
+          { status: application.status },
+          ['status']
+        ),
+      });
       return res.status(400).json({
         success: false,
         message: 'Application must be in submitted status to finalize',
@@ -474,6 +567,7 @@ exports.finalizeVerification = async (req, res) => {
     }
 
     const rejectionReason = ` ${missingRequiredDocuments.join(', ')}.`;
+    const previousStatus = 'submitted';
 
     // ✅ Badge logic (kept as-is)
     const totalPoints = application.totalVerificationPoints;
@@ -527,6 +621,17 @@ exports.finalizeVerification = async (req, res) => {
 
       const emailDelivery = await deliverVendorOnboardingEmails(emailJobs);
 
+      await recordAdminAuditSuccess(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_FINALIZE_APPROVED,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        changeSummary: buildFieldChangeSummary(
+          { status: previousStatus },
+          { status: application.status, badge },
+          ['status', 'badge']
+        ),
+      });
+
       return res.status(200).json({
         success: true,
         message: 'Application approved successfully',
@@ -553,9 +658,19 @@ exports.finalizeVerification = async (req, res) => {
         },
       ]);
 
+      await recordAdminAuditSuccess(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_FINALIZE_REJECTED,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        changeSummary: buildFieldChangeSummary(
+          { status: previousStatus },
+          { status: application.status, badge },
+          ['status', 'badge']
+        ),
+        note: rejectionReason.trim(),
+      });
+
       return res.status(200).json({
-        success: true,
-        message: 'Application rejected due to missing required documents',
         data: {
           status: 'rejected',
           badge,

--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -7,6 +7,15 @@ const FoodSubcategory = require('../models/FoodSubcategory');
 const CategoryRequest = require('../models/CategoryRequest');
 const Product = require('../models/Product');
 const Service = require('../models/Service');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  recordAdminAuditFailure,
+  buildFieldChangeSummary,
+} = require('../services/adminAuditService');
 
 const CATEGORY_MODEL_MAP = {
   product: {
@@ -527,6 +536,17 @@ const approveCategoryRequest = async (req, res) => {
       .populate('approvedCategory')
       .populate('approvedSubcategory');
 
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.CATEGORY_REQUEST_APPROVE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATEGORY_REQUEST,
+      targetId: categoryRequest._id,
+      changeSummary: buildFieldChangeSummary(
+        { status: 'pending' },
+        { status: categoryRequest.status },
+        ['status']
+      ),
+    });
+
     return res.status(200).json({
       success: true,
       message: 'Category request approved successfully',
@@ -568,6 +588,7 @@ const rejectCategoryRequest = async (req, res) => {
     }
 
     const { rejectionReason } = req.body;
+    const previousStatus = categoryRequest.status;
 
     categoryRequest.status = 'rejected';
     categoryRequest.rejectedBy = req.user._id;
@@ -584,6 +605,18 @@ const rejectCategoryRequest = async (req, res) => {
       .populate('rejectedBy', 'name email')
       .populate('approvedCategory')
       .populate('approvedSubcategory');
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.CATEGORY_REQUEST_REJECT,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATEGORY_REQUEST,
+      targetId: categoryRequest._id,
+      changeSummary: buildFieldChangeSummary(
+        { status: previousStatus },
+        { status: 'rejected' },
+        ['status']
+      ),
+      note: categoryRequest.rejectionReason || null,
+    });
 
     return res.status(200).json({
       success: true,

--- a/controllers/subscriptionPlanController.js
+++ b/controllers/subscriptionPlanController.js
@@ -2,6 +2,14 @@ const Stripe = require('stripe');
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 const SubscriptionPlan = require('../models/SubscriptionPlan');
 const { ensurePlanPrice } = require('../helpers/stripePlan');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  buildFieldChangeSummary,
+} = require('../services/adminAuditService');
 
 exports.createSubscriptionPlan = async (req, res) => {
   try {
@@ -45,6 +53,17 @@ exports.createSubscriptionPlan = async (req, res) => {
     // Create Stripe Product+Price (and save IDs back)
     await ensurePlanPrice(plan);
 
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.SUBSCRIPTION_PLAN_CREATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.SUBSCRIPTION_PLAN,
+      targetId: plan._id,
+      changeSummary: buildFieldChangeSummary(
+        {},
+        { name: plan.name, price: plan.price, durationInDays: plan.durationInDays },
+        ['name', 'price', 'durationInDays']
+      ),
+    });
+
     return res.status(201).json({
       message: 'Subscription plan created successfully',
       plan,
@@ -76,6 +95,12 @@ exports.updateSubscriptionPlan = async (req, res) => {
 
     const plan = await SubscriptionPlan.findById(id);
     if (!plan) return res.status(404).json({ message: 'Plan not found' });
+
+    const beforeSummary = {
+      name: plan.name,
+      price: plan.price,
+      durationInDays: plan.durationInDays,
+    };
 
     // Apply simple fields
     if (name) plan.name = name;
@@ -126,6 +151,21 @@ exports.updateSubscriptionPlan = async (req, res) => {
     }
 
     await plan.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.SUBSCRIPTION_PLAN_UPDATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.SUBSCRIPTION_PLAN,
+      targetId: plan._id,
+      changeSummary: buildFieldChangeSummary(
+        beforeSummary,
+        {
+          name: plan.name,
+          price: plan.price,
+          durationInDays: plan.durationInDays,
+        },
+        ['name', 'price', 'durationInDays']
+      ),
+    });
 
     return res.status(200).json({
       message: 'Subscription plan updated successfully',

--- a/docs/audit/BACKEND_REFUND_RETURN_DISPUTE_AS_BUILT_AUDIT.md
+++ b/docs/audit/BACKEND_REFUND_RETURN_DISPUTE_AS_BUILT_AUDIT.md
@@ -1,0 +1,327 @@
+# Backend refund, return, and dispute — as-built audit
+
+**Issue:** #168 (Wave 6) · **Parent:** #162  
+**Branch:** `audit/backend-refund-dispute-as-built`  
+**Scope:** Audit and documentation only — no changes to Stripe refund logic, transfer reversals, payment intents, application fees, Connect payouts, subscriptions, webhooks, or financial status transitions.
+
+**Audit date:** 2026-06-21  
+**Repository:** `Techware-Hut/mosaic-backend`
+
+---
+
+## Executive summary
+
+Marketplace order refunds are implemented as **inline Stripe `refunds.create` calls** in three order-controller paths (vendor reject, customer cancel, vendor accept return). All three use **`reverse_transfer: true`** and **`refund_application_fee: true`**. There is **no partial/line-item refund**, **no admin refund/mediation API**, **no dispute webhook handling**, and **no use of the `Refund` Mongoose model** despite its schema existing.
+
+Return flow is **status-only** on customer initiation (`delivered` → `returned`); Stripe is not touched until the vendor accepts the return.
+
+**Highest-risk gaps:**
+
+1. **`charge.refunded` webhook** looks up `charge.metadata.orderId`, but checkout metadata is set on the **PaymentIntent** only — charge metadata may be empty, so webhook-driven reconciliation may not update the order (confirmed in unit test).
+2. **No duplicate-refund idempotency** — no stored Stripe refund IDs, no idempotency keys, no `Refund` documents.
+3. **No automated integration tests** for cancel/reject/acceptReturn against Stripe test mode (audit tests are static/route-level only).
+
+---
+
+## As-built route and data inventory
+
+### HTTP routes
+
+| Method | Path | Auth middleware | Role | Handler | Stripe side effect |
+|--------|------|-----------------|------|---------|-------------------|
+| `POST` | `/api/orders/initiate` | `authenticate`, `isCustomer` | customer | `initiateOrder` | Creates PI with `metadata.orderId`, destination charge + app fee |
+| `GET` | `/api/orders/retrieve-intent/:id` | `authenticate` | any | `retrievePaymentIntent` | Read PI status |
+| `POST` | `/api/orders/:orderId/cancel` | `authenticate`, `isCustomer` | customer | `cancelOrderByUser` | Full refund if `paymentStatus === 'paid'` |
+| `PUT` | `/api/orders/reject/:orderId` | `authenticate`, `isBusinessOwner` | vendor | `rejectOrder` | Full refund if paid |
+| `PUT` | `/api/orders/initiateReturn/:orderId` | `authenticate`, `isCustomer` | customer | `initiateReturn` | **None** — sets `status: returned` |
+| `PUT` | `/api/orders/return/:orderId` | `authenticate`, `isBusinessOwner` | vendor | `acceptReturn` | Full refund if paid |
+| `PUT` | `/api/orders/ship/:orderId` | `authenticate`, `isBusinessOwner` | vendor | `shipOrder` | None |
+| `PUT` | `/api/orders/deliver/:orderId` | `authenticate`, `isBusinessOwner` | vendor | `deliverOrder` | None |
+| `GET` | `/api/orders/admin` | `authenticate`, `isAdmin` | admin | `getAllOrdersAdmin` | Read-only list |
+| `GET` | `/admin/api/orders` | `authenticate`, `isAdmin` | admin | `getAllOrdersAdmin` | Read-only alias |
+
+**Not present:** admin refund, admin dispute mediation, damaged/lost shipment endpoints, partial refund, return approval queue.
+
+### Webhooks (order financial sync)
+
+| Route | Handler | Events used for orders |
+|-------|---------|------------------------|
+| `POST /api/webhooks/stripe` | `handleStripeWebhook` | `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.refunded` |
+
+Other Stripe webhooks (`/api/stripe/webhook`, payment webhook, subscription, vendor onboarding) do **not** implement order refund/dispute flows.
+
+### Data models
+
+#### `Order` (`models/Order.js`)
+
+| Field | Relevance |
+|-------|-----------|
+| `status` | Includes `cancelled`, `returned`, `refunded`, `rejected`, lifecycle states |
+| `paymentStatus` | `pending` \| `paid` \| `failed` \| `refunded` |
+| `statusHistory` | Append-only audit trail on transitions |
+| `items[].chargeId`, `transferId`, `applicationFeeId` | Populated post-payment (webhook / retrieve flow) — **not** updated on refund |
+| `totalAmount` | Stored in **major currency units** (USD dollars); Stripe calls use `* 100` |
+
+#### `Refund` (`models/Refund.js`)
+
+Schema exists (PayPal-era fields: `refundStatus`, `paypalRefundId`, etc.) but **is never imported** in controllers or webhooks. Refunds are not persisted locally.
+
+---
+
+## Authorization matrix
+
+| Capability | Who | Route | Controller guard | Notes |
+|------------|-----|-------|------------------|-------|
+| Cancel order | Customer | `POST /api/orders/:orderId/cancel` | `order.userId === req.user._id`; blocks if `shipped`/`delivered` | Refunds when paid |
+| Initiate return | Customer | `PUT /api/orders/initiateReturn/:orderId` | Same user ownership; requires `status === 'delivered'` | Immediately sets `returned` |
+| Accept return + refund | Vendor | `PUT /api/orders/return/:orderId` | `order.vendorId === req.user._id`; requires `status === 'returned'` | |
+| Reject + refund | Vendor | `PUT /api/orders/reject/:orderId` | Vendor ownership | Allowed from early statuses (not shipped/delivered) |
+| Ship / deliver | Vendor | `PUT .../ship`, `.../deliver` | Vendor ownership | No refund |
+| List all orders | Admin | `GET /api/orders/admin`, `/admin/api/orders` | `isAdmin` | **No write/refund** |
+| Stripe webhook | Stripe | `POST /api/webhooks/stripe` | Signature verification | No user JWT |
+
+**Gap:** No admin role can force refund, mediate dispute, or override vendor/customer deadlock.
+
+---
+
+## Sequence diagrams
+
+### Customer cancellation (paid order)
+
+```mermaid
+sequenceDiagram
+  participant C as Customer
+  participant API as POST /api/orders/:id/cancel
+  participant DB as Order
+  participant S as Stripe
+
+  C->>API: cancel (JWT customer)
+  API->>DB: load order, verify userId
+  alt paymentStatus is paid
+    API->>S: refunds.create(chargeId, reverse_transfer, refund_application_fee)
+    S-->>API: refund object
+    API->>DB: paymentStatus=refunded, status=cancelled
+  else unpaid
+    API->>DB: status=cancelled only
+  end
+  API-->>C: 200 + order
+  Note over C,S: No customer email on cancel (reject/ship/deliver do email)
+```
+
+### Vendor reject (paid order)
+
+```mermaid
+sequenceDiagram
+  participant V as Vendor
+  participant API as PUT /api/orders/reject/:id
+  participant DB as Order
+  participant S as Stripe
+  participant M as Mailer
+
+  V->>API: reject
+  API->>DB: verify vendorId, status allowed
+  alt paymentStatus is paid
+    API->>S: refunds.create(amount=totalAmount*100, ...)
+    S-->>API: refund
+    API->>DB: paymentStatus=refunded, status=rejected
+  end
+  API->>M: rejection email to customer
+  API-->>V: 200
+```
+
+### Return flow (two-step)
+
+```mermaid
+sequenceDiagram
+  participant C as Customer
+  participant V as Vendor
+  participant API as Order API
+  participant DB as Order
+  participant S as Stripe
+
+  C->>API: PUT initiateReturn
+  API->>DB: status=returned (from delivered)
+  Note over C,S: No Stripe call, no vendor approval gate
+
+  V->>API: PUT return (acceptReturn)
+  API->>DB: verify status=returned
+  alt paid
+    API->>S: refunds.create(full, reverse_transfer, refund_application_fee)
+    API->>DB: paymentStatus=refunded, status=refunded
+  end
+  Note over V,S: No email on initiateReturn or acceptReturn
+```
+
+### Webhook `charge.refunded` (as-built)
+
+```mermaid
+sequenceDiagram
+  participant S as Stripe
+  participant WH as handleStripeWebhook
+  participant DB as Order
+
+  S->>WH: charge.refunded event
+  WH->>WH: orderId = charge.metadata.orderId
+  alt metadata.orderId present
+    WH->>DB: paymentStatus=refunded, status=refunded
+  else metadata missing
+    WH->>DB: findByIdAndUpdate(undefined) — no order updated
+  end
+  Note over S,DB: PI metadata from initiateOrder is not copied to charge in code
+```
+
+---
+
+## Gap matrix
+
+Classification key:
+
+- **Implemented and tested** — code path exists; automated test covers behavior
+- **Implemented; runtime proof needed** — code exists; not verified in Stripe test mode or E2E
+- **Confirmed bug** — code review / test shows incorrect behavior
+- **Client policy decision needed** — product/legal choice before implementation
+- **Future phase / change request** — intentionally out of scope
+- **Absent** — no implementation
+
+| Capability | Classification | Evidence |
+|------------|----------------|----------|
+| Customer cancellation | Implemented; runtime proof needed | `cancelOrderByUser` — no dedicated test; static audit confirms refund flags |
+| Vendor rejection + refund | Implemented; runtime proof needed | `rejectOrder`; vendor email sent |
+| Return request (customer) | Implemented; runtime proof needed | `initiateReturn` sets `returned` immediately — **policy**: no pending/approval state |
+| Vendor accept return + full refund | Implemented; runtime proof needed | `acceptReturn` |
+| Full refund (all paths) | Implemented; runtime proof needed | Always full order amount; cancel omits amount (= full charge) |
+| Partial / line-item refund | **Absent** | No amount/line parameters; single `totalAmount` |
+| Duplicate refund protection | **Confirmed bug** (risk) | Status guards help but no Stripe idempotency key, no refund ID storage, race possible |
+| Damaged shipment | **Absent** | No route or status |
+| Lost shipment | **Absent** | No route or status |
+| Delivery dispute | **Absent** | No dispute object or workflow |
+| Admin mediation / refund | **Absent** | Admin routes list only |
+| Connected-account transfer reversal | Implemented; runtime proof needed | `reverse_transfer: true` on all refund creates |
+| Application fee handling on refund | Implemented; runtime proof needed | `refund_application_fee: true` |
+| Status synchronization (inline + webhook) | **Confirmed bug** (partial) | Inline updates work; `charge.refunded` depends on charge metadata |
+| Notification on refund/cancel/return | **Client policy decision needed** | Reject/ship/deliver email; cancel/return paths silent |
+| Reconciliation / audit trail | **Absent** (partial webhook) | No `Refund` records; item-level Stripe IDs not cleared on refund |
+| Stripe dispute webhooks | **Absent** | No `charge.dispute.*` handlers |
+| `Refund` model persistence | **Absent** | Orphan schema |
+| Frontend contract documentation | **Future phase** | `BACKEND_FRONTEND_ROUTE_CONTRACT.md` documents initiate/admin list only — cancel/return/reject undocumented |
+
+---
+
+## Financial-risk notes
+
+1. **Double refund:** If two requests pass status checks before either saves (or user retries after partial failure), duplicate `refunds.create` calls are possible. No idempotency keys or unique index on Stripe refund ID.
+
+2. **Webhook desync:** Refunds initiated in-app set `paymentStatus` locally; Stripe may also emit `charge.refunded`. If webhook runs with missing `charge.metadata.orderId`, order state relies entirely on inline update — usually OK for happy path, but external/dashboard refunds may not sync.
+
+3. **Amount consistency:** `rejectOrder` passes explicit `amount: Math.round(order.totalAmount * 100)`; `cancelOrderByUser` and `acceptReturn` omit amount (Stripe defaults to full charge). All should be equivalent for single-charge orders but behavior differs if partial charges existed (they do not today).
+
+4. **Connect reversal:** Refunds use platform Stripe client with `reverse_transfer: true` — correct pattern for destination charges; **not proven** against live Connect test accounts in this audit.
+
+5. **Application fee:** `refund_application_fee: true` — fee returned to platform on full refund; **not proven** in Stripe test mode here.
+
+6. **Stock restoration:** `cancelOrderByUser` restores inventory only when prior status was `accepted`; reject/return paths do not consistently restore stock — **policy/reconciliation risk**.
+
+7. **Unused vendor Stripe lookup:** `rejectOrder` loads `vendorStripeAccountId` but refund does not use it (platform refund with reversal is correct); dead code only.
+
+8. **Payment failure webhook:** `payment_intent.payment_failed` sets order `cancelled` — distinct from refund flow.
+
+---
+
+## Policy decisions required (client)
+
+| # | Question | Current behavior |
+|---|----------|------------------|
+| P1 | Should customer `initiateReturn` create a **pending** return vs immediately `returned`? | Immediate `returned`; vendor cannot reject return request |
+| P2 | Should cancel/acceptReturn/initiateReturn send **email notifications**? | Only reject/ship/deliver notify |
+| P3 | Are **partial refunds** (damaged item, shipping only) required? | Not supported |
+| P4 | Who resolves **lost/damaged in transit** — vendor, platform, or insurer? | No workflow |
+| P5 | Should **admin** override refunds or mediate disputes? | No admin actions |
+| P6 | Should returns **restore inventory** on refund completion? | Only cancel-from-accepted restores stock |
+| P7 | Persist **Refund** documents for finance/reporting? | Schema unused |
+| P8 | Handle **Stripe chargebacks/disputes** automatically? | No handlers |
+
+---
+
+## Test matrix
+
+| Area | Existing tests | Added in this audit | Stripe test mode |
+|------|----------------|---------------------|------------------|
+| `payment_intent.succeeded` / failed | `tests/stripe/order-webhook-handlers.test.js` | — | Not run |
+| Post-payment charge/transfer IDs | Same | — | Not run |
+| `charge.refunded` webhook | None | `tests/stripe/order-refund-webhook-handlers.test.js` | Mocked only |
+| Route registration cancel/return/reject | None | `tests/audit/refund-return-dispute-routes.test.js` | N/A |
+| Refund Stripe options (static) | None | Same audit file | N/A |
+| `Refund` model unused | None | Same audit file | N/A |
+| `rejectOrder` / `cancelOrderByUser` / `acceptReturn` HTTP | None | **Not added** (would require Stripe mock refactor) | Not run |
+| Vendor reject E2E | None | — | Not run |
+| Connect transfer reversal proof | None | — | **Not proven** |
+| Application fee refund proof | None | — | **Not proven** |
+
+**Commands run:**
+
+```bash
+npm test
+npm run test:contract
+```
+
+---
+
+## Recommended follow-up issues
+
+| Priority | Title | Rationale |
+|----------|-------|-----------|
+| P0 | Fix `charge.refunded` order lookup (use PI or persist charge→order mapping) | Webhook reconciliation broken when charge metadata empty |
+| P0 | Add refund idempotency (store `stripeRefundId`, guard `paymentStatus`) | Prevent double refund |
+| P1 | Document cancel/return/reject in frontend route contract | Frontend integration gap |
+| P1 | Stripe test-mode E2E: reject, cancel, acceptReturn with Connect account | Prove reversal + app fee |
+| P2 | Wire or remove `Refund` model; persist refund records | Finance audit trail |
+| P2 | Return workflow: pending → approved vs immediate `returned` | Product policy P1 |
+| P2 | Email notifications for cancel/return/refund completion | Policy P2 |
+| P3 | Admin refund/mediation API | Policy P5 |
+| P3 | Dispute webhooks + admin queue | Chargeback handling |
+| P3 | Partial/line-item refund design | Policy P3 |
+| P3 | Lost/damaged shipment workflows | Policy P4 |
+
+---
+
+## Frontend API expectations (current)
+
+Documented in `docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md`:
+
+- `POST /api/orders/initiate` — checkout
+- `GET /api/orders/retrieve-intent/:id` — poll payment
+- Admin list: `/api/orders/admin`, `/admin/api/orders`
+
+**Undocumented but implemented** (frontend must discover from code or this audit):
+
+- `POST /api/orders/:orderId/cancel`
+- `PUT /api/orders/initiateReturn/:orderId`
+- `PUT /api/orders/return/:orderId`
+- `PUT /api/orders/reject/:orderId`
+- Vendor: `ship`, `deliver`
+
+---
+
+## What was NOT proven in Stripe test mode
+
+This audit did **not** execute live Stripe test-mode refunds. The following remain unverified at runtime:
+
+- Actual **transfer reversal** on connected accounts after refund
+- **`refund_application_fee`** crediting behavior on destination charges
+- End-to-end **reject / cancel / acceptReturn** with real PaymentIntent + Charge IDs
+- **`charge.refunded`** webhook delivery with production-like metadata
+- **Duplicate refund** behavior under concurrent requests
+- **Dashboard-initiated** refund syncing to MongoDB order state
+- Any **dispute** lifecycle (not implemented)
+
+Evidence for this audit is **static code review**, **existing unit tests**, and **new non-invasive audit tests** (route registration, refund option flags, mocked `charge.refunded` handler).
+
+---
+
+## Files touched by this audit (documentation + tests only)
+
+- `docs/audit/BACKEND_REFUND_RETURN_DISPUTE_AS_BUILT_AUDIT.md` (this file)
+- `tests/audit/refund-return-dispute-routes.test.js`
+- `tests/stripe/order-refund-webhook-handlers.test.js`
+
+No changes to payment controllers, webhook business logic, or Stripe API call parameters.

--- a/docs/backend/ADMIN_AUDIT_TRAIL_PHASE1.md
+++ b/docs/backend/ADMIN_AUDIT_TRAIL_PHASE1.md
@@ -1,0 +1,97 @@
+# Admin audit trail — Phase 1
+
+**Issue:** #169 (Wave 7) · **Parent:** #162  
+**Branch:** `feat/backend-admin-audit-trail-phase1`
+
+## Scope
+
+Immutable MongoDB audit events for launch-critical admin/moderation actions. No changes to business approval authority or payment behavior.
+
+## Pre-audit findings
+
+No existing `AuditLog`, `ActionLog`, or admin activity model was found. Request IDs were partially used (`x-request-id` in vendor onboarding emails only). Phase 1 adds global `requestIdMiddleware` and centralized audit storage.
+
+## Action registry
+
+| Action code | Trigger |
+|-------------|---------|
+| `vendor.application.verify_item` | `POST .../verify` — document/channel verification |
+| `vendor.application.finalize_approved` | `POST .../finalize` — approved |
+| `vendor.application.finalize_rejected` | `POST .../finalize` — rejected |
+| `vendor.application.finalize_failed` | Finalize blocked (not found / wrong status) |
+| `user.block` / `user.unblock` | `PUT /admin/users/:id/block` |
+| `user.soft_delete` | `DELETE /admin/users/:id` |
+| `business.approve` / `business.disapprove` | `POST /admin/api/business/approve/:id` |
+| `business.activate` / `business.deactivate` | `PATCH /admin/api/business/status/:id` |
+| `product.feature` / `product.unfeature` | `PATCH /admin/api/products/:id/featured` |
+| `category.create` / `update` / `delete` | Product category admin CRUD |
+| `category_request.approve` / `reject` | Category request moderation |
+| `subscription_plan.create` / `update` | Subscription plan admin mutations |
+
+**Not in scope (absent in codebase):** admin order overrides, admin refund actions.
+
+## Schema (`AdminAuditEvent`)
+
+| Field | Description |
+|-------|-------------|
+| `eventId` | UUID (unique) |
+| `createdAt` | Timestamp (immutable; no `updatedAt`) |
+| `actorUserId` | Admin user ObjectId |
+| `actorRole` | e.g. `admin` |
+| `actionCode` | Registry code |
+| `targetType` | e.g. `user`, `business` |
+| `targetId` | String ID |
+| `changeSummary` | Sanitized `{ fields, before, after }` |
+| `requestId` | From `X-Request-Id` or generated |
+| `outcome` | `success` \| `failure` |
+| `note` | Optional reason (max 500 chars stored) |
+
+Records are **insert-only**. Mongoose pre-hooks block update/delete mutations.
+
+## Routes
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/admin/api/audit-events` | admin | Paginated list (filtered) |
+| `GET` | `/admin/api/audit-events/:eventId` | admin | Single event |
+
+No create/update/delete HTTP APIs for audit records.
+
+## Redaction policy (`utils/audit/redaction.js`)
+
+**Never persisted:** passwords, OTPs, tokens, cookies, Stripe keys, bank/routing data, EIN/tax IDs, document URLs/content, raw request bodies, credentials.
+
+Field names matching sensitive patterns are excluded from `changeSummary.fields`; values are replaced with `[REDACTED]`. Long strings truncated to 120 chars.
+
+## Failure behavior
+
+**Decision:** Audit write failure does **not** block the primary admin action.
+
+Rationale: Blocking could leave admins retrying destructive toggles (double block/unblock). On storage failure the service logs `[admin-audit] storage failure`, emits Sentry alert when enabled, and returns `{ recorded: false }`.
+
+Failed **authorization** or validation paths record `outcome: failure` when the handler reaches an explicit audit call before returning 4xx.
+
+## Retention (decision still needed)
+
+- No TTL index or archival job in Phase 1.
+- Recommend: 24-month hot retention in MongoDB, then cold archive — **client/legal decision pending**.
+
+## Rollback
+
+1. Revert branch — admin actions continue without audit side effects.
+2. `AdminAuditEvent` collection can remain (read-only) or be dropped without affecting core flows.
+3. Remove `requestIdMiddleware` from `app.js` if rollback must strip response header (optional).
+
+## Risks
+
+- Audit calls add one Mongo insert per sensitive action (latency under load).
+- `updateUserByAdmin` is not yet audited (broad body merge — needs field allowlist before audit).
+- Service/food category CRUD not wired in Phase 1 (product category + category requests + subscription plans covered).
+
+## Verification
+
+```bash
+npm test
+npm run test:contract
+npm run test:integration
+```

--- a/docs/backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md
+++ b/docs/backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md
@@ -86,7 +86,7 @@ Use [`../production-smoke-checklist.md`](../production-smoke-checklist.md) tiers
 
 | Tier | Examples |
 | --- | --- |
-| P0 | `GET /`, `GET /api/health`, `GET /api/ready` |
+| P0 | `GET /`, `GET /api/health`, `GET /api/ready`, `GET /api/build-info`, release identity on health/build-info |
 | P1 | Auth check 401/200, CORS preflight |
 | P4 | Stripe webhook negative tests (unsigned → 400) |
 | P6 | Public search, featured products |
@@ -98,6 +98,8 @@ Wrapper: `npm run smoke:backend` → `scripts/smoke-backend.ps1` / `.sh`
 ## Rollback
 
 See [`../../DEPLOYMENT.md`](../../DEPLOYMENT.md) — EB version rollback via AWS console or redeploy prior version label.
+
+After rollback, realign release identity env vars (`RELEASE_COMMIT_SHA`, `RELEASE_ENVIRONMENT`, `DEPLOYMENT_VERSION_LABEL`, `SENTRY_RELEASE`) to the restored EB version label and verify `/api/health` → `release.deploymentVersion`. Details: [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
 
 ---
 

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -223,7 +223,7 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | Field | Value |
 | --- | --- |
 | Branch | `test/backend-isolated-integration-suite` |
-| Commit SHA | *(pending push)* |
+| Commit SHA | `8ddc7369e2cc96830709d69a112d9d7a0c5a2392` |
 | PR link | *(pending)* |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -173,3 +173,57 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
+
+---
+
+## Issue #172 — Isolated integration test suite (2026-06-21)
+
+**Branch:** `test/backend-isolated-integration-suite`  
+**Base:** `main` @ `80df57008f33c03df8c0a590efa8d573813ff070`
+
+### Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `npm test` | 0 | **284 pass**, 0 fail (integration excluded via `--test-skip-pattern`) |
+| `npm run test:contract` | 0 | **18 pass**, 0 fail |
+| `npm run test:integration` | 0 | **26 pass**, 0 fail |
+
+### Deliverables
+
+| Path | Purpose |
+| --- | --- |
+| `tests/integration/setup/harness.js` | MongoMemoryServer bootstrap, env, app import |
+| `tests/integration/helpers/` | HTTP client, factories, Stripe/mailer stubs, OTP capture |
+| `tests/integration/*.integration.test.js` | Auth, roles, vendor onboarding, marketplace, commerce, Connect |
+| `docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md` | Runbook + CI notes |
+| `.github/workflows/ci.yml` | Added contract + integration steps |
+| `routes/userRoutes.js` | Skip auth rate limiters when `NODE_ENV=test` |
+
+### Isolation method
+
+- `mongodb-memory-server` — ephemeral URI injected before `require('app')`
+- Collection wipe between tests; memory server stopped per test file process
+- No production/staging/dev Atlas connections
+
+### External stubs
+
+- Stripe (`providerStubs.js`) — dynamic failure toggle for Connect error path
+- Mailer (`providerStubs.js` + `otpCapture.js`) — OTP fixture capture
+- Dummy AWS/Cloudinary env names only
+
+### Known gaps
+
+- `GET /api/connect/:businessId/status` does not enforce business ownership (cross-vendor test uses `account-link` POST instead)
+- Vendor onboarding admin verify step not HTTP-exercised when checklist pre-seeded (finalize-only path covered)
+- WellcomeMailer/Nodemailer may log credential warnings on submit/finalize; emails are not sent in integration runs
+
+### PR metadata (fill on open)
+
+| Field | Value |
+| --- | --- |
+| Branch | `test/backend-isolated-integration-suite` |
+| Commit SHA | *(pending push)* |
+| PR link | *(pending)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |

--- a/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
+++ b/docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md
@@ -173,3 +173,38 @@ This PR:              +16 contract tests → 228 total, 0 fail
 | PR link | https://github.com/Techware-Hut/mosaic-backend/pull/95 |
 | Deploy | **Not performed** |
 | Merge | **Not performed** |
+
+---
+
+## Issue #171 — Backend release identity and Sentry tagging (2026-06-21)
+
+**Branch:** `chore/backend-release-identity-sentry`  
+**Base:** `main` @ `80df57008f33c03df8c0a590efa8d573813ff070`
+
+### Commands run
+
+| Command | Exit code | Result |
+| --- | --- | --- |
+| `npm test` | 0 | **265 pass**, 0 fail |
+| `npm run test:contract` | 0 | **18 pass**, 0 fail |
+| `npm run smoke:backend` (local `http://127.0.0.1:3099`) | 0 | **21 pass**, 0 fail |
+
+### Environment variable names (values not logged)
+
+- `RELEASE_COMMIT_SHA`
+- `RELEASE_ENVIRONMENT`
+- `DEPLOYMENT_VERSION_LABEL`
+- `SENTRY_RELEASE` (existing, aligned with deployment label)
+- `SENTRY_ENVIRONMENT` (existing fallback)
+
+See [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
+
+### PR metadata
+
+| Field | Value |
+| --- | --- |
+| Branch | `chore/backend-release-identity-sentry` |
+| Commit SHA | *(pending push)* |
+| PR link | *(pending)* |
+| Deploy | **Not performed** |
+| Merge | **Not performed** |

--- a/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
+++ b/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
@@ -159,6 +159,18 @@
 
 ---
 
+## Release identity (recommended for EB production)
+
+| Variable | Class |
+| --- | --- |
+| `RELEASE_COMMIT_SHA` | recommended |
+| `RELEASE_ENVIRONMENT` | recommended |
+| `DEPLOYMENT_VERSION_LABEL` | recommended |
+
+See [BACKEND_RELEASE_IDENTITY.md](BACKEND_RELEASE_IDENTITY.md).
+
+---
+
 ## CI / GitHub Actions (not app runtime)
 
 Set in workflows only — see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml), [`.github/workflows/deploy-eb-production.yml`](../../.github/workflows/deploy-eb-production.yml):

--- a/docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md
+++ b/docs/backend/BACKEND_INTEGRATION_TEST_RUNBOOK.md
@@ -1,0 +1,102 @@
+# Backend Integration Test Runbook
+
+**Repo:** `Techware-Hut/mosaic-backend`  
+**Issue:** [#172 — Isolated integration test suite](https://github.com/Techware-Hut/mosaic-backend/issues/172)  
+**Epic:** Cross-repo workflow reliability (#162)
+
+---
+
+## Purpose
+
+HTTP-level integration tests exercise the real Express app (`app.js`) against a **disposable in-memory MongoDB**. External providers (Stripe, SMTP/mailer) are stubbed at module boundaries only.
+
+Production, staging, and shared development databases are **never** used.
+
+---
+
+## Commands
+
+```bash
+npm test
+npm run test:contract
+npm run test:integration
+```
+
+Integration tests run with `--test-concurrency=1` to share one MongoMemoryServer instance safely.
+
+---
+
+## Database isolation
+
+| Item | Value |
+|------|--------|
+| Engine | `mongodb-memory-server` (ephemeral) |
+| URI | Set at runtime to `process.env.MONGODB_URI` |
+| Cleanup | `deleteMany({})` on all collections between tests |
+| Teardown | Memory server stopped after each test file completes |
+
+---
+
+## External services stubbed
+
+| Provider | Stub location | Notes |
+|----------|---------------|-------|
+| Stripe | `tests/integration/helpers/providerStubs.js` | No live API calls |
+| SMTP / mailer | `tests/integration/helpers/providerStubs.js` | OTP captured for verification tests |
+| AWS S3 / Cloudinary | Dummy env vars only | Upload routes not exercised in baseline suite |
+
+---
+
+## Environment variables (names only)
+
+Set automatically by the harness — do not point at real infrastructure:
+
+- `MONGODB_URI`
+- `JWT_SECRET`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `FRONTEND_URL`
+- `CORS_ORIGINS`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET`
+- `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
+- `SENTRY_ENABLED=false` (Sentry disabled)
+
+Optional live credential variables are **not** used by integration tests.
+
+---
+
+## Layout
+
+| Path | Role |
+|------|------|
+| `tests/integration/setup/harness.js` | Memory Mongo, app bootstrap, reset/teardown |
+| `tests/integration/helpers/client.js` | Supertest agent helpers |
+| `tests/integration/helpers/factories.js` | User/vendor/admin seeding |
+| `tests/integration/helpers/providerStubs.js` | Stripe + mailer stubs |
+| `tests/integration/helpers/otpCapture.js` | Controlled OTP fixture capture |
+| `tests/integration/*.integration.test.js` | Domain coverage specs |
+
+---
+
+## CI
+
+GitHub Actions job **Test** (`.github/workflows/ci.yml`) runs:
+
+1. `npm test`
+2. `npm run test:contract`
+3. `npm run test:integration`
+
+No MongoDB service container is required.
+
+---
+
+## Rollback
+
+Remove `mongodb-memory-server` and `supertest` devDependencies, delete `tests/integration/`, remove `test:integration` script and CI step. Unit/contract tests remain unchanged.
+
+---
+
+## Related docs
+
+- [BACKEND_DOCUMENTATION_EVIDENCE_LOG.md](BACKEND_DOCUMENTATION_EVIDENCE_LOG.md)
+- [BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](BACKEND_LAUNCH_CONTRACT_VERIFICATION.md)

--- a/docs/backend/BACKEND_RELEASE_IDENTITY.md
+++ b/docs/backend/BACKEND_RELEASE_IDENTITY.md
@@ -1,0 +1,132 @@
+# Backend Release Identity and Sentry Tagging
+
+**Issue:** [#171 — Backend release identity](https://github.com/Techware-Hut/mosaic-backend/issues/171)  
+**Related:** Frontend #171, epic #162, backend Sentry review #18
+
+---
+
+## Purpose
+
+Tie the running API, Git commit, Elastic Beanstalk version label, smoke proof, rollback target, and Sentry events to one **safe, non-secret release identity**.
+
+---
+
+## Environment variable names (values set in EB / CI only)
+
+| Variable | Role |
+| --- | --- |
+| `RELEASE_COMMIT_SHA` | Canonical deployed Git commit (7–40 hex chars) |
+| `RELEASE_ENVIRONMENT` | Runtime environment label (`production`, `staging`, `development`, …) |
+| `DEPLOYMENT_VERSION_LABEL` | Elastic Beanstalk version label (e.g. `mosaic-<sha>`) |
+| `SENTRY_RELEASE` | Sentry release string; defaults to deployment label when unset |
+| `SENTRY_ENVIRONMENT` | Legacy Sentry env fallback when `RELEASE_ENVIRONMENT` unset |
+| `SENTRY_DSN` | Sentry project DSN (never exposed in API responses) |
+| `SENTRY_ENABLED` | Optional disable switch |
+
+**Recommended EB production set (names only):**
+
+- `RELEASE_COMMIT_SHA=<deployed-git-sha>`
+- `RELEASE_ENVIRONMENT=production`
+- `DEPLOYMENT_VERSION_LABEL=mosaic-<deployed-git-sha>`
+- `SENTRY_RELEASE=mosaic-<deployed-git-sha>`
+- `SENTRY_ENVIRONMENT=production`
+
+Deploy workflow already publishes EB version label `mosaic-${{ github.sha }}`. Align the four release variables to that label after each deploy.
+
+---
+
+## Public API surfaces
+
+Existing consumers remain compatible. New metadata is additive.
+
+### `GET /api/health`
+
+```json
+{
+  "status": "ok",
+  "service": "mosaic-backend",
+  "timestamp": "2026-06-21T12:00:00.000Z",
+  "uptime": 123.45,
+  "release": {
+    "commit": "80df570",
+    "environment": "production",
+    "deploymentVersion": "mosaic-80df57008f33c03df8c0a590efa8d573813ff070"
+  }
+}
+```
+
+### `GET /api/ready`
+
+Same `release` object added alongside existing `status` / `database` fields.
+
+### `GET /api/build-info`
+
+Dedicated QA/ops endpoint:
+
+```json
+{
+  "service": "mosaic-backend",
+  "timestamp": "2026-06-21T12:00:00.000Z",
+  "release": {
+    "commit": "80df570",
+    "environment": "production",
+    "deploymentVersion": "mosaic-80df57008f33c03df8c0a590efa8d573813ff070"
+  }
+}
+```
+
+When release variables are unset locally, `commit` and `deploymentVersion` fall back to `unknown` / `mosaic-unknown`.
+
+---
+
+## Sentry tagging
+
+Configured in [`instrument.js`](../../instrument.js) via [`utils/releaseIdentity.js`](../../utils/releaseIdentity.js):
+
+- `release` → `SENTRY_RELEASE` or deployment label
+- `environment` → `RELEASE_ENVIRONMENT` → `SENTRY_ENVIRONMENT` → `NODE_ENV`
+- Tags: `deployment_version`, `commit_sha`, `environment`
+- HTTP 5xx capture adds the same release tags
+
+PII scrubbing in `beforeSend` is unchanged.
+
+---
+
+## Smoke verification
+
+```bash
+npm run smoke:backend
+```
+
+Checks:
+
+- `P0.5` — `/api/health` includes safe `release` object
+- `P0.6` — `/api/build-info` includes safe `release` object
+
+Local example:
+
+```bash
+RELEASE_COMMIT_SHA=80df570 RELEASE_ENVIRONMENT=development DEPLOYMENT_VERSION_LABEL=mosaic-80df570 npm start
+API_BASE_URL=http://127.0.0.1:3001 npm run smoke:backend
+```
+
+---
+
+## Rollback notes
+
+1. Roll back EB to prior version label (e.g. `mosaic-<previous-sha>`).
+2. Update **all four** release variables to the rolled-back SHA/label.
+3. Confirm `/api/health` → `release.deploymentVersion` matches the active EB label.
+4. Confirm Sentry events group under the rolled-back `release` string.
+
+---
+
+## Source files
+
+| File | Role |
+| --- | --- |
+| `utils/releaseIdentity.js` | Canonical release resolution + public payload |
+| `routes/healthRoutes.js` | Health/readiness/build-info responses |
+| `instrument.js` | Sentry release/environment/tags |
+| `middlewares/sentryHttpCapture.js` | Release tags on 5xx events |
+| `index.js` | Startup `[release]` log line |

--- a/docs/backend/BACKEND_ROUTE_REGISTRATION.md
+++ b/docs/backend/BACKEND_ROUTE_REGISTRATION.md
@@ -23,6 +23,7 @@
 | GET | `/` | `app.js` inline | inline | Public | — | verified |
 | GET | `/api/health` | `healthRoutes.js` | inline | Public | — | verified |
 | GET | `/api/ready` | `healthRoutes.js` | inline | Public | — | verified |
+| GET | `/api/build-info` | `healthRoutes.js` | inline | Public | — | verified |
 | GET | `/internal/sentry-debug` | `app.js` | throws test error | Public | — | verified (env-gated) |
 
 ---

--- a/index.js
+++ b/index.js
@@ -11,12 +11,14 @@ require('./instrument');
 
 const app = require('./app');
 const connectDB = require('./config/Db');
+const { logReleaseIdentityAtStartup } = require('./utils/releaseIdentity');
 
 const PORT = process.env.PORT || 3001;
 
 const startServer = async () => {
   try {
     await connectDB();
+    logReleaseIdentityAtStartup();
     app.listen(PORT, '0.0.0.0', () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/instrument.js
+++ b/instrument.js
@@ -1,4 +1,9 @@
 const Sentry = require('@sentry/node');
+const {
+  getReleaseEnvironment,
+  getSentryRelease,
+  getSentryTags,
+} = require('./utils/releaseIdentity');
 
 const SENSITIVE_KEYS = [
   'password',
@@ -56,8 +61,8 @@ function isSentryEnabled() {
 if (isSentryEnabled()) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV || 'development',
-    release: process.env.SENTRY_RELEASE,
+    environment: getReleaseEnvironment(),
+    release: getSentryRelease(),
     enabled: true,
     sendDefaultPii: false,
     tracesSampleRate: parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE, 0),
@@ -75,6 +80,11 @@ if (isSentryEnabled()) {
       return event;
     },
   });
+
+  const tags = getSentryTags();
+  for (const [key, value] of Object.entries(tags)) {
+    Sentry.setTag(key, value);
+  }
 }
 
 module.exports = Sentry;

--- a/middlewares/requestId.js
+++ b/middlewares/requestId.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto');
+
+/**
+ * Attach a stable request ID for tracing admin actions and audit events.
+ * Honors inbound x-request-id when present; otherwise generates one.
+ */
+function requestIdMiddleware(req, res, next) {
+  const inbound = req.headers['x-request-id'];
+  const requestId =
+    typeof inbound === 'string' && inbound.trim()
+      ? inbound.trim().slice(0, 128)
+      : crypto.randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader('X-Request-Id', requestId);
+  next();
+}
+
+module.exports = requestIdMiddleware;

--- a/middlewares/sentryHttpCapture.js
+++ b/middlewares/sentryHttpCapture.js
@@ -1,5 +1,6 @@
 const Sentry = require('../instrument');
 const { isSentryEnabled } = require('../instrument');
+const { getSentryTags } = require('../utils/releaseIdentity');
 
 /**
  * Reports HTTP 5xx responses to Sentry when controllers return errors
@@ -15,6 +16,7 @@ function sentryHttpCapture(req, res, next) {
       Sentry.captureMessage(`HTTP ${res.statusCode} ${req.method} ${req.originalUrl}`, {
         level: 'error',
         tags: {
+          ...getSentryTags(),
           method: req.method,
           path: req.originalUrl,
           status_code: String(res.statusCode),

--- a/models/AdminAuditEvent.js
+++ b/models/AdminAuditEvent.js
@@ -1,0 +1,85 @@
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+
+const IMMUTABLE_ERROR = 'AdminAuditEvent records are immutable';
+
+const adminAuditEventSchema = new mongoose.Schema(
+  {
+    eventId: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => crypto.randomUUID(),
+    },
+    actorUserId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    actorRole: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    actionCode: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    targetType: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    targetId: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    changeSummary: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
+    },
+    requestId: {
+      type: String,
+      default: null,
+      index: true,
+    },
+    outcome: {
+      type: String,
+      required: true,
+      enum: ['success', 'failure'],
+      index: true,
+    },
+    note: {
+      type: String,
+      default: null,
+      maxlength: 2000,
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    versionKey: false,
+  }
+);
+
+adminAuditEventSchema.index({ createdAt: -1 });
+
+const blockMutation = function blockMutation() {
+  throw new Error(IMMUTABLE_ERROR);
+};
+
+adminAuditEventSchema.pre('updateOne', blockMutation);
+adminAuditEventSchema.pre('updateMany', blockMutation);
+adminAuditEventSchema.pre('findOneAndUpdate', blockMutation);
+adminAuditEventSchema.pre('replaceOne', blockMutation);
+adminAuditEventSchema.pre('deleteOne', blockMutation);
+adminAuditEventSchema.pre('deleteMany', blockMutation);
+adminAuditEventSchema.pre('findOneAndDelete', blockMutation);
+
+module.exports = mongoose.model('AdminAuditEvent', adminAuditEventSchema);
+module.exports.IMMUTABLE_ERROR = IMMUTABLE_ERROR;

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,9 @@
         "xss-clean": "^0.1.4"
       },
       "devDependencies": {
-        "nodemon": "^3.1.10"
+        "mongodb-memory-server": "^11.2.0",
+        "nodemon": "^3.1.10",
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -973,12 +975,25 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.2.2.tgz",
-      "integrity": "sha512-EB0O3SCSNRUFk66iRCpI+cXzIjdswfCs7F6nOC3RAGJ7xr5YhaicvsRwJ9eyzYvYRlCSDUO/c7g4yNulxKC1WA==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1074,6 +1089,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -2080,6 +2105,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -2090,6 +2122,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -2126,19 +2168,19 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
       "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/bare-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.2.tgz",
-      "integrity": "sha512-5vn+bdnlCYMwETIm1FqQXDP6TYPbxr2uJd88ve40kr4oPbiTZJVrTNzqA3/4sfWZeWKuQR/RkboBt7qEEDtfMA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -2157,7 +2199,6 @@
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -2167,7 +2208,6 @@
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -2177,7 +2217,6 @@
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
       },
@@ -2192,6 +2231,15 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -2410,6 +2458,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2520,6 +2581,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2600,6 +2678,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -2655,9 +2740,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2708,6 +2793,17 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dfa": {
       "version": "1.2.0",
@@ -3036,6 +3132,13 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -3116,10 +3219,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3154,16 +3289,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3200,6 +3335,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3603,9 +3756,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3942,6 +4095,19 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -3999,6 +4165,32 @@
         "node": ">=12"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4033,6 +4225,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4156,6 +4371,156 @@
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.2.0.tgz",
+      "integrity": "sha512-506AD8qvClVx8Raw/WhAUUWBgIXPyi856iC01aa5vAzHmn6WOXC6ulvudkTF7oTMzJxkyA0A84VpD4BpyfqJ9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.2.0.tgz",
+      "integrity": "sha512-vOoDtn0JiLrHvZY81Rp/UtKXXK0rtJHZGZFVnccvJwYitPLNspO0Ty0grqFQOe7iAET8+GI4zAQcphg+R3vxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.16.0",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.2.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.8",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.0.tgz",
+      "integrity": "sha512-WmjjMEwFwZHmGnAb7wn90MhkiT+mTm4x/rLj7dvAPWfwnVWDXhLun2e+UM88MJoDGW624yzZglVX/zTBy9ZZMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
+      "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/mongoose": {
@@ -4284,6 +4649,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-cron": {
@@ -4438,6 +4816,45 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -4585,6 +5002,16 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
@@ -4635,6 +5062,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/png-js": {
@@ -4765,9 +5205,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4910,9 +5350,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5218,6 +5658,42 @@
       ],
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5246,12 +5722,13 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "trusted marketplace",
   "main": "index.js",
   "scripts": {
-    "test": "node --test tests/**/*.test.js",
+    "test": "node --test tests/**/*.test.js --test-skip-pattern integration",
     "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
+    "test:integration": "node --test --test-concurrency=1 tests/integration/**/*.integration.test.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"
@@ -45,6 +46,8 @@
     "xss-clean": "^0.1.4"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "mongodb-memory-server": "^11.2.0",
+    "nodemon": "^3.1.10",
+    "supertest": "^7.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node --test tests/**/*.test.js",
     "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
+    "test:integration": "node --test \"tests/integration/**/*.integration.test.js\"",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"

--- a/routes/admin/adminAuditRoutes.js
+++ b/routes/admin/adminAuditRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const authenticate = require('../../middlewares/authenticate');
+const isAdmin = require('../../middlewares/isAdmin');
+const {
+  listAdminAuditEvents,
+  getAdminAuditEventByEventId,
+} = require('../../controllers/admin/adminAudit.controller');
+
+const router = express.Router();
+
+router.use(authenticate, isAdmin);
+
+router.get('/', listAdminAuditEvents);
+router.get('/:eventId', getAdminAuditEventByEventId);
+
+module.exports = router;

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const { getPublicReleaseInfo } = require('../utils/releaseIdentity');
 
 const router = express.Router();
 const SERVICE_NAME = 'mosaic-backend';
@@ -10,6 +11,7 @@ router.get('/health', (_req, res) => {
     service: SERVICE_NAME,
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
+    release: getPublicReleaseInfo(),
   });
 });
 
@@ -20,6 +22,15 @@ router.get('/ready', (_req, res) => {
     status: connected ? 'ready' : 'not_ready',
     database: connected ? 'connected' : 'disconnected',
     timestamp: new Date().toISOString(),
+    release: getPublicReleaseInfo(),
+  });
+});
+
+router.get('/build-info', (_req, res) => {
+  res.status(200).json({
+    service: SERVICE_NAME,
+    timestamp: new Date().toISOString(),
+    release: getPublicReleaseInfo(),
   });
 });
 

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -13,6 +13,7 @@ function buildAuthLimiter(max, message) {
     max,
     standardHeaders: true,
     legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === 'test',
     message: {
       success: false,
       message,

--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -69,6 +69,36 @@ if ($code -eq 200) { Write-SmokePass "P0.2 GET /api/health ($code)" } else { Wri
 $code = Get-StatusCode "$Base/api/ready"
 if ($code -eq 200) { Write-SmokePass "P0.3 GET /api/ready ($code)" } else { Write-SmokeFail "P0.3 GET /api/ready ($code, expected 200)" }
 
+function Test-ReleaseIdentity([string]$Path) {
+    try {
+        $response = Invoke-WebRequest -Uri "$Base$Path" -UseBasicParsing -ErrorAction Stop
+        $json = $response.Content | ConvertFrom-Json
+        if (-not $json.release) { return $false }
+        foreach ($field in @('commit', 'environment', 'deploymentVersion')) {
+            if (-not $json.release.$field) { return $false }
+        }
+        $serialized = ($json.release | ConvertTo-Json -Compress).ToLower()
+        foreach ($bad in @('sk_live_', 'sk_test_', 'whsec_', 'sentry_dsn', 'mongodb', 'password', 'secret')) {
+            if ($serialized.Contains($bad)) { return $false }
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+if (Test-ReleaseIdentity '/api/health') {
+    Write-SmokePass 'P0.5 GET /api/health release identity'
+} else {
+    Write-SmokeFail 'P0.5 GET /api/health release identity missing or unsafe'
+}
+
+if (Test-ReleaseIdentity '/api/build-info') {
+    Write-SmokePass 'P0.6 GET /api/build-info release identity'
+} else {
+    Write-SmokeFail 'P0.6 GET /api/build-info release identity missing or unsafe'
+}
+
 $code = Get-StatusCode "$Base/api/users/auth/check"
 if ($code -eq 401) { Write-SmokePass "P2.1 GET /api/users/auth/check unauth ($code)" } else { Write-SmokeFail "P2.1 GET /api/users/auth/check ($code, expected 401)" }
 

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -41,6 +41,36 @@ if [ "$code" = "200" ]; then pass "P0.2 GET /api/health ($code)"; else fail "P0.
 code=$(http_code "$BASE/api/ready")
 if [ "$code" = "200" ]; then pass "P0.3 GET /api/ready ($code)"; else fail "P0.3 GET /api/ready ($code, expected 200)"; fi
 
+release_identity_ok() {
+  local path="$1"
+  local body
+  body=$(curl -s "$BASE$path")
+  node -e "
+    const payload = JSON.parse(process.argv[1]);
+    const release = payload.release;
+    if (!release) process.exit(1);
+    for (const key of ['commit', 'environment', 'deploymentVersion']) {
+      if (!release[key]) process.exit(1);
+    }
+    const serialized = JSON.stringify(release).toLowerCase();
+    for (const bad of ['sk_live_', 'sk_test_', 'whsec_', 'sentry_dsn', 'mongodb', 'password', 'secret']) {
+      if (serialized.includes(bad)) process.exit(1);
+    }
+  " "$body"
+}
+
+if release_identity_ok "/api/health"; then
+  pass "P0.5 GET /api/health release identity"
+else
+  fail "P0.5 GET /api/health release identity missing or unsafe"
+fi
+
+if release_identity_ok "/api/build-info"; then
+  pass "P0.6 GET /api/build-info release identity"
+else
+  fail "P0.6 GET /api/build-info release identity missing or unsafe"
+fi
+
 # P2.1 Unauthenticated auth check
 code=$(http_code "$BASE/api/users/auth/check")
 if [ "$code" = "401" ]; then pass "P2.1 GET /api/users/auth/check unauth ($code)"; else fail "P2.1 GET /api/users/auth/check ($code, expected 401)"; fi

--- a/services/adminAuditService.js
+++ b/services/adminAuditService.js
@@ -1,0 +1,130 @@
+const crypto = require('crypto');
+const AdminAuditEvent = require('../models/AdminAuditEvent');
+const { buildChangeSummary, sanitizeNote } = require('../utils/audit/redaction');
+
+function getRequestIdFromRequest(req) {
+  if (!req) return null;
+
+  const headerId = req.headers?.['x-request-id'];
+  if (typeof headerId === 'string' && headerId.trim()) {
+    return headerId.trim().slice(0, 128);
+  }
+
+  if (typeof req.requestId === 'string' && req.requestId.trim()) {
+    return req.requestId.trim().slice(0, 128);
+  }
+
+  return null;
+}
+
+function getActorFromRequest(req) {
+  const actorUserId = req?.user?._id || req?.user?.id || null;
+  const actorRole = req?.user?.role || 'unknown';
+
+  return { actorUserId, actorRole };
+}
+
+/**
+ * Persist an immutable admin audit event.
+ * Returns { recorded: true, event } on success.
+ * On storage failure, logs an operational alert and returns { recorded: false, error }.
+ * Does not throw — primary admin actions must not fail because audit storage failed.
+ */
+async function recordAdminAuditEvent(req, payload) {
+  const {
+    actionCode,
+    targetType,
+    targetId,
+    outcome,
+    changeSummary = null,
+    note = null,
+    requestId = undefined,
+  } = payload;
+
+  const { actorUserId, actorRole } = getActorFromRequest(req);
+
+  if (!actorUserId) {
+    console.error('[admin-audit] missing actorUserId — audit event skipped', {
+      actionCode,
+      targetType,
+      targetId,
+      outcome,
+    });
+    return { recorded: false, error: new Error('Missing actor user') };
+  }
+
+  if (!actionCode || !targetType || !targetId || !outcome) {
+    console.error('[admin-audit] invalid payload — audit event skipped', payload);
+    return { recorded: false, error: new Error('Invalid audit payload') };
+  }
+
+  const eventDoc = {
+    eventId: crypto.randomUUID(),
+    actorUserId,
+    actorRole,
+    actionCode,
+    targetType,
+    targetId: String(targetId),
+    changeSummary,
+    requestId: requestId === undefined ? getRequestIdFromRequest(req) : requestId,
+    outcome,
+    note: sanitizeNote(note),
+  };
+
+  try {
+    const event = await AdminAuditEvent.create(eventDoc);
+    return { recorded: true, event };
+  } catch (error) {
+    console.error('[admin-audit] storage failure — primary action preserved', {
+      actionCode,
+      targetType,
+      targetId,
+      outcome,
+      requestId: eventDoc.requestId,
+      message: error.message,
+    });
+
+    try {
+      const Sentry = require('../instrument');
+      if (Sentry?.isSentryEnabled?.()) {
+        Sentry.captureMessage('Admin audit storage failure', {
+          level: 'error',
+          tags: {
+            action_code: actionCode,
+            target_type: targetType,
+            outcome,
+          },
+          extra: {
+            targetId: String(targetId),
+            requestId: eventDoc.requestId,
+          },
+        });
+      }
+    } catch (_sentryError) {
+      // ignore Sentry failures
+    }
+
+    return { recorded: false, error };
+  }
+}
+
+async function recordAdminAuditSuccess(req, payload) {
+  return recordAdminAuditEvent(req, { ...payload, outcome: 'success' });
+}
+
+async function recordAdminAuditFailure(req, payload) {
+  return recordAdminAuditEvent(req, { ...payload, outcome: 'failure' });
+}
+
+function buildFieldChangeSummary(before, after, fields) {
+  return buildChangeSummary({ before, after, fields });
+}
+
+module.exports = {
+  getRequestIdFromRequest,
+  getActorFromRequest,
+  recordAdminAuditEvent,
+  recordAdminAuditSuccess,
+  recordAdminAuditFailure,
+  buildFieldChangeSummary,
+};

--- a/tests/admin/admin-audit-controller.test.js
+++ b/tests/admin/admin-audit-controller.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/admin/adminAudit.controller.js'
+);
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('listAdminAuditEvents rejects unauthenticated access via route guards in integration', () => {
+  const routesSource = require('fs').readFileSync(
+    path.resolve(__dirname, '../../routes/admin/adminAuditRoutes.js'),
+    'utf8'
+  );
+  assert.match(routesSource, /router\.use\(authenticate, isAdmin\)/);
+});
+
+test('listAdminAuditEvents returns paginated audit events for admin handler', async () => {
+  const events = [
+    {
+      eventId: 'evt-1',
+      actionCode: 'user.block',
+      targetType: 'user',
+      targetId: '507f1f77bcf86cd799439099',
+      outcome: 'success',
+    },
+  ];
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/AdminAuditEvent')) {
+      return {
+        find: () => ({
+          sort: () => ({
+            skip: () => ({
+              limit: () => ({
+                select: () => ({
+                  lean: async () => events,
+                }),
+              }),
+            }),
+          }),
+        }),
+        countDocuments: async () => 1,
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const { listAdminAuditEvents } = require(controllerPath);
+  Module._load = originalLoad;
+
+  const res = mockResponse();
+  await listAdminAuditEvents({ query: { page: 1, limit: 10 } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.length, 1);
+  assert.equal(res.body.data[0].eventId, 'evt-1');
+});

--- a/tests/admin/admin-audit-redaction.test.js
+++ b/tests/admin/admin-audit-redaction.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  redactValue,
+  redactObject,
+  buildChangeSummary,
+  sanitizeNote,
+  isSensitiveFieldName,
+} = require('../../utils/audit/redaction');
+
+test('redaction masks sensitive field names and values', () => {
+  assert.equal(isSensitiveFieldName('passwordHash'), true);
+  assert.equal(isSensitiveFieldName('otp'), true);
+  assert.equal(isSensitiveFieldName('stripeSecretKey'), true);
+  assert.equal(isSensitiveFieldName('isBlocked'), false);
+
+  assert.equal(redactValue('password', 'secret123'), '[REDACTED]');
+  assert.equal(redactValue('isBlocked', true), true);
+});
+
+test('buildChangeSummary excludes sensitive fields from field list', () => {
+  const summary = buildChangeSummary({
+    before: { isBlocked: false, passwordHash: 'hash' },
+    after: { isBlocked: true, passwordHash: 'hash2' },
+    fields: ['isBlocked', 'passwordHash'],
+  });
+
+  assert.deepEqual(summary.fields, ['isBlocked']);
+  assert.equal(summary.before.isBlocked, false);
+  assert.equal(summary.after.isBlocked, true);
+  assert.equal(summary.before.passwordHash, undefined);
+});
+
+test('redactObject truncates long strings', () => {
+  const longText = 'a'.repeat(200);
+  const output = redactObject({ note: longText });
+  assert.ok(output.note.endsWith('...'));
+  assert.ok(output.note.length <= 120);
+});
+
+test('sanitizeNote trims and caps note length', () => {
+  assert.equal(sanitizeNote('  hello  '), 'hello');
+  assert.equal(sanitizeNote(null), null);
+  assert.ok(sanitizeNote('x'.repeat(600)).length <= 500);
+});

--- a/tests/admin/admin-audit-routes.test.js
+++ b/tests/admin/admin-audit-routes.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '../..');
+const auditRoutesPath = path.join(root, 'routes/admin/adminAuditRoutes.js');
+const appPath = path.join(root, 'app.js');
+const modelPath = path.join(root, 'models/AdminAuditEvent.js');
+
+test('audit routes require authenticate and isAdmin on all handlers', () => {
+  const source = fs.readFileSync(auditRoutesPath, 'utf8');
+  assert.match(source, /router\.use\(authenticate, isAdmin\)/);
+  assert.doesNotMatch(source, /router\.(post|put|patch|delete)/);
+});
+
+test('app mounts protected admin audit read API', () => {
+  const source = fs.readFileSync(appPath, 'utf8');
+  assert.match(source, /app\.use\('\/admin\/api\/audit-events', adminAuditRoutes\)/);
+});
+
+test('AdminAuditEvent schema disables updatedAt for tamper resistance', () => {
+  const source = fs.readFileSync(modelPath, 'utf8');
+  assert.match(source, /updatedAt:\s*false/);
+  assert.match(source, /blockMutation/);
+  assert.match(source, /pre\('updateOne'/);
+  assert.match(source, /pre\('deleteOne'/);
+});
+
+test('request ID middleware is registered globally', () => {
+  const source = fs.readFileSync(appPath, 'utf8');
+  assert.match(source, /requestIdMiddleware/);
+  assert.match(source, /app\.use\(requestIdMiddleware\)/);
+});

--- a/tests/admin/admin-audit-service.test.js
+++ b/tests/admin/admin-audit-service.test.js
@@ -1,0 +1,150 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const servicePath = path.resolve(__dirname, '../../services/adminAuditService.js');
+const modelPath = path.resolve(__dirname, '../../models/AdminAuditEvent.js');
+
+const ACTOR_ID = '507f1f77bcf86cd799439011';
+
+function mockReq(overrides = {}) {
+  return {
+    user: { _id: ACTOR_ID, role: 'admin' },
+    headers: { 'x-request-id': 'req-test-001' },
+    requestId: 'req-generated-001',
+    ...overrides,
+  };
+}
+
+test('recordAdminAuditSuccess creates event with request ID from header', async () => {
+  const created = [];
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/AdminAuditEvent')) {
+      return {
+        create: async (doc) => {
+          created.push(doc);
+          return { ...doc, _id: 'audit001' };
+        },
+      };
+    }
+    if (request.endsWith('instrument')) {
+      return { isSentryEnabled: () => false };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[servicePath];
+  const { recordAdminAuditSuccess } = require(servicePath);
+
+  const result = await recordAdminAuditSuccess(mockReq(), {
+    actionCode: 'user.block',
+    targetType: 'user',
+    targetId: '507f1f77bcf86cd799439099',
+    changeSummary: { fields: ['isBlocked'], before: { isBlocked: false }, after: { isBlocked: true } },
+  });
+
+  Module._load = originalLoad;
+  delete require.cache[servicePath];
+
+  assert.equal(result.recorded, true);
+  assert.equal(created.length, 1);
+  assert.equal(created[0].requestId, 'req-test-001');
+  assert.equal(created[0].outcome, 'success');
+  assert.equal(String(created[0].actorUserId), ACTOR_ID);
+});
+
+test('recordAdminAuditFailure stores failure outcome', async () => {
+  const created = [];
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/AdminAuditEvent')) {
+      return {
+        create: async (doc) => {
+          created.push(doc);
+          return doc;
+        },
+      };
+    }
+    if (request.endsWith('instrument')) {
+      return { isSentryEnabled: () => false };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[servicePath];
+  const { recordAdminAuditFailure } = require(servicePath);
+
+  const result = await recordAdminAuditFailure(mockReq({ headers: {} }), {
+    actionCode: 'business.approve',
+    targetType: 'business',
+    targetId: 'biz001',
+    note: 'Onboarding incomplete',
+  });
+
+  Module._load = originalLoad;
+  delete require.cache[servicePath];
+
+  assert.equal(result.recorded, true);
+  assert.equal(created[0].outcome, 'failure');
+  assert.equal(created[0].requestId, 'req-generated-001');
+});
+
+test('audit storage failure does not throw and returns recorded false', async () => {
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/AdminAuditEvent')) {
+      return {
+        create: async () => {
+          throw new Error('mongo down');
+        },
+      };
+    }
+    if (request.endsWith('instrument')) {
+      return { isSentryEnabled: () => false, captureMessage: () => {} };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[servicePath];
+  const { recordAdminAuditSuccess } = require(servicePath);
+
+  const result = await recordAdminAuditSuccess(mockReq(), {
+    actionCode: 'user.unblock',
+    targetType: 'user',
+    targetId: 'user001',
+  });
+
+  Module._load = originalLoad;
+  delete require.cache[servicePath];
+
+  assert.equal(result.recorded, false);
+  assert.match(result.error.message, /mongo down/);
+});
+
+test('missing actor skips audit without throwing', async () => {
+  delete require.cache[servicePath];
+  const { recordAdminAuditSuccess } = require(servicePath);
+
+  const result = await recordAdminAuditSuccess({ headers: {} }, {
+    actionCode: 'user.block',
+    targetType: 'user',
+    targetId: 'user001',
+  });
+
+  assert.equal(result.recorded, false);
+});
+
+test('AdminAuditEvent model declares immutable mutation guards', () => {
+  const AdminAuditEvent = require(modelPath);
+  const source = require('fs').readFileSync(modelPath, 'utf8');
+
+  assert.match(AdminAuditEvent.IMMUTABLE_ERROR, /immutable/i);
+  assert.match(source, /pre\('updateOne', blockMutation\)/);
+  assert.match(source, /pre\('deleteOne', blockMutation\)/);
+  assert.match(source, /updatedAt:\s*false/);
+});

--- a/tests/audit/refund-return-dispute-routes.test.js
+++ b/tests/audit/refund-return-dispute-routes.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '../..');
+const orderRoutesPath = path.join(root, 'routes/orderRoutes.js');
+const orderControllerPath = path.join(root, 'controllers/orderController.js');
+const webhookControllerPath = path.join(root, 'controllers/webhookController.js');
+const refundModelPath = path.join(root, 'models/Refund.js');
+
+function readSource(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+test('order routes register cancel, return, reject, and vendor fulfillment handlers', () => {
+  const routes = readSource(orderRoutesPath);
+
+  assert.match(routes, /router\.post\("\/:orderId\/cancel", authenticate, isCustomer, cancelOrderByUser\)/);
+  assert.match(routes, /router\.put\('\/initiateReturn\/:orderId', authenticate, isCustomer, initiateReturn\)/);
+  assert.match(routes, /router\.put\('\/return\/:orderId', authenticate, isBusinessOwner, acceptReturn\)/);
+  assert.match(routes, /router\.put\('\/reject\/:orderId', authenticate, isBusinessOwner, rejectOrder\)/);
+  assert.match(routes, /router\.put\('\/ship\/:orderId', authenticate, isBusinessOwner, shipOrder\)/);
+  assert.match(routes, /router\.put\('\/deliver\/:orderId', authenticate, isBusinessOwner, deliverOrder\)/);
+});
+
+test('admin order routes expose read-only list alias without refund mutations', () => {
+  const adminRoutes = readSource(path.join(root, 'routes/admin/adminOrderRoutes.js'));
+  const orderController = readSource(orderControllerPath);
+
+  assert.match(adminRoutes, /router\.get\('\/', authenticate, isAdmin, getAllOrdersAdmin\)/);
+  assert.doesNotMatch(adminRoutes, /refund|return|cancel|reject/i);
+  assert.doesNotMatch(orderController, /exports\.\w*Refund/);
+});
+
+test('refund handlers use Connect-safe Stripe refund options', () => {
+  const source = readSource(orderControllerPath);
+
+  const refundBlocks = source.match(/stripe\.refunds\.create\([\s\S]*?\);/g) || [];
+  assert.equal(refundBlocks.length, 3, 'expected reject, acceptReturn, and cancel refund paths');
+
+  for (const block of refundBlocks) {
+    assert.match(block, /reverse_transfer:\s*true/);
+    assert.match(block, /refund_application_fee:\s*true/);
+  }
+});
+
+test('Refund mongoose model exists but is not referenced by order refund flows', () => {
+  const refundModel = readSource(refundModelPath);
+  const controller = readSource(orderControllerPath);
+  const webhook = readSource(webhookControllerPath);
+
+  assert.match(refundModel, /refundStatus/);
+  assert.doesNotMatch(controller, /require\(['"].*Refund['"]\)/);
+  assert.doesNotMatch(webhook, /require\(['"].*Refund['"]\)/);
+});
+
+test('order status webhook handles charge.refunded using charge metadata orderId', () => {
+  const source = readSource(webhookControllerPath);
+
+  assert.match(source, /case 'charge\.refunded':/);
+  assert.match(source, /chargeRefunded\.metadata\.orderId/);
+});

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent, parseCookies } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  registerUser,
+  verifyRegistrationOtp,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('register → OTP verify → login → auth/check → logout session flow', async () => {
+  const agent = createAgent(getApp());
+
+  const { registerRes, email, password } = await registerAndVerify(agent, {
+    role: 'customer',
+  });
+
+  assert.equal(registerRes.status, 201);
+  assert.equal(registerRes.body.success, true);
+
+  const loginRes = await login(agent, email, password);
+  assert.equal(loginRes.status, 200);
+  assert.ok(loginRes.body.token);
+  assert.equal(loginRes.headers['set-cookie']?.some((c) => c.startsWith('token=')), true);
+
+  const authCheck = await agent.get('/api/users/auth/check');
+  assert.equal(authCheck.status, 200);
+  assert.equal(authCheck.body.loggedIn, true);
+  assert.equal(authCheck.body.user.role, 'customer');
+
+  const logoutRes = await agent.post('/api/users/logout');
+  assert.equal(logoutRes.status, 200);
+
+  const afterLogout = await agent.get('/api/users/auth/check');
+  assert.equal(afterLogout.status, 401);
+});
+
+test('OTP verification uses captured fixture OTP from mailer stub', async () => {
+  const agent = createAgent(getApp());
+  const { email } = await registerUser(agent, { role: 'business_owner' });
+
+  const verifyRes = await verifyRegistrationOtp(agent, email);
+  assert.equal(verifyRes.status, 200);
+  assert.equal(verifyRes.body.success, true);
+  assert.equal(verifyRes.body.user.role, 'business_owner');
+});
+
+test('auth check rejects invalidated session after sessionVersion bump', async () => {
+  const agent = createAgent(getApp());
+  const { email, password } = await registerAndVerify(agent, { role: 'customer' });
+
+  await login(agent, email, password);
+  const ok = await agent.get('/api/users/auth/check');
+  assert.equal(ok.status, 200);
+
+  const user = await User.findOne({ email });
+  user.sessionVersion = (user.sessionVersion || 0) + 1;
+  await user.save();
+
+  const stale = await agent.get('/api/users/auth/check');
+  assert.equal(stale.status, 401);
+  assert.match(stale.body.message, /Session expired/i);
+});
+
+test('unauthenticated auth check returns 401', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/users/auth/check');
+  assert.equal(res.status, 401);
+});
+
+test('register sets otpPending cookie', async () => {
+  const agent = createAgent(getApp());
+  const { res, email } = await registerUser(agent, { role: 'customer' });
+  assert.equal(res.status, 201);
+  const cookies = parseCookies(res.headers['set-cookie']);
+  assert.equal(cookies.otpPending, 'true');
+  assert.ok(email);
+});

--- a/tests/integration/commerce.integration.test.js
+++ b/tests/integration/commerce.integration.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('authenticated customer receives cart payload', async () => {
+  const agent = createAgent(getApp());
+  const customer = await registerAndVerify(agent, { role: 'customer' });
+  await login(agent, customer.email, customer.password);
+
+  const res = await agent.get('/api/cart');
+  assert.equal(res.status, 200);
+  assert.ok(Object.prototype.hasOwnProperty.call(res.body, 'cart'));
+});
+
+test('order initiate rejects empty cart for customer', async () => {
+  const agent = createAgent(getApp());
+  const customer = await registerAndVerify(agent, { role: 'customer' });
+  await login(agent, customer.email, customer.password);
+
+  const res = await agent.post('/api/orders/initiate').send({
+    shippingAddress: {
+      fullName: 'Test Customer',
+      phone: '5555550100',
+      addressLine1: '123 Main St',
+      city: 'Atlanta',
+      state: 'GA',
+      country: 'USA',
+      postalCode: '30301',
+    },
+  });
+
+  assert.notEqual(res.status, 200);
+});
+
+test('vendor cannot initiate customer checkout order', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const res = await agent.post('/api/orders/initiate').send({});
+  assert.equal(res.status, 403);
+});
+
+test('admin can list orders; vendor can list vendor orders endpoint', async () => {
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const adminOrders = await adminAgent.get('/api/orders/admin');
+  assert.equal(adminOrders.status, 200);
+
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+  const user = await User.findOne({ email: vendor.email });
+  await seedApprovedBusiness(user);
+
+  const vendorOrders = await vendorAgent.get('/api/orders/vendor');
+  assert.equal(vendorOrders.status, 200);
+});

--- a/tests/integration/connect.integration.test.js
+++ b/tests/integration/connect.integration.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const {
+  setStripeShouldFail,
+  resetStripeStub,
+} = require('./helpers/providerStubs');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  resetStripeStub();
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('connect account-link returns onboarding URL contract', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    stripeConnectAccountId: null,
+  });
+
+  const res = await agent.post(`/api/connect/${business._id}/account-link`);
+  assert.equal(res.status, 200);
+  assert.match(res.body.url, /connect\.stripe\.com/);
+});
+
+test('connect status returns capability summary', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user);
+
+  const res = await agent.get(`/api/connect/${business._id}/status`);
+  assert.equal(res.status, 200);
+  assert.ok(Object.prototype.hasOwnProperty.call(res.body, 'chargesEnabled'));
+});
+
+test('connect account-link surfaces provider failure without live Stripe', async () => {
+  setStripeShouldFail(true);
+
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    stripeConnectAccountId: null,
+  });
+
+  const res = await agent.post(`/api/connect/${business._id}/account-link`);
+  assert.notEqual(res.status, 200);
+});

--- a/tests/integration/helpers/client.js
+++ b/tests/integration/helpers/client.js
@@ -1,0 +1,25 @@
+const supertest = require('supertest');
+
+function createAgent(app) {
+  return supertest.agent(app);
+}
+
+function parseCookies(setCookieHeader) {
+  const headers = Array.isArray(setCookieHeader)
+    ? setCookieHeader
+    : setCookieHeader
+      ? [setCookieHeader]
+      : [];
+
+  return headers.reduce((acc, header) => {
+    const [pair] = header.split(';');
+    const idx = pair.indexOf('=');
+    if (idx === -1) {
+      return acc;
+    }
+    acc[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
+    return acc;
+  }, {});
+}
+
+module.exports = { createAgent, parseCookies };

--- a/tests/integration/helpers/factories.js
+++ b/tests/integration/helpers/factories.js
@@ -1,0 +1,186 @@
+const bcrypt = require('bcryptjs');
+const mongoose = require('mongoose');
+const User = require('../../../models/User');
+const Business = require('../../../models/Business');
+const Product = require('../../../models/Product');
+const Subscription = require('../../../models/Subscription');
+const SubscriptionPlan = require('../../../models/SubscriptionPlan');
+const VendorOnboarding = require('../../../models/VendorOnboardingStage1');
+const { getCapturedOtp } = require('./otpCapture');
+
+function uniqueEmail(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}@example.test`;
+}
+
+let mobileCounter = 0;
+
+function uniqueMobile() {
+  mobileCounter += 1;
+  return `+1415555${String(mobileCounter).padStart(4, '0')}`;
+}
+
+const validStage1Draft = {
+  businessName: 'Integration Test Business LLC',
+  businessType: 'product',
+  primaryContactName: 'Integration Vendor',
+  address: {
+    city: 'Atlanta',
+    state: 'GA',
+    country: 'USA',
+    zipCode: '30301',
+  },
+  acceptedTerms: true,
+  declarationAccepted: true,
+  isMinorityOwned: false,
+};
+
+async function registerUser(agent, { role = 'customer', password = 'Secret123!' } = {}) {
+  const email = uniqueEmail(role);
+  const mobile = uniqueMobile();
+
+  const res = await agent.post('/api/users/register').send({
+    name: `${role} Integration`,
+    email,
+    password,
+    mobile,
+    role,
+  });
+
+  if (res.status !== 201) {
+    throw new Error(
+      `Register failed (${res.status}): ${JSON.stringify(res.body)}`
+    );
+  }
+
+  return { res, email, password, mobile };
+}
+
+async function verifyRegistrationOtp(agent, email) {
+  const otp = getCapturedOtp(email);
+  if (!otp) {
+    throw new Error(`No captured OTP for ${email}`);
+  }
+
+  return agent.post('/api/users/verify-otp').send({ email, otp });
+}
+
+async function registerAndVerify(agent, options = {}) {
+  const { res: registerRes, email, password } = await registerUser(agent, options);
+  const verifyRes = await verifyRegistrationOtp(agent, email);
+  return { registerRes, verifyRes, email, password };
+}
+
+async function login(agent, email, password) {
+  return agent.post('/api/users/login').send({ email, password });
+}
+
+async function createAdminDirect() {
+  const email = uniqueEmail('admin');
+  const password = 'AdminSecret123!';
+  const user = await User.create({
+    name: 'Integration Admin',
+    email,
+    mobile: uniqueMobile(),
+    passwordHash: await bcrypt.hash(password, 12),
+    role: 'admin',
+    isOtpVerified: true,
+  });
+
+  return { user, email, password };
+}
+
+async function ensureSubscriptionPlan() {
+  let plan = await SubscriptionPlan.findOne({ name: 'Silver Plan' });
+  if (!plan) {
+    plan = await SubscriptionPlan.create({
+      name: 'Silver Plan',
+      price: 0,
+      limits: {
+        productListings: 10,
+        serviceListings: 10,
+        foodListings: 10,
+        imageLimit: 100,
+        videoLimit: 10,
+      },
+    });
+  }
+  return plan;
+}
+
+async function seedApprovedBusiness(ownerUser, overrides = {}) {
+  const owner =
+    ownerUser && ownerUser._id
+      ? ownerUser
+      : await User.findById(ownerUser);
+
+  if (!owner) {
+    throw new Error('seedApprovedBusiness requires a valid owner User');
+  }
+
+  const plan = await ensureSubscriptionPlan();
+  const subscription = await Subscription.create({
+    userId: owner._id,
+    subscriptionPlanId: plan._id,
+    stripeSubscriptionId: `sub_int_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+    paymentStatus: 'COMPLETED',
+    startDate: new Date(),
+    endDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    status: 'active',
+  });
+
+  return Business.create({
+    owner: owner._id,
+    businessName: 'Integration Vendor Shop',
+    email: owner.email,
+    isApproved: overrides.isApproved ?? true,
+    isActive: overrides.isActive ?? true,
+    stripeConnectAccountId: overrides.stripeConnectAccountId ?? 'acct_integration_test',
+    listingType: 'product',
+    subscriptionId: subscription._id,
+    subscriptionPlanId: plan._id,
+    ...overrides,
+  });
+}
+
+async function seedPublishedProduct(business, ownerUser) {
+  return Product.create({
+    title: 'Integration Test Product',
+    description: 'Integration test product description',
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: ownerUser._id,
+    businessId: business._id,
+    isPublished: true,
+    price: 1999,
+    coverImage: 'https://example.test/product.png',
+    slug: `integration-product-${Date.now()}`,
+  });
+}
+
+async function seedVendorOnboarding(user, overrides = {}) {
+  return VendorOnboarding.create({
+    userId: user._id,
+    applicationId: overrides.applicationId || `MBH-INT-${Date.now()}`,
+    businessName: validStage1Draft.businessName,
+    status: overrides.status || 'draft',
+    isMinorityOwned: overrides.isMinorityOwned ?? false,
+    verificationPayment: overrides.verificationPayment || {
+      status: 'paid',
+      paymentIntentId: 'pi_integration_test',
+    },
+    ...overrides,
+  });
+}
+
+module.exports = {
+  validStage1Draft,
+  registerUser,
+  verifyRegistrationOtp,
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+  seedPublishedProduct,
+  seedVendorOnboarding,
+  uniqueEmail,
+};

--- a/tests/integration/helpers/otpCapture.js
+++ b/tests/integration/helpers/otpCapture.js
@@ -1,0 +1,15 @@
+const otpByEmail = new Map();
+
+function captureOtp(email, otp) {
+  otpByEmail.set(String(email).toLowerCase(), String(otp));
+}
+
+function getCapturedOtp(email) {
+  return otpByEmail.get(String(email).toLowerCase());
+}
+
+function resetOtpCapture() {
+  otpByEmail.clear();
+}
+
+module.exports = { captureOtp, getCapturedOtp, resetOtpCapture };

--- a/tests/integration/helpers/providerStubs.js
+++ b/tests/integration/helpers/providerStubs.js
@@ -1,0 +1,123 @@
+const Module = require('module');
+const path = require('path');
+const { captureOtp } = require('./otpCapture');
+
+let originalLoad = null;
+let stripeShouldFail = false;
+
+function setStripeShouldFail(value) {
+  stripeShouldFail = Boolean(value);
+}
+
+function createStripeClient() {
+  const failIfRequested = () => {
+    if (stripeShouldFail) {
+      const err = new Error('Stripe provider unavailable (integration stub)');
+      err.type = 'StripeConnectionError';
+      throw err;
+    }
+  };
+
+  return {
+    paymentIntents: {
+      create: async (params) => {
+        failIfRequested();
+        return {
+          id: 'pi_integration_test',
+          client_secret: 'pi_integration_test_secret',
+          status: 'requires_payment_method',
+          amount: params?.amount ?? 2000,
+          currency: params?.currency || 'usd',
+          metadata: params?.metadata || {},
+        };
+      },
+      retrieve: async (id) => {
+        failIfRequested();
+        return {
+          id: id || 'pi_integration_test',
+          status: 'succeeded',
+          amount: 2000,
+          currency: 'usd',
+          metadata: { type: 'vendor_verification' },
+        };
+      },
+    },
+    accounts: {
+      create: async () => {
+        failIfRequested();
+        return { id: 'acct_integration_test' };
+      },
+      retrieve: async () => {
+        failIfRequested();
+        return {
+          id: 'acct_integration_test',
+          charges_enabled: true,
+          payouts_enabled: true,
+          capabilities: { transfers: 'active' },
+          requirements: { currently_due: [] },
+        };
+      },
+    },
+    accountLinks: {
+      create: async () => {
+        failIfRequested();
+        return { url: 'https://connect.stripe.com/setup/test/integration' };
+      },
+    },
+    webhooks: {
+      constructEvent: () => ({ type: 'test.event' }),
+    },
+  };
+}
+
+function createMailerStub() {
+  return {
+    sendOtpEmail: async (email, otp) => {
+      captureOtp(email, otp);
+    },
+    sendWelcomeEmail: async () => {},
+    sendPasswordResetOtpEmail: async () => {},
+    sendVendorOnboardingAdminNotification: async () => {},
+    sendVendorOnboardingVendorConfirmation: async () => {},
+  };
+}
+
+function installProviderStubs() {
+  if (originalLoad) {
+    return;
+  }
+
+  originalLoad = Module._load;
+  const mailerPath = path.normalize(
+    path.join(__dirname, '../../../utils/mailer.js')
+  );
+
+  Module._load = function integrationMockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      function StripeMock() {
+        return createStripeClient();
+      }
+      StripeMock.Stripe = StripeMock;
+      return StripeMock;
+    }
+
+    try {
+      const resolved = Module._resolveFilename(request, parent);
+      if (path.normalize(resolved) === mailerPath) {
+        return createMailerStub();
+      }
+    } catch {
+      // fall through
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+}
+
+module.exports = {
+  installProviderStubs,
+  setStripeShouldFail,
+  resetStripeStub: () => {
+    stripeShouldFail = false;
+  },
+};

--- a/tests/integration/marketplace.integration.test.js
+++ b/tests/integration/marketplace.integration.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+  seedPublishedProduct,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('GET /api/featured-products returns safe empty payload', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/featured-products');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.products));
+});
+
+test('GET /api/products/list returns list wrapper', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/products/list');
+  assert.equal(res.status, 200);
+  assert.ok(Array.isArray(res.body.data));
+});
+
+test('GET /api/public/product/:id returns product detail when seeded', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user);
+  const product = await seedPublishedProduct(business, user);
+
+  const res = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.data.title, 'Integration Test Product');
+});
+
+test('GET /api/services/list and /api/food/list return safe empty arrays', async () => {
+  const agent = createAgent(getApp());
+
+  const services = await agent.get('/api/services/list');
+  assert.equal(services.status, 200);
+
+  const foods = await agent.get('/api/food/list');
+  assert.equal(foods.status, 200);
+});
+
+test('missing product detail returns 404', async () => {
+  const agent = createAgent(getApp());
+  const missingId = '507f1f77bcf86cd799439011';
+  const res = await agent.get(`/api/public/product/${missingId}`);
+  assert.equal(res.status, 404);
+});

--- a/tests/integration/roles.integration.test.js
+++ b/tests/integration/roles.integration.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  seedApprovedBusiness,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('customer can access cart; vendor receives 403 on admin orders', async () => {
+  const customerAgent = createAgent(getApp());
+  const { email, password } = await registerAndVerify(customerAgent, {
+    role: 'customer',
+  });
+  await login(customerAgent, email, password);
+
+  const cartRes = await customerAgent.get('/api/cart');
+  assert.equal(cartRes.status, 200);
+
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+
+  const adminOrders = await vendorAgent.get('/api/orders/admin');
+  assert.equal(adminOrders.status, 403);
+});
+
+test('admin can access admin orders list', async () => {
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const res = await adminAgent.get('/api/orders/admin');
+  assert.equal(res.status, 200);
+});
+
+test('business_owner can access business/my scoped to own account', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  await seedApprovedBusiness(user);
+
+  const myBusiness = await vendorAgent.get('/api/business/my');
+  assert.equal(myBusiness.status, 200);
+  assert.ok(Array.isArray(myBusiness.body.businesses));
+});
+
+test('cross-vendor connect account-link rejects foreign businessId', async () => {
+  const vendorA = createAgent(getApp());
+  const vendorB = createAgent(getApp());
+
+  const a = await registerAndVerify(vendorA, { role: 'business_owner' });
+  const b = await registerAndVerify(vendorB, { role: 'business_owner' });
+  await login(vendorA, a.email, a.password);
+  await login(vendorB, b.email, b.password);
+
+  const bUser = await User.findOne({ email: b.email });
+  const businessB = await seedApprovedBusiness(bUser);
+
+  const foreignLink = await vendorA.post(
+    `/api/connect/${businessB._id}/account-link`
+  );
+  assert.equal(foreignLink.status, 403);
+});

--- a/tests/integration/setup/harness.js
+++ b/tests/integration/setup/harness.js
@@ -1,0 +1,95 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const {
+  installProviderStubs,
+  resetStripeStub,
+} = require('../helpers/providerStubs');
+const { resetOtpCapture } = require('../helpers/otpCapture');
+
+let mongoServer = null;
+let app = null;
+let started = false;
+
+function applyIntegrationEnv(mongoUri) {
+  process.env.NODE_ENV = 'test';
+  process.env.MONGODB_URI = mongoUri;
+  process.env.JWT_SECRET =
+    process.env.JWT_SECRET || 'integration-test-jwt-secret-min-32-chars';
+  process.env.STRIPE_SECRET_KEY =
+    process.env.STRIPE_SECRET_KEY || 'sk_test_integration_mock_key_000000000';
+  process.env.STRIPE_WEBHOOK_SECRET =
+    process.env.STRIPE_WEBHOOK_SECRET || 'whsec_test_integration_mock';
+  process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:3000';
+  process.env.CORS_ORIGINS =
+    process.env.CORS_ORIGINS || 'http://127.0.0.1:3000';
+  process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'test';
+  process.env.AWS_SECRET_ACCESS_KEY =
+    process.env.AWS_SECRET_ACCESS_KEY || 'test';
+  process.env.AWS_REGION = process.env.AWS_REGION || 'us-east-1';
+  process.env.AWS_S3_BUCKET = process.env.AWS_S3_BUCKET || 'integration-test-bucket';
+  process.env.CLOUDINARY_CLOUD_NAME =
+    process.env.CLOUDINARY_CLOUD_NAME || 'integration-test';
+  process.env.CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY || 'test';
+  process.env.CLOUDINARY_API_SECRET =
+    process.env.CLOUDINARY_API_SECRET || 'test';
+  delete process.env.SENTRY_DSN;
+  process.env.SENTRY_ENABLED = 'false';
+}
+
+async function startHarness() {
+  if (started && app) {
+    return app;
+  }
+
+  installProviderStubs();
+  mongoServer = await MongoMemoryServer.create();
+  applyIntegrationEnv(mongoServer.getUri());
+
+  await mongoose.connect(process.env.MONGODB_URI, {
+    serverSelectionTimeoutMS: 10000,
+  });
+
+  // eslint-disable-next-line global-require
+  app = require('../../../app');
+  started = true;
+  return app;
+}
+
+async function resetDatabase() {
+  resetOtpCapture();
+  resetStripeStub();
+
+  if (mongoose.connection.readyState !== 1) {
+    return;
+  }
+
+  for (const collection of Object.values(mongoose.connection.collections)) {
+    await collection.deleteMany({});
+  }
+}
+
+async function stopHarness() {
+  if (mongoose.connection.readyState !== 0) {
+    await mongoose.disconnect();
+  }
+  if (mongoServer) {
+    await mongoServer.stop();
+    mongoServer = null;
+  }
+  app = null;
+  started = false;
+}
+
+function getApp() {
+  if (!app) {
+    throw new Error('Integration harness not started. Call startHarness() first.');
+  }
+  return app;
+}
+
+module.exports = {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+};

--- a/tests/integration/vendor-onboarding.integration.test.js
+++ b/tests/integration/vendor-onboarding.integration.test.js
@@ -1,0 +1,144 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  createAdminDirect,
+  validStage1Draft,
+  seedVendorOnboarding,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const VendorOnboarding = require('../../models/VendorOnboardingStage1');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('vendor can save and retrieve onboarding draft', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const saveRes = await agent.post('/api/vendor-onboarding/draft').send(validStage1Draft);
+  assert.equal(saveRes.status, 200);
+
+  const getRes = await agent.get('/api/vendor-onboarding/draft');
+  assert.equal(getRes.status, 200);
+  assert.equal(getRes.body.data.businessName, validStage1Draft.businessName);
+});
+
+test('payment-pending onboarding reports pending payment status', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  const user = await User.findOne({ email: vendor.email });
+  await seedVendorOnboarding(user, {
+    status: 'draft',
+    verificationPayment: { status: 'pending', paymentIntentId: 'pi_integration_test' },
+  });
+
+  const statusRes = await agent.get('/api/vendor-onboarding/stage1/payment-status');
+  assert.equal(statusRes.status, 200);
+  assert.equal(statusRes.body.data.status, 'pending');
+});
+
+test('submit moves application to submitted when payment is paid', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  await login(agent, vendor.email, vendor.password);
+
+  await agent.post('/api/vendor-onboarding/draft').send(validStage1Draft);
+
+  const user = await User.findOne({ email: vendor.email });
+  const onboarding = await VendorOnboarding.findOneAndUpdate(
+    { userId: user._id },
+    {
+      verificationPayment: {
+        status: 'paid',
+        paymentIntentId: 'pi_integration_test',
+      },
+    },
+    { new: true }
+  );
+
+  const submitRes = await agent.post('/api/vendor-onboarding/submit');
+  assert.equal(submitRes.status, 200);
+
+  const refreshed = await VendorOnboarding.findOne({ _id: onboarding._id });
+  assert.equal(refreshed.status, 'submitted');
+});
+
+test('admin verify and finalize progression', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  await login(vendorAgent, vendor.email, vendor.password);
+  const user = await User.findOne({ email: vendor.email });
+
+  const onboarding = await seedVendorOnboarding(user, {
+    status: 'submitted',
+    totalVerificationPoints: 50,
+    verificationPayment: { status: 'paid', paymentIntentId: 'pi_integration_test' },
+    verificationChecklist: {
+      minorityDocs: true,
+      taxDocs: true,
+      businessLicense: true,
+      website: true,
+      facebook: false,
+      instagram: false,
+      linkedin: false,
+      tiktok: false,
+    },
+  });
+
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const finalizeRes = await adminAgent.post(
+    `/api/vendor-onboarding/${onboarding.applicationId}/finalize`
+  );
+  assert.equal(finalizeRes.status, 200);
+
+  const statusRes = await adminAgent.get(
+    `/api/vendor-onboarding/${onboarding.applicationId}`
+  );
+  assert.equal(statusRes.status, 200);
+  assert.equal(statusRes.body.data.status, 'verified');
+});
+
+test('rejected application state is readable by admin', async () => {
+  const vendor = await registerAndVerify(createAgent(getApp()), {
+    role: 'business_owner',
+  });
+  const user = await User.findOne({ email: vendor.email });
+  const onboarding = await seedVendorOnboarding(user, {
+    status: 'rejected',
+    rejectionReason: 'Integration test rejection',
+  });
+
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const detail = await adminAgent.get(
+    `/api/vendor-onboarding/${onboarding.applicationId}`
+  );
+  assert.equal(detail.status, 200);
+  assert.equal(detail.body.data.status, 'rejected');
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -219,6 +219,8 @@ test('health routes are mounted under /api with /health and /ready handlers', ()
   assert.ok(appSource.includes("app.use('/api', healthRoutes)"));
   assert.ok(healthSource.includes("router.get('/health'"));
   assert.ok(healthSource.includes("router.get('/ready'"));
+  assert.ok(healthSource.includes("router.get('/build-info'"));
+  assert.ok(healthSource.includes('getPublicReleaseInfo'));
 });
 
 test('app.js defines public GET / root handler', () => {

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -257,3 +257,22 @@ test('documented launch paths resolve to expected registration status', () => {
     assert.ok(!appSource.includes(needle), `${needle} should not be registered`);
   }
 });
+
+test('admin audit read API is mounted and guarded', () => {
+  const appSource = readSource(appPath);
+  const auditRoutesPath = path.join(root, 'routes/admin/adminAuditRoutes.js');
+  const auditSource = readSource(auditRoutesPath);
+
+  assert.ok(appSource.includes("app.use('/admin/api/audit-events', adminAuditRoutes)"));
+  assert.ok(auditSource.includes('router.use(authenticate, isAdmin)'));
+  assert.ok(!auditSource.match(/router\.(post|put|patch|delete)/));
+});
+
+test('request ID middleware is applied before route handlers', () => {
+  const appSource = readSource(appPath);
+  const requestIdx = appSource.indexOf('app.use(requestIdMiddleware)');
+  const healthIdx = appSource.indexOf("app.use('/api', healthRoutes)");
+
+  assert.ok(requestIdx > -1, 'requestIdMiddleware should be registered');
+  assert.ok(requestIdx < healthIdx, 'requestIdMiddleware should run before API routes');
+});

--- a/tests/release/healthReleaseInfo.test.js
+++ b/tests/release/healthReleaseInfo.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const mongoose = require('mongoose');
+const healthRoutes = require('../../routes/healthRoutes');
+const {
+  getPublicReleaseInfo,
+  isLikelySafePublicReleasePayload,
+} = require('../../utils/releaseIdentity');
+
+async function withHealthApp(run) {
+  const app = express();
+  app.use('/api', healthRoutes);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+test('health and build-info expose safe release metadata without breaking core fields', async () => {
+  await withHealthApp(async (baseUrl) => {
+    const healthRes = await fetch(`${baseUrl}/api/health`);
+    assert.equal(healthRes.status, 200);
+    const health = await healthRes.json();
+    assert.equal(health.status, 'ok');
+    assert.equal(health.service, 'mosaic-backend');
+    assert.ok(health.release);
+    assert.equal(typeof health.release.commit, 'string');
+    assert.equal(typeof health.release.environment, 'string');
+    assert.equal(typeof health.release.deploymentVersion, 'string');
+    assert.equal(isLikelySafePublicReleasePayload(health.release), true);
+
+    const buildInfoRes = await fetch(`${baseUrl}/api/build-info`);
+    assert.equal(buildInfoRes.status, 200);
+    const buildInfo = await buildInfoRes.json();
+    assert.deepEqual(buildInfo.release, getPublicReleaseInfo());
+  });
+});
+
+test('ready preserves database status fields and adds release metadata', async () => {
+  const originalReadyState = mongoose.connection.readyState;
+  Object.defineProperty(mongoose.connection, 'readyState', {
+    configurable: true,
+    get() {
+      return 1;
+    },
+  });
+
+  try {
+    await withHealthApp(async (baseUrl) => {
+      const readyRes = await fetch(`${baseUrl}/api/ready`);
+      assert.equal(readyRes.status, 200);
+      const ready = await readyRes.json();
+      assert.equal(ready.status, 'ready');
+      assert.equal(ready.database, 'connected');
+      assert.ok(ready.release);
+    });
+  } finally {
+    Object.defineProperty(mongoose.connection, 'readyState', {
+      configurable: true,
+      value: originalReadyState,
+    });
+  }
+});

--- a/tests/release/releaseIdentity.test.js
+++ b/tests/release/releaseIdentity.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const releaseIdentityPath = path.resolve(__dirname, '../../utils/releaseIdentity.js');
+
+function withReleaseIdentity(envOverrides, run) {
+  const saved = {};
+  for (const key of [
+    'RELEASE_COMMIT_SHA',
+    'RELEASE_ENVIRONMENT',
+    'DEPLOYMENT_VERSION_LABEL',
+    'SENTRY_RELEASE',
+    'SENTRY_ENVIRONMENT',
+    'NODE_ENV',
+  ]) {
+    saved[key] = process.env[key];
+  }
+
+  for (const key of Object.keys(saved)) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, envOverrides);
+
+  delete require.cache[releaseIdentityPath];
+
+  try {
+    return run(require(releaseIdentityPath));
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    delete require.cache[releaseIdentityPath];
+  }
+}
+
+test('getPublicReleaseInfo prefers explicit release env vars', () => {
+  withReleaseIdentity(
+    {
+      RELEASE_COMMIT_SHA: 'abcdef1234567890abcdef1234567890abcdef12',
+      RELEASE_ENVIRONMENT: 'production',
+      DEPLOYMENT_VERSION_LABEL: 'mosaic-abcdef1',
+    },
+    ({ getPublicReleaseInfo, isLikelySafePublicReleasePayload }) => {
+      const info = getPublicReleaseInfo();
+      assert.deepEqual(info, {
+        commit: 'abcdef1',
+        environment: 'production',
+        deploymentVersion: 'mosaic-abcdef1',
+      });
+      assert.equal(isLikelySafePublicReleasePayload(info), true);
+    }
+  );
+});
+
+test('getSentryRelease falls back to deployment label when SENTRY_RELEASE unset', () => {
+  withReleaseIdentity(
+    {
+      DEPLOYMENT_VERSION_LABEL: 'mosaic-deadbee',
+      RELEASE_ENVIRONMENT: 'staging',
+    },
+    ({ getSentryRelease, getSentryTags }) => {
+      assert.equal(getSentryRelease(), 'mosaic-deadbee');
+      assert.deepEqual(getSentryTags(), {
+        deployment_version: 'mosaic-deadbee',
+        commit_sha: 'deadbee',
+        environment: 'staging',
+      });
+    }
+  );
+});
+
+test('getReleaseCommitSha derives commit from SENTRY_RELEASE mosaic label', () => {
+  withReleaseIdentity(
+    {
+      SENTRY_RELEASE: 'mosaic-1234567890abcdef1234567890abcdef123456',
+    },
+    ({ getShortReleaseCommitSha }) => {
+      assert.equal(getShortReleaseCommitSha(), '1234567');
+    }
+  );
+});
+
+test('unknown commit is returned when no safe release vars are set', () => {
+  withReleaseIdentity(
+    {
+      NODE_ENV: 'test',
+    },
+    ({ getPublicReleaseInfo }) => {
+      assert.deepEqual(getPublicReleaseInfo(), {
+        commit: 'unknown',
+        environment: 'test',
+        deploymentVersion: 'mosaic-unknown',
+      });
+    }
+  );
+});
+
+test('isLikelySafePublicReleasePayload rejects secret-like fragments', () => {
+  withReleaseIdentity({}, ({ isLikelySafePublicReleasePayload }) => {
+    assert.equal(
+      isLikelySafePublicReleasePayload({
+        commit: 'abc1234',
+        environment: 'production',
+        deploymentVersion: 'sk_live_bad',
+      }),
+      false
+    );
+  });
+});

--- a/tests/stripe/order-refund-webhook-handlers.test.js
+++ b/tests/stripe/order-refund-webhook-handlers.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const webhookControllerPath = path.resolve(__dirname, '../../controllers/webhookController.js');
+
+const ORDER_ID = '507f1f77bcf86cd799439020';
+const CHARGE_ID = 'ch_test_refund_001';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function loadChargeRefundedWebhook({ orderIdInMetadata } = {}) {
+  const updates = [];
+  const stripeMock = {
+    webhooks: {
+      constructEvent: () => ({
+        type: 'charge.refunded',
+        data: {
+          object: {
+            id: CHARGE_ID,
+            metadata: orderIdInMetadata ? { orderId: orderIdInMetadata } : {},
+          },
+        },
+      }),
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return function StripeClient() {
+        return stripeMock;
+      };
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        findByIdAndUpdate: async (id, update) => {
+          updates.push({ id, update });
+          return id ? { _id: id, ...update } : null;
+        },
+      };
+    }
+    if (request.endsWith('models/Subscription')) {
+      return {};
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[webhookControllerPath];
+  const { handleStripeWebhook } = require(webhookControllerPath);
+  Module._load = originalLoad;
+
+  return { handleStripeWebhook, getUpdates: () => updates };
+}
+
+test('charge.refunded webhook marks order refunded when charge metadata includes orderId', async () => {
+  process.env.STRIPE_ORDER_WEBHOOK_SECRET = 'whsec_order_test';
+  const { handleStripeWebhook, getUpdates } = loadChargeRefundedWebhook({
+    orderIdInMetadata: ORDER_ID,
+  });
+  const res = mockResponse();
+
+  await handleStripeWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(getUpdates().length, 1);
+  assert.equal(String(getUpdates()[0].id), ORDER_ID);
+  assert.equal(getUpdates()[0].update.paymentStatus, 'refunded');
+  assert.equal(getUpdates()[0].update.status, 'refunded');
+});
+
+test('charge.refunded webhook does not update order when charge metadata lacks orderId', async () => {
+  process.env.STRIPE_ORDER_WEBHOOK_SECRET = 'whsec_order_test';
+  const { handleStripeWebhook, getUpdates } = loadChargeRefundedWebhook({
+    orderIdInMetadata: undefined,
+  });
+  const res = mockResponse();
+
+  await handleStripeWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(getUpdates().length, 1);
+  assert.equal(getUpdates()[0].id, undefined);
+});

--- a/utils/audit/actionRegistry.js
+++ b/utils/audit/actionRegistry.js
@@ -1,0 +1,47 @@
+/**
+ * Canonical admin audit action codes for Phase 1.
+ * @see docs/backend/ADMIN_AUDIT_TRAIL_PHASE1.md
+ */
+const ADMIN_AUDIT_ACTIONS = Object.freeze({
+  VENDOR_APPLICATION_VERIFY_ITEM: 'vendor.application.verify_item',
+  VENDOR_APPLICATION_FINALIZE_APPROVED: 'vendor.application.finalize_approved',
+  VENDOR_APPLICATION_FINALIZE_REJECTED: 'vendor.application.finalize_rejected',
+  VENDOR_APPLICATION_FINALIZE_FAILED: 'vendor.application.finalize_failed',
+
+  USER_BLOCK: 'user.block',
+  USER_UNBLOCK: 'user.unblock',
+  USER_SOFT_DELETE: 'user.soft_delete',
+
+  BUSINESS_APPROVE: 'business.approve',
+  BUSINESS_DISAPPROVE: 'business.disapprove',
+  BUSINESS_ACTIVATE: 'business.activate',
+  BUSINESS_DEACTIVATE: 'business.deactivate',
+
+  PRODUCT_FEATURE: 'product.feature',
+  PRODUCT_UNFEATURE: 'product.unfeature',
+
+  CATEGORY_CREATE: 'category.create',
+  CATEGORY_UPDATE: 'category.update',
+  CATEGORY_DELETE: 'category.delete',
+
+  CATEGORY_REQUEST_APPROVE: 'category_request.approve',
+  CATEGORY_REQUEST_REJECT: 'category_request.reject',
+
+  SUBSCRIPTION_PLAN_CREATE: 'subscription_plan.create',
+  SUBSCRIPTION_PLAN_UPDATE: 'subscription_plan.update',
+});
+
+const ADMIN_AUDIT_TARGET_TYPES = Object.freeze({
+  VENDOR_APPLICATION: 'vendor_application',
+  USER: 'user',
+  BUSINESS: 'business',
+  PRODUCT: 'product',
+  CATEGORY: 'category',
+  CATEGORY_REQUEST: 'category_request',
+  SUBSCRIPTION_PLAN: 'subscription_plan',
+});
+
+module.exports = {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+};

--- a/utils/audit/redaction.js
+++ b/utils/audit/redaction.js
@@ -1,0 +1,92 @@
+const SENSITIVE_FIELD_PATTERN =
+  /password|otp|token|cookie|secret|credential|stripe|bank|routing|accountnumber|ein|ssn|taxid|document|url|file|content|body|raw/i;
+
+const ALWAYS_REDACT_VALUE = '[REDACTED]';
+
+function isSensitiveFieldName(fieldName) {
+  if (typeof fieldName !== 'string') return true;
+  return SENSITIVE_FIELD_PATTERN.test(fieldName);
+}
+
+function redactValue(fieldName, value) {
+  if (isSensitiveFieldName(fieldName)) {
+    return ALWAYS_REDACT_VALUE;
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value.length > 120 ? `${value.slice(0, 117)}...` : value;
+  }
+
+  if (Array.isArray(value)) {
+    return { count: value.length };
+  }
+
+  if (typeof value === 'object') {
+    return redactObject(value, 1);
+  }
+
+  return ALWAYS_REDACT_VALUE;
+}
+
+function redactObject(source, depth = 0) {
+  if (!source || typeof source !== 'object' || depth > 2) {
+    return ALWAYS_REDACT_VALUE;
+  }
+
+  const output = {};
+  for (const [key, value] of Object.entries(source)) {
+    output[key] = redactValue(key, value);
+  }
+  return output;
+}
+
+/**
+ * Build a sanitized before/after summary using field names and safe scalar values only.
+ */
+function buildChangeSummary({ before = {}, after = {}, fields = [] } = {}) {
+  const fieldNames =
+    fields.length > 0
+      ? fields
+      : [...new Set([...Object.keys(before || {}), ...Object.keys(after || {})])];
+
+  const safeFields = fieldNames.filter((name) => !isSensitiveFieldName(name));
+
+  return {
+    fields: safeFields,
+    before: redactObject(
+      Object.fromEntries(safeFields.map((name) => [name, before?.[name]]))
+    ),
+    after: redactObject(
+      Object.fromEntries(safeFields.map((name) => [name, after?.[name]]))
+    ),
+  };
+}
+
+function sanitizeNote(note) {
+  if (note === null || note === undefined || note === '') {
+    return null;
+  }
+
+  const text = String(note).trim();
+  if (!text) return null;
+
+  return text.length > 500 ? `${text.slice(0, 497)}...` : text;
+}
+
+module.exports = {
+  ALWAYS_REDACT_VALUE,
+  SENSITIVE_FIELD_PATTERN,
+  isSensitiveFieldName,
+  redactValue,
+  redactObject,
+  buildChangeSummary,
+  sanitizeNote,
+};

--- a/utils/releaseIdentity.js
+++ b/utils/releaseIdentity.js
@@ -1,0 +1,132 @@
+const SAFE_LABEL_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+const SAFE_SHA_PATTERN = /^[a-f0-9]{7,40}$/i;
+const VERSION_LABEL_PATTERN = /^mosaic-[a-f0-9]{7,40}$/i;
+
+function normalizeOptionalString(value) {
+  if (value == null) return undefined;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeCommitSha(value) {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized || !SAFE_SHA_PATTERN.test(normalized)) {
+    return undefined;
+  }
+  return normalized.toLowerCase();
+}
+
+function extractCommitFromVersionLabel(label) {
+  const normalized = normalizeOptionalString(label);
+  if (!normalized) return undefined;
+
+  const mosaicMatch = normalized.match(/^mosaic-([a-f0-9]{7,40})$/i);
+  if (mosaicMatch) {
+    return sanitizeCommitSha(mosaicMatch[1]);
+  }
+
+  return sanitizeCommitSha(normalized);
+}
+
+function getReleaseCommitSha() {
+  return (
+    sanitizeCommitSha(process.env.RELEASE_COMMIT_SHA)
+    || extractCommitFromVersionLabel(process.env.DEPLOYMENT_VERSION_LABEL)
+    || extractCommitFromVersionLabel(process.env.SENTRY_RELEASE)
+    || 'unknown'
+  );
+}
+
+function getShortReleaseCommitSha() {
+  const sha = getReleaseCommitSha();
+  return sha === 'unknown' ? sha : sha.slice(0, 7);
+}
+
+function getReleaseEnvironment() {
+  return (
+    normalizeOptionalString(process.env.RELEASE_ENVIRONMENT)
+    || normalizeOptionalString(process.env.SENTRY_ENVIRONMENT)
+    || normalizeOptionalString(process.env.NODE_ENV)
+    || 'development'
+  );
+}
+
+function getDeploymentVersionLabel() {
+  const explicit = normalizeOptionalString(process.env.DEPLOYMENT_VERSION_LABEL);
+  if (explicit && SAFE_LABEL_PATTERN.test(explicit)) {
+    return explicit;
+  }
+
+  const sentryRelease = normalizeOptionalString(process.env.SENTRY_RELEASE);
+  if (sentryRelease && SAFE_LABEL_PATTERN.test(sentryRelease)) {
+    return sentryRelease;
+  }
+
+  const shortSha = getShortReleaseCommitSha();
+  if (shortSha !== 'unknown') {
+    return `mosaic-${shortSha}`;
+  }
+
+  return 'mosaic-unknown';
+}
+
+function getSentryRelease() {
+  const sentryRelease = normalizeOptionalString(process.env.SENTRY_RELEASE);
+  if (sentryRelease && SAFE_LABEL_PATTERN.test(sentryRelease)) {
+    return sentryRelease;
+  }
+  return getDeploymentVersionLabel();
+}
+
+function getPublicReleaseInfo() {
+  return {
+    commit: getShortReleaseCommitSha(),
+    environment: getReleaseEnvironment(),
+    deploymentVersion: getDeploymentVersionLabel(),
+  };
+}
+
+function getSentryTags() {
+  return {
+    deployment_version: getDeploymentVersionLabel(),
+    commit_sha: getShortReleaseCommitSha(),
+    environment: getReleaseEnvironment(),
+  };
+}
+
+function logReleaseIdentityAtStartup() {
+  const info = getPublicReleaseInfo();
+  console.log(
+    `[release] env=${info.environment} version=${info.deploymentVersion} commit=${info.commit}`
+  );
+}
+
+function isLikelySafePublicReleasePayload(payload) {
+  if (!payload || typeof payload !== 'object') return false;
+
+  const serialized = JSON.stringify(payload).toLowerCase();
+  const forbiddenFragments = [
+    'sk_live_',
+    'sk_test_',
+    'whsec_',
+    'sentry_dsn',
+    'mongodb',
+    'password',
+    'secret',
+  ];
+
+  return !forbiddenFragments.some((fragment) => serialized.includes(fragment));
+}
+
+module.exports = {
+  VERSION_LABEL_PATTERN,
+  getReleaseCommitSha,
+  getShortReleaseCommitSha,
+  getReleaseEnvironment,
+  getDeploymentVersionLabel,
+  getSentryRelease,
+  getPublicReleaseInfo,
+  getSentryTags,
+  logReleaseIdentityAtStartup,
+  isLikelySafePublicReleasePayload,
+};


### PR DESCRIPTION
## Summary

Consolidates all open launch backend work into one merge for production deploy:

- **#104 / #172** — Isolated HTTP integration test suite (`mongodb-memory-server`, 26 integration tests)
- **#105 / #171** — Release identity on `/api/health`, `/api/ready`, `/api/build-info`; Sentry release/env tags
- **#106 / #168** — Refund/return/dispute as-built audit (docs + non-invasive tests only; no payment logic changes)
- **#169** — Phase 1 immutable admin audit trail + `GET /admin/api/audit-events` (admin-only read)

## Fixes in this PR

- Resolved merge conflicts in `docs/backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md`, `package.json`, `app.js`
- Fixed `npm test` to use `--test-skip-pattern=integration` before test paths (CI/deploy compatible)

## Test plan

- [x] `npm test` — 314 pass
- [x] `npm run test:contract` — 20 pass
- [x] `npm run test:integration` — 26 pass

Supersedes open PRs #104, #105, #106. Admin audit #169 included (no separate PR).

## Post-merge

Manual EB deploy via `deploy-eb-production.yml` per PRODUCTION_RUNBOOK.

EOF