### PR TITLE
Trim marketplace card payloads and preserve detail galleries

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -13,6 +13,7 @@ const {
   formatOwnerServiceResponse,
   formatValidationErrorResponse,
 } = require('../lib/service/serviceContract');
+const { normalizeImages } = require('../lib/listing/publicListingDto');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
@@ -898,6 +899,11 @@ exports.getBusinessServiceById = async (req, res) => {
       };
     });
 
+    const serviceImages = normalizeImages({
+      coverImage: service.coverImage,
+      images: service.images,
+    });
+
     const mappedService = {
       _id: service._id,
       title: service.title || '',
@@ -924,7 +930,9 @@ exports.getBusinessServiceById = async (req, res) => {
         }
         : null,
       coverImage: service.coverImage || '',
-      images: Array.isArray(service.images) ? service.images : [],
+      images: serviceImages.images,
+      image: serviceImages.image,
+      imageUrl: serviceImages.imageUrl,
       location: service.location || '',
       businessHours: mappedBusinessHours,
       bookingToolLink: service.bookingToolLink || '',

--- a/docs/MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md
+++ b/docs/MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md
@@ -36,7 +36,7 @@ These fields are added to responses where source data exists. Missing values are
 | `description` | string \| null | full description |
 | `shortDescription` | string \| null | truncated from description (~160 chars) |
 | `image` / `imageUrl` | string \| null | `coverImage` → `images[0]` → vendor `logo` |
-| `images` | string[] | `[]` when none |
+| `images` | string[] | Card/list: primary image only (`[]` when none). Detail: full deduped gallery |
 | `price` | number \| null | `null` when missing (not coerced to 0) |
 | `priceLabel` / `displayPrice` | string | `"Contact for price"` when price is null; else `$X.XX` |
 | `vendorId` / `businessId` | string \| null | from populated or raw business ref |
@@ -55,6 +55,15 @@ These fields are added to responses where source data exists. Missing values are
 | `contact` | object \| null | `{ email, phone }` when available |
 | `detailPath` | string \| null | frontend routing hint |
 | `createdAt` / `updatedAt` | ISO date | passed through when present on raw doc |
+
+### Card vs detail media
+
+| Response | `images[]` | Omitted from cards |
+|----------|------------|-------------------|
+| List/card (`toPublicListingCard`) | Primary image only (0 or 1 entry) | `videos` and other non-whitelisted raw doc fields |
+| Detail (`toPublicListingDetail`) | Full deduped gallery | — |
+
+Cards still pass through whitelisted legacy keys (`_id`, `coverImage`, `categoryId`, etc.) for backward compatibility with #28.
 
 ---
 

--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -5,6 +5,27 @@
 
 const SHORT_DESCRIPTION_MAX = 160;
 
+const CARD_LEGACY_FIELDS = [
+  '_id',
+  'coverImage',
+  'categoryId',
+  'subcategoryId',
+  'businessId',
+  'isPublished',
+  'stockQuantity',
+  'sku',
+  'brand',
+  'services',
+  'duration',
+  'durationMinutes',
+  'createdAt',
+  'updatedAt',
+  'ownerId',
+  'businessHours',
+  'bookingToolLink',
+  'location',
+];
+
 const LISTING_DETAIL_PATHS = {
   product: (item) => (item.slug ? `/products/${item.slug}` : item.id ? `/products/${item.id}` : null),
   service: (item) => (item.slug ? `/services/${item.slug}` : item.id ? `/services/${item.id}` : null),
@@ -202,17 +223,37 @@ function omitUndefined(obj) {
   return result;
 }
 
+function pickLegacyCardFields(doc) {
+  const legacy = {};
+  for (const key of CARD_LEGACY_FIELDS) {
+    if (doc[key] !== undefined) {
+      legacy[key] = doc[key];
+    }
+  }
+  return legacy;
+}
+
+function trimImagesForCard(fullImages) {
+  const primary = fullImages.image ?? null;
+  return {
+    image: primary,
+    imageUrl: primary,
+    images: primary ? [primary] : [],
+  };
+}
+
 function toPublicListingCard(raw, options = {}) {
   const listingType = options.listingType || 'product';
   const doc = raw && typeof raw.toObject === 'function' ? raw.toObject() : { ...raw };
   const id = normalizeId(doc._id ?? doc.id);
   const businessSource = extractBusinessSource(doc);
   const vendor = normalizeVendor(doc, businessSource);
-  const images = normalizeImages({
+  const fullImages = normalizeImages({
     coverImage: doc.coverImage,
     images: doc.images,
     logo: businessSource?.logo,
   });
+  const cardImages = trimImagesForCard(fullImages);
   const price = normalizePrice(doc.price);
   const category = normalizeTaxonomyRef(doc.category ?? doc.categoryId);
   const subcategory = normalizeTaxonomyRef(doc.subcategory ?? doc.subcategoryId);
@@ -225,7 +266,7 @@ function toPublicListingCard(raw, options = {}) {
   const vendorLogo = businessSource?.logo ?? vendor.business?.logo ?? null;
 
   const cardBase = {
-    ...doc,
+    ...pickLegacyCardFields(doc),
     id,
     listingType,
     title: doc.title ?? null,
@@ -233,7 +274,7 @@ function toPublicListingCard(raw, options = {}) {
     description: doc.description ?? null,
     shortDescription: truncateDescription(doc.description ?? doc.shortDescription),
     slug: doc.slug ?? null,
-    ...images,
+    ...cardImages,
     price,
     priceLabel,
     displayPrice: priceLabel,
@@ -268,10 +309,18 @@ function toPublicListingCard(raw, options = {}) {
 }
 
 function toPublicListingDetail(raw, options = {}) {
+  const doc = raw && typeof raw.toObject === 'function' ? raw.toObject() : { ...raw };
+  const businessSource = extractBusinessSource(doc);
+  const fullImages = normalizeImages({
+    coverImage: doc.coverImage,
+    images: doc.images,
+    logo: businessSource?.logo,
+  });
   const card = toPublicListingCard(raw, options);
   const extras = options.extras && typeof options.extras === 'object' ? options.extras : {};
   return omitUndefined({
     ...card,
+    ...fullImages,
     ...extras,
   });
 }

--- a/tests/marketplace/public-listing-dto.test.js
+++ b/tests/marketplace/public-listing-dto.test.js
@@ -248,3 +248,55 @@ test('normalizeLocation returns null fields when no source data exists', () => {
   assert.equal(card.city, null);
   assert.equal(card.state, null);
 });
+
+test('toPublicListingCard omits oversized media fields from list payloads', () => {
+  const card = toPublicListingCard(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Gallery Item',
+      coverImage: 'https://cdn.example.com/cover.jpg',
+      images: [
+        'https://cdn.example.com/cover.jpg',
+        'https://cdn.example.com/b.jpg',
+        'https://cdn.example.com/c.jpg',
+      ],
+      videos: ['https://cdn.example.com/promo.mp4'],
+    },
+    { listingType: 'product' }
+  );
+
+  assert.equal(card.imageUrl, 'https://cdn.example.com/cover.jpg');
+  assert.deepEqual(card.images, ['https://cdn.example.com/cover.jpg']);
+  assert.equal(card.coverImage, 'https://cdn.example.com/cover.jpg');
+  assert.equal(card.videos, undefined);
+});
+
+test('toPublicListingDetail preserves full image gallery on detail payloads', () => {
+  const detail = toPublicListingDetail(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Gallery Item',
+      coverImage: 'https://cdn.example.com/cover.jpg',
+      images: [
+        'https://cdn.example.com/cover.jpg',
+        'https://cdn.example.com/b.jpg',
+      ],
+    },
+    { listingType: 'product' }
+  );
+
+  assert.equal(detail.imageUrl, 'https://cdn.example.com/cover.jpg');
+  assert.equal(detail.images.length, 2);
+  assert.equal(detail.images[1], 'https://cdn.example.com/b.jpg');
+});
+
+test('toPublicListingCard returns null imageUrl when no media exists', () => {
+  const card = toPublicListingCard(
+    { _id: '507f1f77bcf86cd799439011', title: 'No media' },
+    { listingType: 'food' }
+  );
+
+  assert.equal(card.image, null);
+  assert.equal(card.imageUrl, null);
+  assert.deepEqual(card.images, []);
+});


### PR DESCRIPTION
## Summary
- Cards no longer spread the full Mongoose document; oversized fields like `videos` are omitted from list responses
- Card `images[]` carries the primary image only; detail responses keep the full deduped gallery
- `getBusinessServiceById` adds canonical `image` / `imageUrl` fields

Fixes #45 and #54 (focused scope).

## Test plan
- [x] `npm test` (305 pass)
- [x] Updated `tests/marketplace/public-listing-dto.test.js`
- [x] Updated `docs/MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md` card vs detail media section

Made with [Cursor](https://cursor.com)