### PR TITLE
Fix service publication pipeline and public visibility contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies

--- a/controllers/privateListing.js
+++ b/controllers/privateListing.js
@@ -26,7 +26,7 @@ exports.getAllPrivateServicesForBusiness = async (req, res) => {
       return res.status(400).json({ success: false, message: 'Business ID is required' });
     }
 
-    const filters = { businessId: businessId, ownerId: req.user.id }; // Filter by businessId and ownerId
+    const filters = { businessId: businessId, ownerId: req.user._id };
 
     // Search filter
     if (search) {
@@ -44,7 +44,7 @@ exports.getAllPrivateServicesForBusiness = async (req, res) => {
     if (categorySlug) {
       const category = await ServiceCategory.findOne({ slug: categorySlug });
       if (category) {
-        filters['categories.categoryId'] = category._id;
+        filters.categoryId = category._id;
       } else {
         return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
       }
@@ -107,8 +107,9 @@ exports.getServiceBySlug = async (req, res) => {
     const { slug } = req.params;
 
     const service = await Service.findOne({ slug })
-      .populate('categories.categoryId', 'name')
-      .populate('ownerId', 'businessName');
+      .populate('categoryId', 'name')
+      .populate('subcategoryId', 'name')
+      .populate('ownerId', 'name');
 
     if (!service) {
       return res.status(404).json({ success: false, message: 'Service not found' });

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -378,12 +378,14 @@ exports.getServiceBySlug = async (req, res) => {
       listingId: service._id,
       listingType: 'service',
     })
-      .populate('userId', 'name profileImage'); // Adjust fields as needed
+      .populate('userId', 'name profileImage');
+
+    const serviceData = service.toObject();
 
     res.status(200).json({
       success: true,
       data: {
-        service,
+        service: toPublicListingDetail(serviceData, { listingType: 'service' }),
         reviews,
       },
     });

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -357,14 +357,23 @@ exports.getServiceBySlug = async (req, res) => {
     const { slug } = req.params;
 
     const service = await Service.findOne({ slug, isPublished: true })
-      .populate('categories.categoryId', 'name')
-      .populate('ownerId', 'businessName');
+      .populate('categoryId', 'name')
+      .populate('subcategoryId', 'name')
+      .populate('ownerId', 'name');
 
     if (!service) {
       return res.status(404).json({ success: false, message: 'Service not found' });
     }
 
-    // 👉 Fetch related reviews
+    const visibleBusiness = await Business.findOne({
+      _id: service.businessId,
+      isActive: true,
+    }).select('_id').lean();
+
+    if (!visibleBusiness) {
+      return res.status(404).json({ success: false, message: 'Service not found' });
+    }
+
     const reviews = await Review.find({
       listingId: service._id,
       listingType: 'service',
@@ -410,6 +419,13 @@ exports.getServiceById = async (req, res) => {
       });
 
     if (!service) {
+      return res.status(404).json({
+        success: false,
+        message: 'Service not found',
+      });
+    }
+
+    if (service.isPublished !== true) {
       return res.status(404).json({
         success: false,
         message: 'Service not found',

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -4,6 +4,15 @@ const Subscription = require('../models/Subscription');
 const SubscriptionPlan = require('../models/SubscriptionPlan');
 const PendingImage = require('../models/PendingImage');
 const deleteCloudinaryFile = require('../utils/deleteCloudinaryFile');
+const {
+  normalizeChildServices,
+  normalizeServicePayload,
+  validateChildServices,
+  validatePublishRequest,
+  getMinimumChildServicePrice,
+  formatOwnerServiceResponse,
+  formatValidationErrorResponse,
+} = require('../lib/service/serviceContract');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
@@ -35,62 +44,6 @@ const getOwnerChildServiceCount = async (ownerId, excludeServiceId = null) => {
   return services.reduce((sum, item) => (
     sum + (Array.isArray(item.services) ? item.services.length : 0)
   ), 0);
-};
-
-const parseDurationMinutes = (value) => {
-  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-
-    const numericValue = Number(trimmed);
-    if (Number.isFinite(numericValue) && numericValue > 0) {
-      return numericValue;
-    }
-
-    const matched = trimmed.match(/(\d+(?:\.\d+)?)/);
-    if (matched) {
-      const parsed = Number(matched[1]);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        return parsed;
-      }
-    }
-  }
-
-  return null;
-};
-
-const normalizeChildService = (item = {}) => {
-  const normalizedImages = Array.isArray(item.images)
-    ? item.images.filter(Boolean)
-    : [];
-  const fallbackImage = item.image || item.imagePath || item.path || normalizedImages[0] || '';
-  const durationMinutes = parseDurationMinutes(item.durationMinutes ?? item.duration);
-  const price = Number(item.price);
-
-  return {
-    name: item.name ? String(item.name).trim() : '',
-    description: item.description ? String(item.description).trim() : '',
-    image: fallbackImage,
-    images: normalizedImages.length ? normalizedImages : (fallbackImage ? [fallbackImage] : []),
-    durationMinutes,
-    price: Number.isFinite(price) && price >= 0 ? price : 0
-  };
-};
-
-const normalizeChildServices = (childServices = []) => {
-  return childServices.map(normalizeChildService);
-};
-
-const getMinimumChildServicePrice = (childServices = [], fallbackPrice = 0) => {
-  const prices = childServices
-    .map((item) => Number(item.price))
-    .filter((price) => Number.isFinite(price) && price >= 0);
-
-  return prices.length > 0 ? Math.min(...prices) : fallbackPrice;
 };
 
 // Create parent service with minimal details
@@ -221,27 +174,46 @@ exports.createService = async (req, res) => {
       subcategoryId,
       businessId,
       bookingToolLink,
-      services,
       coverImage,
       images,
       businessHours,
       location,
-      isPublished,
     } = req.body;
 
     const userId = req.user._id;
+    const payload = normalizeServicePayload(req.body);
+    const { title, description, isPublished, normalizedServices, parentPrice, parentDuration } = payload;
 
-    // 🛡️ Step 1: Verify ownership
     const business = await Business.findOne({ _id: businessId, owner: userId });
     if (!business)
       return res.status(403).json({ error: 'You do not own this business.' });
 
-    //   return res.status(400).json({ error: 'Business is not approved yet.' });
+    const existingParentService = await Service.findOne({
+      businessId,
+      ownerId: userId,
+    }).select('_id title isPublished');
 
-    // if (business.listingType !== 'service')
-    //   return res.status(400).json({ error: 'This business is not allowed to list services.' });
+    if (existingParentService) {
+      return res.status(409).json({
+        success: false,
+        error: 'A service listing already exists for this business. Use PUT /api/service/:id to update or publish it.',
+        existingServiceId: existingParentService._id,
+        fieldErrors: {
+          businessId: 'Service listing already exists for this business.',
+        },
+      });
+    }
 
-    // 📅 Step 2: Subscription check
+    const childValidation = validateChildServices(normalizedServices);
+    if (!childValidation.ok) {
+      return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
+    }
+
+    const publishValidation = validatePublishRequest({ isPublished, normalizedServices });
+    if (!publishValidation.ok) {
+      return res.status(400).json(formatValidationErrorResponse(publishValidation.fieldErrors));
+    }
+
     const subscription = await Subscription.findOne({
       userId,
       status: 'active',
@@ -254,17 +226,6 @@ exports.createService = async (req, res) => {
     const subscriptionPlan = await SubscriptionPlan.findById(subscription.subscriptionPlanId);
     const serviceLimit = subscriptionPlan?.limits?.serviceListings || 0;
     const galleryImageLimit = getGalleryImageLimit(subscriptionPlan);
-
-    // ------------------------
-    // Step 3: Determine default parent price from child services
-    // ------------------------
-    const normalizedServices = Array.isArray(services) ? normalizeChildServices(services) : [];
-    const invalidDurationService = normalizedServices.find((item) => !item.durationMinutes);
-    if (invalidDurationService) {
-      return res.status(400).json({
-        error: 'Each child service must include a valid duration or durationMinutes value.'
-      });
-    }
 
     const currentChildServiceCount = await getOwnerChildServiceCount(userId);
     if (currentChildServiceCount + normalizedServices.length > serviceLimit) {
@@ -279,16 +240,11 @@ exports.createService = async (req, res) => {
       });
     }
 
-    const defaultPrice = getMinimumChildServicePrice(normalizedServices, 0);
-
-    // ------------------------
-    // Step 4: Save service with defaults
-    // ------------------------
     const service = new Service({
-      title: 'Service',
-      description: '',
-      price: defaultPrice, // <-- Set parent price as minimum of children
-      duration: '',
+      title,
+      description,
+      price: parentPrice,
+      duration: parentDuration,
 
       categoryId,
       subcategoryId,
@@ -297,7 +253,7 @@ exports.createService = async (req, res) => {
       services: normalizedServices,
       coverImage: coverImage || '',
       images: images || [],
-      isPublished: isPublished || false,
+      isPublished,
       businessHours: businessHours || [],
       location: location?.address || '',
 
@@ -319,7 +275,6 @@ exports.createService = async (req, res) => {
 
     await service.save();
 
-    // Clean up pending images
     const usedImages = [coverImage, ...(images || [])].filter(Boolean);
     if (usedImages.length > 0) {
       await PendingImage.deleteMany({ url: { $in: usedImages } });
@@ -328,16 +283,14 @@ exports.createService = async (req, res) => {
     await session.commitTransaction();
     session.endSession();
 
-    res.status(201).json({
-      message: 'Service created successfully.',
-      service,
-    });
+    return res.status(201).json(
+      formatOwnerServiceResponse(service, business, 'Service created successfully.')
+    );
 
   } catch (err) {
     await session.abortTransaction();
     session.endSession();
 
-    // Clean up uploaded images on error
     const usedImages = [req.body.coverImage, ...(req.body.images || [])].filter(Boolean);
     for (const image of usedImages) {
       await deleteCloudinaryFile(image).catch(() => { });
@@ -590,11 +543,9 @@ exports.addChildServices = async (req, res) => {
 
     // Add new child services to existing ones
     const normalizedChildServices = normalizeChildServices(childServices);
-    const invalidDurationService = normalizedChildServices.find((item) => !item.durationMinutes);
-    if (invalidDurationService) {
-      return res.status(400).json({
-        error: 'Each child service must include a valid duration or durationMinutes value.'
-      });
+    const childValidation = validateChildServices(normalizedChildServices);
+    if (!childValidation.ok) {
+      return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
     }
 
     const currentChildServiceCount = await getOwnerChildServiceCount(userId);
@@ -637,10 +588,11 @@ exports.addChildServices = async (req, res) => {
       { new: true }
     );
 
-    res.status(200).json({
-      message: 'Child services added successfully.',
-      service: updatedService
-    });
+    const business = await Business.findById(parentService.businessId).select('isActive isApproved owner');
+
+    return res.status(200).json(
+      formatOwnerServiceResponse(updatedService, business, 'Child services added successfully.')
+    );
 
   } catch (err) {
     console.error('Failed to add child services:', err.message);
@@ -672,8 +624,24 @@ exports.getMyServices = async (req, res) => {
 
     const total = await Service.countDocuments(filters);
 
+    const businessIds = [...new Set(services.map((item) => String(item.businessId)).filter(Boolean))];
+    const businesses = await Business.find({ _id: { $in: businessIds } })
+      .select('_id isActive isApproved owner')
+      .lean();
+    const businessById = new Map(businesses.map((item) => [String(item._id), item]));
+
+    const servicesWithPublication = services.map((item) => {
+      const plainService = item.toObject();
+      const business = businessById.get(String(item.businessId));
+      return formatOwnerServiceResponse(plainService, business).data;
+    });
+
     res.status(200).json({
-      services,
+      services: servicesWithPublication.map((entry) => entry.service),
+      publicationByServiceId: Object.fromEntries(
+        servicesWithPublication.map((entry) => [String(entry.service._id), entry.publication])
+      ),
+      data: servicesWithPublication,
       total,
       page,
       totalPages: Math.ceil(total / limit)
@@ -719,6 +687,9 @@ exports.updateService = async (req, res) => {
       return res.status(404).json({ message: 'Service not found' });
     }
 
+    const business = await Business.findOne({ _id: service.businessId, owner: userId })
+      .select('_id isActive isApproved owner');
+
     const subscription = await Subscription.findOne({
       userId,
       status: 'active',
@@ -733,7 +704,6 @@ exports.updateService = async (req, res) => {
     const serviceLimit = subscriptionPlan?.limits?.serviceListings || 0;
     const galleryImageLimit = getGalleryImageLimit(subscriptionPlan);
 
-    // Handle image updates
     if (req.body.coverImage && req.body.coverImage !== service.coverImage) {
       await deleteCloudinaryFile(service.coverImage).catch(() => { });
     }
@@ -745,40 +715,59 @@ exports.updateService = async (req, res) => {
       }
     }
 
-    // Update allowed fields
+    let nextServices = service.services;
+    if (req.body.services !== undefined) {
+      const payload = normalizeServicePayload({
+        ...req.body,
+        services: req.body.services,
+      });
+      const childValidation = validateChildServices(payload.normalizedServices);
+      if (!childValidation.ok) {
+        return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
+      }
+
+      const otherChildServiceCount = await getOwnerChildServiceCount(userId, service._id);
+      if (otherChildServiceCount + payload.normalizedServices.length > serviceLimit) {
+        return res.status(403).json({
+          message: `Service listing limit reached. You can add only ${Math.max(serviceLimit - otherChildServiceCount, 0)} more child services.`,
+        });
+      }
+
+      nextServices = payload.normalizedServices;
+      service.services = nextServices;
+      service.price = getMinimumChildServicePrice(nextServices, service.price);
+      service.duration = '';
+    }
+
     const updatableFields = [
-      'title', 'description', 'price', 'duration', 'services', 'isPublished',
-      'coverImage', 'images', 'features', 'amenities', 'businessHours',
+      'title', 'description', 'coverImage', 'images', 'features', 'amenities', 'businessHours',
       'bookingToolLink', 'maxBookingsPerSlot', 'location', 'contact'
     ];
 
     for (const field of updatableFields) {
       if (req.body[field] !== undefined) {
-        if (field === 'services') {
-          const normalizedServices = normalizeChildServices(req.body.services);
-          const invalidDurationService = normalizedServices.find((item) => !item.durationMinutes);
-
-          if (invalidDurationService) {
-            return res.status(400).json({
-              message: 'Each child service must include a valid duration or durationMinutes value.'
-            });
-          }
-
-          const otherChildServiceCount = await getOwnerChildServiceCount(userId, service._id);
-          if (otherChildServiceCount + normalizedServices.length > serviceLimit) {
-            return res.status(403).json({
-              message: `Service listing limit reached. You can add only ${Math.max(serviceLimit - otherChildServiceCount, 0)} more child services.`,
-            });
-          }
-
-          service.services = normalizedServices;
-          service.price = getMinimumChildServicePrice(normalizedServices, service.price);
-          service.duration = '';
-          continue;
-        }
-
         service[field] = req.body[field];
       }
+    }
+
+    if (req.body.title !== undefined) {
+      service.title = String(req.body.title).trim() || 'Service';
+    }
+
+    if (req.body.description !== undefined) {
+      service.description = String(req.body.description).trim();
+    }
+
+    if (req.body.isPublished !== undefined) {
+      service.isPublished = req.body.isPublished === true || req.body.isPublished === 'true';
+    }
+
+    const publishValidation = validatePublishRequest({
+      isPublished: service.isPublished,
+      normalizedServices: nextServices,
+    });
+    if (!publishValidation.ok) {
+      return res.status(400).json(formatValidationErrorResponse(publishValidation.fieldErrors));
     }
 
     const nextGalleryImages = req.body.images !== undefined ? req.body.images : service.images;
@@ -788,7 +777,6 @@ exports.updateService = async (req, res) => {
       });
     }
 
-    // Handle location as string
     if (req.body.location?.address) {
       service.location = req.body.location.address;
       if (service.contact) {
@@ -798,10 +786,9 @@ exports.updateService = async (req, res) => {
 
     await service.save();
 
-    res.status(200).json({
-      message: 'Service updated successfully',
-      service
-    });
+    return res.status(200).json(
+      formatOwnerServiceResponse(service, business, 'Service updated successfully')
+    );
 
   } catch (error) {
     console.error('Service update error:', error);
@@ -828,7 +815,12 @@ exports.getServiceById = async (req, res) => {
       });
     }
 
-    res.status(200).json({ service });
+    const business = await Business.findOne({ _id: service.businessId, owner: userId })
+      .select('_id isActive isApproved owner');
+
+    return res.status(200).json(
+      formatOwnerServiceResponse(service, business)
+    );
 
   } catch (err) {
     console.error('Failed to fetch service:', err.message);
@@ -867,6 +859,12 @@ exports.getBusinessServiceById = async (req, res) => {
     }).select('_id').lean();
 
     if (!visibleBusiness) {
+      return res.status(404).json({
+        message: 'Business service not found.'
+      });
+    }
+
+    if (service.isPublished !== true) {
       return res.status(404).json({
         message: 'Business service not found.'
       });

--- a/docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md
+++ b/docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md
@@ -1,0 +1,172 @@
+# Service Publication & Public Visibility — Backend Proof
+
+**Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
+**Branch:** `fix/backend-service-publication-visibility-contract`  
+**Cross-repo:** [Digital-Builders-757/mosaic-biz-frontend-launch#185](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/185)  
+**Evidence date:** 2026-06-22  
+
+No secrets, JWTs, tokens, credentials, or PII in this document.
+
+---
+
+## Executive verdict
+
+**Root cause:** Multi-factor contract and visibility bug — not a single missing flag.
+
+1. `createService` ignored vendor-supplied parent `title`/`description` and did not normalize frontend `{ name }`-only child payloads.
+2. `isPublished` defaults to `false`, so drafts never appear on `GET /api/services/list` until published.
+3. `GET /api/public/services/:id` and `GET /api/service/business-service/:id` omitted the `isPublished` gate used by list/slug/search.
+
+**Fix:** Canonical parent+child DTO in `lib/service/serviceContract.js`, aligned create/update validation, publication metadata on owner responses, consistent public visibility gates.
+
+---
+
+## Product contract (locked)
+
+**Model A:** One parent `Service` document per business with embedded bookable `services[]` children.
+
+---
+
+## Canonical service DTO
+
+### Parent fields (persisted)
+
+| Field | Source |
+|-------|--------|
+| `title`, `description` | Request body |
+| `categoryId`, `subcategoryId`, `businessId` | Request body |
+| `isPublished` | Request body (default `false`) |
+| `price` | Derived `min(services[].price)` |
+| `duration` | `''` when children exist |
+| `slug` | Auto from `title` |
+
+### Child fields (`services[]`)
+
+| Field | Required |
+|-------|----------|
+| `name` | yes |
+| `price` | yes (`>= 0`) |
+| `durationMinutes` | yes (or parseable `duration` alias) |
+
+### Frontend compatibility
+
+When exactly one child has only `name` and top-level `price` + `duration`/`durationMinutes` are present, values backfill that child before validation.
+
+### Owner publication block (additive)
+
+```json
+{
+  "success": true,
+  "data": {
+    "service": {},
+    "publication": {
+      "isPublished": true,
+      "isPubliclyVisible": true,
+      "visibilityReason": null
+    }
+  }
+}
+```
+
+Stable `visibilityReason` codes: `SERVICE_UNPUBLISHED`, `BUSINESS_INACTIVE`, `BUSINESS_NOT_PUBLICLY_ELIGIBLE`, `INVALID_SERVICE_DATA`.
+
+---
+
+## Before / after payload example
+
+**Frontend payload:**
+
+```json
+{
+  "title": "Hair Styling",
+  "description": "Full salon menu",
+  "price": 45,
+  "duration": "60",
+  "services": [{ "name": "Basic Cut" }]
+}
+```
+
+**Before:** `title: "Service"`, empty description, `isPublished: false`, often 400 on missing child duration.
+
+**After:** Parent title/description preserved; child gets `price: 45`, `durationMinutes: 60`; publish via `PUT /api/service/:id`.
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `lib/service/serviceContract.js` | New DTO + publication helpers |
+| `controllers/serviceController.js` | Create/update/read contract + duplicate guard |
+| `controllers/publicListing.js` | Public ID/slug visibility gates |
+| `controllers/privateListing.js` | `ownerId` + `categoryId` filter fixes |
+| `tests/service/service-payload-contract.test.js` | Unit tests |
+| `tests/service/service-publication-visibility.test.js` | Controller visibility tests |
+| `tests/integration/service-publication.integration.test.js` | End-to-end proof |
+| `tests/integration/helpers/factories.js` | Service seed helpers |
+| `scripts/service-publication-smoke.ps1` | Runtime smoke script |
+
+---
+
+## Commands run
+
+| Command | Result |
+|---------|--------|
+| `npm test` | **302 pass**, 0 fail |
+| `npm run test:integration` | **28 pass**, 0 fail |
+| `node --test tests/service/service-*.test.js` | **13 pass**, 0 fail |
+| `node --check` on modified controllers + contract lib | **PASS** |
+
+---
+
+## Integration proof (in-memory Mongo)
+
+`tests/integration/service-publication.integration.test.js` proves:
+
+1. Draft created with frontend-shaped payload → private list includes service, public list excludes it, public detail 404.
+2. `PUT` publish same `_id` → `GET /api/services/list` and `GET /api/public/services/:id` both return the service.
+3. Unpublish → public list and detail 404.
+4. Republish → still one document (`Service.countDocuments === 1`).
+5. Retry `POST /api/service/` → **409** with `existingServiceId`.
+
+---
+
+## Runtime smoke (live API)
+
+Script: `scripts/service-publication-smoke.ps1`
+
+Requires env (not configured in local session):
+
+- `SMOKE_TEST_VENDOR_TOKEN`
+- `SMOKE_TEST_BUSINESS_ID`
+- `SMOKE_TEST_SERVICE_CATEGORY_ID`
+- `SMOKE_TEST_SERVICE_SUBCATEGORY_ID`
+
+**Status:** BLOCKED — env-owned credentials not provided in this session. Integration test provides equivalent proof locally.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Clients relied on unpublished public ID reads | Matches visibility matrix; intentional |
+| Duplicate POST now returns 409 | Document: use PUT to publish/update |
+| Additive response shape | Legacy `service`/`message` keys preserved |
+
+## Rollback
+
+Revert branch commits. No schema migration required.
+
+## Not tested
+
+- Live production API with disposable vendor credentials
+- Frontend E2E in mosaic-biz-frontend-launch
+- S3/Cloudinary upload during service create
+- Booking/review flows after visibility fix
+
+---
+
+## PR
+
+Open after commit/push: `fix/backend-service-publication-visibility-contract` → `main`.

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -1,0 +1,265 @@
+const parseDurationMinutes = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    const numericValue = Number(trimmed);
+    if (Number.isFinite(numericValue) && numericValue > 0) {
+      return numericValue;
+    }
+
+    const matched = trimmed.match(/(\d+(?:\.\d+)?)/);
+    if (matched) {
+      const parsed = Number(matched[1]);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const parsePrice = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const price = Number(value);
+  if (!Number.isFinite(price) || price < 0) {
+    return null;
+  }
+
+  return price;
+};
+
+const childMissingPrice = (item) =>
+  item.price === undefined || item.price === null || item.price === '';
+
+const childMissingDuration = (item) =>
+  item.durationMinutes === undefined
+  || item.durationMinutes === null
+  || item.durationMinutes === ''
+  || (item.duration === undefined || item.duration === null || item.duration === '');
+
+const isNameOnlyChild = (item) => {
+  if (!item || !item.name || !String(item.name).trim()) {
+    return false;
+  }
+
+  return childMissingPrice(item) && childMissingDuration(item);
+};
+
+const applyTopLevelBackfill = (body, childServices) => {
+  if (!Array.isArray(childServices) || childServices.length !== 1) {
+    return childServices;
+  }
+
+  if (!isNameOnlyChild(childServices[0])) {
+    return childServices;
+  }
+
+  const topLevelPrice = parsePrice(body.price);
+  const topLevelDuration = parseDurationMinutes(body.durationMinutes ?? body.duration);
+
+  if (topLevelPrice === null || topLevelDuration === null) {
+    return childServices;
+  }
+
+  return [{
+    ...childServices[0],
+    price: topLevelPrice,
+    durationMinutes: topLevelDuration,
+    duration: body.duration ?? `${topLevelDuration}`,
+  }];
+};
+
+const normalizeChildService = (item = {}) => {
+  const normalizedImages = Array.isArray(item.images)
+    ? item.images.filter(Boolean)
+    : [];
+  const fallbackImage = item.image || item.imagePath || item.path || normalizedImages[0] || '';
+  const durationMinutes = parseDurationMinutes(item.durationMinutes ?? item.duration);
+  const price = parsePrice(item.price);
+
+  return {
+    name: item.name ? String(item.name).trim() : '',
+    description: item.description ? String(item.description).trim() : '',
+    image: fallbackImage,
+    images: normalizedImages.length ? normalizedImages : (fallbackImage ? [fallbackImage] : []),
+    durationMinutes,
+    price,
+  };
+};
+
+const normalizeChildServices = (childServices = []) => {
+  return childServices.map(normalizeChildService);
+};
+
+const getMinimumChildServicePrice = (childServices = [], fallbackPrice = 0) => {
+  const prices = childServices
+    .map((item) => Number(item.price))
+    .filter((price) => Number.isFinite(price) && price >= 0);
+
+  return prices.length > 0 ? Math.min(...prices) : fallbackPrice;
+};
+
+const normalizeServicePayload = (body = {}) => {
+  const backfilledChildren = applyTopLevelBackfill(body, Array.isArray(body.services) ? body.services : []);
+  const normalizedServices = normalizeChildServices(backfilledChildren);
+
+  return {
+    title: body.title ? String(body.title).trim() : 'Service',
+    description: body.description ? String(body.description).trim() : '',
+    isPublished: body.isPublished === true || body.isPublished === 'true',
+    normalizedServices,
+    parentPrice: getMinimumChildServicePrice(normalizedServices, 0),
+    parentDuration: normalizedServices.length > 0 ? '' : (body.duration ? String(body.duration).trim() : ''),
+  };
+};
+
+const validateChildServices = (children = []) => {
+  const fieldErrors = {};
+
+  if (!Array.isArray(children) || children.length === 0) {
+    fieldErrors.services = 'At least one child service is required.';
+    return { ok: false, fieldErrors };
+  }
+
+  children.forEach((item, index) => {
+    if (!item.name) {
+      fieldErrors[`services[${index}].name`] = 'Child service name is required.';
+    }
+
+    if (item.price === null || item.price === undefined) {
+      fieldErrors[`services[${index}].price`] = 'Child service price is required and must be a number >= 0.';
+    }
+
+    if (!item.durationMinutes) {
+      fieldErrors[`services[${index}].durationMinutes`] =
+        'Child service duration is required. Provide durationMinutes or a parseable duration value.';
+    }
+  });
+
+  return {
+    ok: Object.keys(fieldErrors).length === 0,
+    fieldErrors,
+  };
+};
+
+const deriveParentPricing = (children = []) => ({
+  price: getMinimumChildServicePrice(children, 0),
+  duration: children.length > 0 ? '' : '',
+});
+
+const evaluateServicePublication = ({ service, business }) => {
+  const isPublished = Boolean(service?.isPublished);
+  const children = Array.isArray(service?.services) ? service.services : [];
+  const childValidation = validateChildServices(children);
+
+  if (!isPublished) {
+    return {
+      isPublished,
+      isPubliclyVisible: false,
+      visibilityReason: 'SERVICE_UNPUBLISHED',
+    };
+  }
+
+  if (!childValidation.ok) {
+    return {
+      isPublished,
+      isPubliclyVisible: false,
+      visibilityReason: 'INVALID_SERVICE_DATA',
+    };
+  }
+
+  if (!business) {
+    return {
+      isPublished,
+      isPubliclyVisible: false,
+      visibilityReason: 'BUSINESS_NOT_PUBLICLY_ELIGIBLE',
+    };
+  }
+
+  if (business.isActive !== true) {
+    return {
+      isPublished,
+      isPubliclyVisible: false,
+      visibilityReason: 'BUSINESS_INACTIVE',
+    };
+  }
+
+  return {
+    isPublished,
+    isPubliclyVisible: true,
+    visibilityReason: null,
+  };
+};
+
+const validatePublishRequest = ({ isPublished, normalizedServices }) => {
+  if (!isPublished) {
+    return { ok: true, fieldErrors: {} };
+  }
+
+  const validation = validateChildServices(normalizedServices);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      fieldErrors: {
+        ...validation.fieldErrors,
+        isPublished: 'Cannot publish a service without valid child service data.',
+      },
+    };
+  }
+
+  return { ok: true, fieldErrors: {} };
+};
+
+const toPlainService = (service) => {
+  if (!service) return null;
+  if (typeof service.toObject === 'function') {
+    return service.toObject();
+  }
+  return service;
+};
+
+const formatOwnerServiceResponse = (service, business, message) => {
+  const plainService = toPlainService(service);
+  const publication = evaluateServicePublication({ service: plainService, business });
+
+  return {
+    success: true,
+    message,
+    service: plainService,
+    data: {
+      service: plainService,
+      publication,
+    },
+  };
+};
+
+const formatValidationErrorResponse = (fieldErrors, message = 'Validation failed') => ({
+  success: false,
+  message,
+  error: message,
+  fieldErrors,
+});
+
+module.exports = {
+  parseDurationMinutes,
+  parsePrice,
+  normalizeChildService,
+  normalizeChildServices,
+  normalizeServicePayload,
+  validateChildServices,
+  validatePublishRequest,
+  deriveParentPricing,
+  getMinimumChildServicePrice,
+  evaluateServicePublication,
+  formatOwnerServiceResponse,
+  formatValidationErrorResponse,
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node scripts/run-unit-tests.js",
     "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
-    "test:integration": "node --test --test-concurrency=1 tests/integration/**/*.integration.test.js",
+    "test:integration": "node scripts/run-integration-tests.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
     "dev": "nodemon index.js",
     "start": "node index.js"

--- a/scripts/run-integration-tests.js
+++ b/scripts/run-integration-tests.js
@@ -1,0 +1,36 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function collectIntegrationTestFiles(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      collectIntegrationTestFiles(fullPath, files);
+      continue;
+    }
+
+    if (entry.name.endsWith('.integration.test.js')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const integrationRoot = path.join(__dirname, '..', 'tests', 'integration');
+const files = collectIntegrationTestFiles(integrationRoot);
+
+if (files.length === 0) {
+  console.error('No integration test files found under tests/integration/');
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  ['--test', '--test-concurrency=1', ...files],
+  { stdio: 'inherit' }
+);
+
+process.exit(result.status ?? 1);

--- a/scripts/service-publication-smoke.ps1
+++ b/scripts/service-publication-smoke.ps1
@@ -1,0 +1,158 @@
+# Service publication visibility smoke - sanitized output only.
+# Requires session env vars (never commit values):
+#   SMOKE_TEST_VENDOR_TOKEN
+#   SMOKE_TEST_BUSINESS_ID
+#   SMOKE_TEST_SERVICE_CATEGORY_ID
+#   SMOKE_TEST_SERVICE_SUBCATEGORY_ID
+# Optional:
+#   API_BASE_URL (default https://api.mosaicbizhub.com)
+
+param(
+    [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "https://api.mosaicbizhub.com" }),
+    [string]$VendorToken = $env:SMOKE_TEST_VENDOR_TOKEN,
+    [string]$BusinessId = $env:SMOKE_TEST_BUSINESS_ID,
+    [string]$CategoryId = $env:SMOKE_TEST_SERVICE_CATEGORY_ID,
+    [string]$SubcategoryId = $env:SMOKE_TEST_SERVICE_SUBCATEGORY_ID
+)
+
+$ErrorActionPreference = 'Stop'
+$Base = $ApiBaseUrl.TrimEnd('/')
+$Results = @()
+
+function Add-Result($route, $action, $expected, $actual, $statusCode, $severity) {
+    $script:Results += [pscustomobject]@{
+        route      = $route
+        action     = $action
+        expected   = $expected
+        actual     = $actual
+        statusCode = $statusCode
+        severity   = $severity
+    }
+}
+
+function Invoke-Api($Method, $Path, $Token = $null, $Body = $null) {
+    $headers = @{ Accept = 'application/json' }
+    if ($Token) { $headers.Authorization = "Bearer $Token" }
+    try {
+        $params = @{
+            Uri             = "$Base$Path"
+            Method          = $Method
+            Headers         = $headers
+            UseBasicParsing = $true
+            ErrorAction     = 'Stop'
+        }
+        if ($Body) {
+            $params.Body = ($Body | ConvertTo-Json -Compress)
+            $params.ContentType = 'application/json'
+        }
+        $r = Invoke-WebRequest @params
+        $parsed = $null
+        if ($r.Content) {
+            try { $parsed = $r.Content | ConvertFrom-Json } catch { $parsed = $r.Content }
+        }
+        return @{ statusCode = [int]$r.StatusCode; body = $parsed; error = $null }
+    } catch {
+        if ($_.Exception.Response) {
+            $resp = $_.Exception.Response
+            $reader = New-Object System.IO.StreamReader($resp.GetResponseStream())
+            $content = $reader.ReadToEnd()
+            $reader.Close()
+            $parsed = $null
+            if ($content) {
+                try { $parsed = $content | ConvertFrom-Json } catch { $parsed = $content }
+            }
+            return @{
+                statusCode = [int]$resp.StatusCode.value__
+                body       = $parsed
+                error      = $null
+            }
+        }
+        return @{ statusCode = 0; body = $null; error = $_.Exception.Message }
+    }
+}
+
+Write-Host "Service publication smoke against $Base"
+
+if (-not $VendorToken -or -not $BusinessId -or -not $CategoryId -or -not $SubcategoryId) {
+    Add-Result 'setup' 'env-check' 'required smoke env vars present' 'BLOCKED - missing vendor/business/category env' 0 'P0-blocker-env'
+    $Results | Format-Table -AutoSize
+    exit 2
+}
+
+$health = Invoke-Api 'GET' '/api/health'
+Add-Result '/api/health' 'liveness' '200' $(if ($health.statusCode -eq 200) { 'PASS' } else { 'FAIL' }) $health.statusCode 'info'
+
+$ready = Invoke-Api 'GET' '/api/ready'
+Add-Result '/api/ready' 'readiness' '200' $(if ($ready.statusCode -eq 200) { 'PASS' } else { 'FAIL' }) $ready.statusCode 'info'
+
+$createBody = @{
+    title          = 'Smoke Service Listing'
+    description    = 'Sanitized smoke draft service'
+    price          = 45
+    duration       = '60'
+    businessId     = $BusinessId
+    categoryId     = $CategoryId
+    subcategoryId  = $SubcategoryId
+    isPublished    = $false
+    services       = @(@{ name = 'Smoke Offering' })
+}
+
+$create = Invoke-Api 'POST' '/api/service/' $VendorToken $createBody
+$serviceId = $null
+if ($create.statusCode -eq 201 -and $create.body.data.service._id) {
+    $serviceId = [string]$create.body.data.service._id
+    Add-Result 'POST /api/service/' 'create-draft' '201 + service id' 'PASS' $create.statusCode 'info'
+} elseif ($create.statusCode -eq 409 -and $create.body.existingServiceId) {
+    $serviceId = [string]$create.body.existingServiceId
+    Add-Result 'POST /api/service/' 'create-draft' '201 or existing id' 'PASS-existing' $create.statusCode 'info'
+} else {
+    Add-Result 'POST /api/service/' 'create-draft' '201 + service id' 'FAIL' $create.statusCode 'P0'
+}
+
+if ($serviceId) {
+    $private = Invoke-Api 'GET' "/api/private/services/list?businessId=$BusinessId" $VendorToken
+    $privateHas = $false
+    if ($private.body.data) {
+        foreach ($item in $private.body.data) {
+            if ([string]$item._id -eq $serviceId) { $privateHas = $true; break }
+        }
+    }
+    Add-Result 'GET /api/private/services/list' 'draft-visible-private' 'contains service id' $(if ($privateHas) { 'PASS' } else { 'FAIL' }) $private.statusCode 'P0'
+
+    $publicListDraft = Invoke-Api 'GET' '/api/services/list'
+    $publicHasDraft = $false
+    if ($publicListDraft.body.data) {
+        foreach ($item in $publicListDraft.body.data) {
+            $id = if ($item.id) { [string]$item.id } else { [string]$item._id }
+            if ($id -eq $serviceId) { $publicHasDraft = $true; break }
+        }
+    }
+    Add-Result 'GET /api/services/list' 'draft-hidden-public' 'excludes service id' $(if (-not $publicHasDraft) { 'PASS' } else { 'FAIL' }) $publicListDraft.statusCode 'P0'
+
+    $publish = Invoke-Api 'PUT' "/api/service/$serviceId" $VendorToken @{ isPublished = $true }
+    Add-Result 'PUT /api/service/:id' 'publish' '200 + isPubliclyVisible=true' $(if ($publish.statusCode -eq 200 -and $publish.body.data.publication.isPubliclyVisible) { 'PASS' } else { 'FAIL' }) $publish.statusCode 'P0'
+
+    $publicList = Invoke-Api 'GET' '/api/services/list'
+    $publicHas = $false
+    if ($publicList.body.data) {
+        foreach ($item in $publicList.body.data) {
+            $id = if ($item.id) { [string]$item.id } else { [string]$item._id }
+            if ($id -eq $serviceId) { $publicHas = $true; break }
+        }
+    }
+    Add-Result 'GET /api/services/list' 'published-visible-public' 'contains service id' $(if ($publicHas) { 'PASS' } else { 'FAIL' }) $publicList.statusCode 'P0'
+
+    $publicDetail = Invoke-Api 'GET' "/api/public/services/$serviceId"
+    Add-Result 'GET /api/public/services/:id' 'published-detail' '200' $(if ($publicDetail.statusCode -eq 200) { 'PASS' } else { 'FAIL' }) $publicDetail.statusCode 'P0'
+
+    $unpublish = Invoke-Api 'PUT' "/api/service/$serviceId" $VendorToken @{ isPublished = $false }
+    Add-Result 'PUT /api/service/:id' 'unpublish' '200' $(if ($unpublish.statusCode -eq 200) { 'PASS' } else { 'FAIL' }) $unpublish.statusCode 'info'
+
+    $publicDetailHidden = Invoke-Api 'GET' "/api/public/services/$serviceId"
+    Add-Result 'GET /api/public/services/:id' 'unpublished-detail-hidden' '404' $(if ($publicDetailHidden.statusCode -eq 404) { 'PASS' } else { 'FAIL' }) $publicDetailHidden.statusCode 'info'
+}
+
+$Results | Format-Table -AutoSize
+$failed = @($Results | Where-Object { $_.actual -like 'FAIL*' -and $_.severity -eq 'P0' })
+if ($failed.Count -gt 0) { exit 1 }
+exit 0

--- a/tests/integration/helpers/factories.js
+++ b/tests/integration/helpers/factories.js
@@ -3,6 +3,9 @@ const mongoose = require('mongoose');
 const User = require('../../../models/User');
 const Business = require('../../../models/Business');
 const Product = require('../../../models/Product');
+const Service = require('../../../models/Service');
+const ServiceCategory = require('../../../models/ServiceCategory');
+const ServiceSubcategory = require('../../../models/ServiceSubcategory');
 const Subscription = require('../../../models/Subscription');
 const SubscriptionPlan = require('../../../models/SubscriptionPlan');
 const VendorOnboarding = require('../../../models/VendorOnboardingStage1');
@@ -142,6 +145,25 @@ async function seedApprovedBusiness(ownerUser, overrides = {}) {
   });
 }
 
+async function seedServiceCategories() {
+  const category = await ServiceCategory.create({
+    name: `Integration Service Category ${Date.now()}`,
+  });
+  const subcategory = await ServiceSubcategory.create({
+    name: `Integration Service Subcategory ${Date.now()}`,
+    category: category._id,
+  });
+
+  return { category, subcategory };
+}
+
+async function seedServiceBusiness(ownerUser, overrides = {}) {
+  return seedApprovedBusiness(ownerUser, {
+    listingType: 'service',
+    ...overrides,
+  });
+}
+
 async function seedPublishedProduct(business, ownerUser) {
   return Product.create({
     title: 'Integration Test Product',
@@ -180,6 +202,8 @@ module.exports = {
   login,
   createAdminDirect,
   seedApprovedBusiness,
+  seedServiceBusiness,
+  seedServiceCategories,
   seedPublishedProduct,
   seedVendorOnboarding,
   uniqueEmail,

--- a/tests/integration/service-publication.integration.test.js
+++ b/tests/integration/service-publication.integration.test.js
@@ -1,0 +1,138 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedServiceBusiness,
+  seedServiceCategories,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Service = require('../../models/Service');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+const canonicalChildPayload = {
+  title: 'Integration Hair Styling',
+  description: 'Full salon menu for integration proof',
+  price: 45,
+  duration: '60',
+  services: [{ name: 'Basic Cut' }],
+};
+
+test('service publication flow: draft private, publish public list + detail, unpublish hides public reads', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user);
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const createRes = await agent.post('/api/service/').send({
+    ...canonicalChildPayload,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: false,
+  });
+
+  assert.equal(createRes.status, 201);
+  assert.equal(createRes.body.data.publication.isPublished, false);
+  assert.equal(createRes.body.data.publication.isPubliclyVisible, false);
+  assert.equal(createRes.body.data.service.title, 'Integration Hair Styling');
+  assert.equal(createRes.body.data.service.services[0].price, 45);
+  assert.equal(createRes.body.data.service.services[0].durationMinutes, 60);
+
+  const serviceId = String(createRes.body.data.service._id);
+
+  const privateList = await agent.get('/api/private/services/list').query({
+    businessId: String(business._id),
+  });
+  assert.equal(privateList.status, 200, JSON.stringify(privateList.body));
+  assert.ok(privateList.body.data.some((entry) => String(entry._id || entry.id) === serviceId));
+
+  const publicListDraft = await agent.get('/api/services/list');
+  assert.equal(publicListDraft.status, 200);
+  assert.ok(!publicListDraft.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+  const publicDetailDraft = await agent.get(`/api/public/services/${serviceId}`);
+  assert.equal(publicDetailDraft.status, 404);
+
+  const publishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: true });
+  assert.equal(publishRes.status, 200);
+  assert.equal(String(publishRes.body.data.service._id), serviceId);
+  assert.equal(publishRes.body.data.publication.isPublished, true);
+  assert.equal(publishRes.body.data.publication.isPubliclyVisible, true);
+
+  const publicListPublished = await agent.get('/api/services/list');
+  assert.equal(publicListPublished.status, 200);
+  assert.ok(publicListPublished.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+  const publicDetailPublished = await agent.get(`/api/public/services/${serviceId}`);
+  assert.equal(publicDetailPublished.status, 200);
+  assert.equal(String(publicDetailPublished.body.data.service.id || publicDetailPublished.body.data.service._id), serviceId);
+
+  const unpublishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: false });
+  assert.equal(unpublishRes.status, 200);
+  assert.equal(unpublishRes.body.data.publication.isPubliclyVisible, false);
+
+  const publicListUnpublished = await agent.get('/api/services/list');
+  assert.ok(!publicListUnpublished.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+  const publicDetailUnpublished = await agent.get(`/api/public/services/${serviceId}`);
+  assert.equal(publicDetailUnpublished.status, 404);
+
+  const republishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: true });
+  assert.equal(republishRes.status, 200);
+
+  const serviceCount = await Service.countDocuments({ businessId: business._id });
+  assert.equal(serviceCount, 1);
+
+  const retryCreate = await agent.post('/api/service/').send({
+    ...canonicalChildPayload,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+  });
+  assert.equal(retryCreate.status, 409);
+});
+
+test('createService rejects missing child price and duration with field errors', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user);
+  const { category, subcategory } = await seedServiceCategories();
+
+  await login(agent, vendor.email, vendor.password);
+
+  const res = await agent.post('/api/service/').send({
+    title: 'Invalid Service',
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    services: [{ name: 'Only Name' }],
+  });
+
+  assert.equal(res.status, 400);
+  assert.ok(res.body.fieldErrors['services[0].price']);
+  assert.ok(res.body.fieldErrors['services[0].durationMinutes']);
+});

--- a/tests/integration/setup/harness.js
+++ b/tests/integration/setup/harness.js
@@ -15,6 +15,12 @@ function applyIntegrationEnv(mongoUri) {
   process.env.MONGODB_URI = mongoUri;
   process.env.JWT_SECRET =
     process.env.JWT_SECRET || 'integration-test-jwt-secret-min-32-chars';
+  process.env.GOOGLE_CLIENT_ID =
+    process.env.GOOGLE_CLIENT_ID || 'integration-test-google-client-id';
+  process.env.GOOGLE_CLIENT_SECRET =
+    process.env.GOOGLE_CLIENT_SECRET || 'integration-test-google-client-secret';
+  process.env.API_BASE_URL =
+    process.env.API_BASE_URL || 'http://127.0.0.1:3001';
   process.env.STRIPE_SECRET_KEY =
     process.env.STRIPE_SECRET_KEY || 'sk_test_integration_mock_key_000000000';
   process.env.STRIPE_WEBHOOK_SECRET =

--- a/tests/service/service-payload-contract.test.js
+++ b/tests/service/service-payload-contract.test.js
@@ -1,0 +1,113 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  normalizeServicePayload,
+  validateChildServices,
+  validatePublishRequest,
+  evaluateServicePublication,
+  formatOwnerServiceResponse,
+} = require('../../lib/service/serviceContract');
+
+test('validateChildServices rejects missing child price with field key', () => {
+  const result = validateChildServices([
+    { name: 'Basic Cut', durationMinutes: 60 },
+  ]);
+
+  assert.equal(result.ok, false);
+  assert.ok(result.fieldErrors['services[0].price']);
+});
+
+test('validateChildServices rejects missing child duration with field key', () => {
+  const result = validateChildServices([
+    { name: 'Basic Cut', price: 45 },
+  ]);
+
+  assert.equal(result.ok, false);
+  assert.ok(result.fieldErrors['services[0].durationMinutes']);
+});
+
+test('normalizeServicePayload persists canonical parent and child fields', () => {
+  const payload = normalizeServicePayload({
+    title: 'Hair Styling',
+    description: 'Full salon menu',
+    services: [{
+      name: 'Basic Cut',
+      price: 45,
+      durationMinutes: 60,
+    }],
+  });
+
+  assert.equal(payload.title, 'Hair Styling');
+  assert.equal(payload.description, 'Full salon menu');
+  assert.equal(payload.parentPrice, 45);
+  assert.equal(payload.normalizedServices[0].price, 45);
+  assert.equal(payload.normalizedServices[0].durationMinutes, 60);
+});
+
+test('normalizeServicePayload backfills single name-only child from top-level price and duration', () => {
+  const payload = normalizeServicePayload({
+    title: 'Hair Styling',
+    description: 'Full salon menu',
+    price: 45,
+    duration: '60',
+    services: [{ name: 'Basic Cut' }],
+  });
+
+  assert.equal(payload.normalizedServices.length, 1);
+  assert.equal(payload.normalizedServices[0].name, 'Basic Cut');
+  assert.equal(payload.normalizedServices[0].price, 45);
+  assert.equal(payload.normalizedServices[0].durationMinutes, 60);
+  assert.equal(payload.parentPrice, 45);
+});
+
+test('validatePublishRequest rejects publish without valid children', () => {
+  const result = validatePublishRequest({
+    isPublished: true,
+    normalizedServices: [{ name: 'Only Name' }],
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.fieldErrors.isPublished);
+});
+
+test('evaluateServicePublication returns SERVICE_UNPUBLISHED for drafts', () => {
+  const publication = evaluateServicePublication({
+    service: {
+      isPublished: false,
+      services: [{ name: 'Cut', price: 20, durationMinutes: 30 }],
+    },
+    business: { isActive: true },
+  });
+
+  assert.equal(publication.isPubliclyVisible, false);
+  assert.equal(publication.visibilityReason, 'SERVICE_UNPUBLISHED');
+});
+
+test('evaluateServicePublication returns BUSINESS_INACTIVE for inactive business', () => {
+  const publication = evaluateServicePublication({
+    service: {
+      isPublished: true,
+      services: [{ name: 'Cut', price: 20, durationMinutes: 30 }],
+    },
+    business: { isActive: false },
+  });
+
+  assert.equal(publication.isPubliclyVisible, false);
+  assert.equal(publication.visibilityReason, 'BUSINESS_INACTIVE');
+});
+
+test('formatOwnerServiceResponse includes publication block', () => {
+  const response = formatOwnerServiceResponse(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Hair Styling',
+      isPublished: true,
+      services: [{ name: 'Cut', price: 20, durationMinutes: 30 }],
+    },
+    { isActive: true }
+  );
+
+  assert.equal(response.success, true);
+  assert.equal(response.data.publication.isPubliclyVisible, true);
+  assert.equal(response.data.publication.visibilityReason, null);
+});

--- a/tests/service/service-publication-visibility.test.js
+++ b/tests/service/service-publication-visibility.test.js
@@ -1,0 +1,369 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const serviceControllerPath = path.resolve(__dirname, '../../controllers/serviceController.js');
+const publicListingPath = path.resolve(__dirname, '../../controllers/publicListing.js');
+
+const ownerId = '507f1f77bcf86cd799439011';
+const businessId = '507f1f77bcf86cd799439012';
+const serviceId = '507f1f77bcf86cd799439013';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function awsMocks() {
+  return {
+    S3Client: class S3Client {},
+    PutObjectCommand: class PutObjectCommand {},
+  };
+}
+
+function buildServiceDoc(overrides = {}) {
+  return {
+    _id: serviceId,
+    ownerId,
+    businessId,
+    title: 'Hair Styling',
+    description: 'Salon menu',
+    isPublished: false,
+    services: [{ name: 'Cut', price: 45, durationMinutes: 60 }],
+    price: 45,
+    duration: '',
+    save: async function save() { return this; },
+    toObject() { return { ...this }; },
+    ...overrides,
+  };
+}
+
+function loadServiceController(options = {}) {
+  const {
+    existingService = null,
+    business = { _id: businessId, owner: ownerId, isActive: true, minorityType: 'none' },
+    subscription = { subscriptionPlanId: 'plan-1', status: 'active' },
+    serviceLimit = 10,
+  } = options;
+
+  const savedDocs = [];
+  let createCalled = false;
+
+  const Service = {
+    startSession: async () => ({
+      startTransaction: () => {},
+      commitTransaction: async () => {},
+      abortTransaction: async () => {},
+      endSession: () => {},
+    }),
+    findOne: async (query) => {
+      if (query._id === serviceId || (query.businessId && query.ownerId)) {
+        if (existingService === 'missing') return null;
+        if (existingService) return existingService;
+        if (query.businessId && createCalled) {
+          return buildServiceDoc({ isPublished: true });
+        }
+        return existingService;
+      }
+      return null;
+    },
+    find: () => ({
+      select: () => ({
+        lean: async () => [],
+      }),
+    }),
+    findById: () => ({
+      populate: () => ({
+        populate: () => ({
+          populate: () => Promise.resolve(buildServiceDoc()),
+        }),
+      }),
+    }),
+    findByIdAndUpdate: async () => buildServiceDoc({ isPublished: true }),
+  };
+
+  Service.prototype = function ServiceModel(data) {
+    Object.assign(this, data);
+    this.save = async () => {
+      savedDocs.push(this);
+      createCalled = true;
+      return this;
+    };
+    this.toObject = () => ({ ...this, _id: serviceId });
+  };
+
+  const resolveFindOne = (query) => {
+    if (query._id === serviceId && query.ownerId) {
+      if (existingService === 'missing') return null;
+      return existingService || buildServiceDoc();
+    }
+    if (query.businessId && query.ownerId) {
+      if (existingService === 'missing') return null;
+      return existingService || null;
+    }
+    return null;
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Service')) {
+      const ServiceExport = function ServiceModel(data) {
+        Object.assign(this, data);
+        this._id = serviceId;
+        this.save = async () => {
+          savedDocs.push(this);
+          createCalled = true;
+          return this;
+        };
+        this.toObject = () => ({ ...this, _id: serviceId });
+      };
+      ServiceExport.startSession = Service.startSession;
+      ServiceExport.findOne = (query) => {
+        const exec = async () => resolveFindOne(query);
+        const chain = {
+          select: () => chain,
+          exec,
+          then: (resolve, reject) => exec().then(resolve, reject),
+        };
+        return chain;
+      };
+      ServiceExport.find = Service.find;
+      ServiceExport.findById = Service.findById;
+      ServiceExport.findByIdAndUpdate = Service.findByIdAndUpdate;
+      return ServiceExport;
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findOne: () => ({
+          select: () => ({
+            exec: async () => business,
+            then: (resolve, reject) => Promise.resolve(business).then(resolve, reject),
+          }),
+        }),
+        find: () => ({
+          select: () => ({
+            lean: async () => [business],
+          }),
+        }),
+        findById: async () => business,
+      };
+    }
+    if (request.endsWith('models/Subscription')) {
+      return {
+        findOne: () => ({
+          sort: async () => subscription,
+        }),
+      };
+    }
+    if (request.endsWith('models/SubscriptionPlan')) {
+      return {
+        findById: async () => ({ limits: { serviceListings: serviceLimit, imageLimit: 5 } }),
+      };
+    }
+    if (request.endsWith('models/PendingImage')) {
+      return { deleteMany: async () => {}, deleteOne: async () => {} };
+    }
+    if (request.endsWith('utils/deleteCloudinaryFile')) return async () => {};
+    if (request.endsWith('@aws-sdk/client-s3')) return awsMocks();
+    if (request.endsWith('@aws-sdk/s3-request-presigner')) return { getSignedUrl: async () => 'url' };
+    if (request.endsWith('models/ServiceCategory')) return {};
+    if (request.endsWith('models/ServiceSubcategory')) return {};
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[serviceControllerPath];
+  const controller = require(serviceControllerPath);
+  Module._load = originalLoad;
+  return { controller, savedDocs };
+}
+
+function loadPublicListingController(options = {}) {
+  const {
+    service = buildServiceDoc({ isPublished: false }),
+    businessActive = true,
+    capturedFindById = { called: false },
+  } = options;
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Service')) {
+      return {
+        find: () => ({
+          populate: () => ({
+            sort: () => ({
+              skip: () => ({
+                limit: async () => [],
+              }),
+            }),
+          }),
+        }),
+        countDocuments: async () => 0,
+        findById: () => {
+          capturedFindById.called = true;
+          return {
+            populate: () => ({
+              populate: () => ({
+                populate: async () => service,
+              }),
+            }),
+          };
+        },
+        findOne: async () => null,
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        find: () => ({
+          select: () => ({
+            lean: async () => (businessActive ? [{ _id: businessId }] : []),
+          }),
+        }),
+        findOne: () => ({
+          select: () => ({
+            lean: async () => (businessActive ? { _id: businessId } : null),
+          }),
+        }),
+      };
+    }
+    if (request.endsWith('models/VendorOnboardingStage1')) {
+      return { findOne: () => ({ select: () => ({ lean: async () => null }) }) };
+    }
+    if (request.endsWith('models/Review')) return { find: () => ({ populate: async () => [] }) };
+    if (request.endsWith('models/ServiceCategory')) return { findOne: async () => null };
+    if (request.endsWith('models/ServiceSubcategory')) return { findOne: async () => null };
+    if (request.endsWith('lib/listing/publicListingDto')) {
+      return {
+        toPublicListingCard: (doc) => doc,
+        toPublicListingDetail: (doc) => doc,
+        toPublicBusinessCard: (doc) => doc,
+      };
+    }
+    if (request.endsWith('lib/listing/publicSearchFilters')) {
+      return {
+        parsePublicSearchQuery: () => ({}),
+        detectUnsupportedGeoParams: () => false,
+        shouldIncludeListingType: () => true,
+        resolveBusinessIdsByKeyword: async () => [],
+        resolveCombinedBusinessFilters: async () => ({ businessIds: [], empty: false }),
+        intersectBusinessIdSets: () => [],
+        loadVerifiedByBusinessIds: async () => new Map(),
+        loadTagsByBusinessIds: async () => new Map(),
+        narrowVisibleBusinessIds: async () => ({ businessIds: [businessId], empty: false }),
+        mergeBusinessIdFilter: () => ({ filter: { $in: [businessId] }, empty: false }),
+        buildKeywordRegex: () => /./,
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[publicListingPath];
+  const controller = require(publicListingPath);
+  Module._load = originalLoad;
+  return { controller, capturedFindById };
+}
+
+test('createService returns 409 when parent service already exists', async () => {
+  const { controller } = loadServiceController({
+    existingService: buildServiceDoc(),
+  });
+  const res = mockResponse();
+
+  await controller.createService(
+    {
+      user: { _id: ownerId },
+      body: {
+        businessId,
+        categoryId: '507f1f77bcf86cd799439014',
+        subcategoryId: '507f1f77bcf86cd799439015',
+        title: 'Hair Styling',
+        services: [{ name: 'Cut', price: 45, durationMinutes: 60 }],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 409);
+  assert.ok(res.body.existingServiceId);
+});
+
+test('createService returns field errors for frontend name-only child without top-level backfill', async () => {
+  const { controller } = loadServiceController({ existingService: null });
+  const res = mockResponse();
+
+  await controller.createService(
+    {
+      user: { _id: ownerId },
+      body: {
+        businessId,
+        categoryId: '507f1f77bcf86cd799439014',
+        subcategoryId: '507f1f77bcf86cd799439015',
+        services: [{ name: 'Cut' }],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.ok(res.body.fieldErrors['services[0].price']);
+  assert.ok(res.body.fieldErrors['services[0].durationMinutes']);
+});
+
+test('public getServiceById excludes unpublished services', async () => {
+  const { controller } = loadPublicListingController({
+    service: buildServiceDoc({ isPublished: false }),
+  });
+  const res = mockResponse();
+
+  await controller.getServiceById({ params: { id: serviceId } }, res);
+
+  assert.equal(res.statusCode, 404);
+});
+
+test('public getServiceById returns published service for active business', async () => {
+  const { controller } = loadPublicListingController({
+    service: {
+      ...buildServiceDoc({ isPublished: true }),
+      businessId: { _id: businessId, toObject: () => ({ _id: businessId }) },
+      toObject() {
+        return { ...this, businessId: { _id: businessId } };
+      },
+    },
+  });
+  const res = mockResponse();
+
+  await controller.getServiceById({ params: { id: serviceId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+});
+
+test('updateService publish response exposes publication block without duplicate create', async () => {
+  const draft = buildServiceDoc({ isPublished: false });
+  const { controller } = loadServiceController({
+    existingService: draft,
+  });
+  const res = mockResponse();
+
+  await controller.updateService(
+    {
+      user: { _id: ownerId },
+      params: { id: serviceId },
+      body: { isPublished: true },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.publication.isPublished, true);
+});


### PR DESCRIPTION
## Summary
- Lock canonical parent+child service DTO in `lib/service/serviceContract.js` with frontend single-child backfill, field-level validation, and owner `publication` metadata.
- Fix `createService`/`updateService` to persist title/description, block duplicate parent creates (409), and guard publish until child data is valid.
- Align public visibility: `GET /api/public/services/:id`, slug detail, and `business-service/:id` now require `isPublished: true` plus active business (matching list/search).
- Add unit + integration proof that a published service appears on both public list and public detail; unpublish removes it.

Fixes launch blocker context: Digital-Builders-757/mosaic-biz-frontend-launch#185

## Test plan
- [x] `npm test` (302 pass)
- [x] `npm run test:integration` (28 pass)
- [x] `node --test tests/service/service-*.test.js`
- [x] `GET /`, `/api/health`, `/api/ready` smoke via harness
- [ ] Live smoke: `scripts/service-publication-smoke.ps1` (requires `SMOKE_TEST_*` env vars)

## Evidence
- `docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md`
- Commit: `8637121`