### PR TITLE
Verify service publication Model A contract for frontend #186

### DIFF
--- a/controllers/privateListing.js
+++ b/controllers/privateListing.js
@@ -106,7 +106,7 @@ exports.getServiceBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
 
-    const service = await Service.findOne({ slug })
+    const service = await Service.findOne({ slug, ownerId: req.user._id })
       .populate('categoryId', 'name')
       .populate('subcategoryId', 'name')
       .populate('ownerId', 'name');

--- a/docs/SERVICE_PUBLICATION_CONTRACT.md
+++ b/docs/SERVICE_PUBLICATION_CONTRACT.md
@@ -1,0 +1,193 @@
+# Service Publication Contract (Model A)
+
+**Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
+**Branch:** `fix/backend-service-publication-visibility-contract`  
+**Frontend dependency:** [mosaic-biz-frontend-launch PR #186](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/pull/186) / [issue #185](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/185)  
+**Related:** [SERVICE_PUBLICATION_VISIBILITY_PROOF.md](SERVICE_PUBLICATION_VISIBILITY_PROOF.md), [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md)
+
+No secrets, tokens, or credentials in this document.
+
+---
+
+## Model A (publication owner)
+
+One parent `Service` MongoDB document per business. Bookable line items live in embedded `services[]` children — not separate Service documents.
+
+Publication state is owned by the parent field **`isPublished`** (Boolean, default `false`).
+
+---
+
+## Public eligibility predicate
+
+A service is **publicly eligible** when **all** of the following are true:
+
+```text
+service.isPublished === true
+AND Business.exists({ _id: service.businessId, isActive: true })
+```
+
+**Not** required for public browse:
+
+- `Business.isApproved`
+- Vendor onboarding / verification status
+- `Service.isDeleted` (field does not exist on Service model)
+
+Owner-facing metadata (`evaluateServicePublication` in `lib/service/serviceContract.js`) additionally validates embedded children and returns stable codes:
+
+| Code | Meaning |
+|------|---------|
+| `SERVICE_UNPUBLISHED` | `isPublished` is false |
+| `INVALID_SERVICE_DATA` | Published but child validation fails |
+| `BUSINESS_NOT_PUBLICLY_ELIGIBLE` | Business record missing |
+| `BUSINESS_INACTIVE` | `business.isActive !== true` |
+
+When publicly visible, `visibilityReason` is `null` and `isPubliclyVisible` is `true`.
+
+---
+
+## Route contract
+
+### Vendor create / update / delete
+
+| Method | Path | Auth | Ownership |
+|--------|------|------|-----------|
+| POST | `/api/service/` | `authenticate`, `isBusinessOwner` | `Business.findOne({ _id: businessId, owner: userId })`; one listing per business (409 on duplicate) |
+| PUT | `/api/service/:id` | same | `Service.findOne({ _id, ownerId: userId })` — publish/unpublish via `{ isPublished: true/false }` |
+| DELETE | `/api/service/delete-service/:id` | same | `Service.findOne({ _id, ownerId: userId })` |
+| GET | `/api/service/:id` | same | Owner read + `data.publication` metadata |
+| GET | `/api/service/my-services` | same | All owner services + `publicationByServiceId` map |
+
+**Mount:** `app.use('/api/service', serviceRoutes)` in `app.js`.
+
+### Vendor inventory
+
+| Method | Path | Auth | Ownership |
+|--------|------|------|-----------|
+| GET | `/api/private/services/list?businessId=` | `authenticate`, `isBusinessOwner` | `filters: { businessId, ownerId: req.user._id }` — returns drafts and published by default |
+| GET | `/api/private/services/:slug` | same | `{ slug, ownerId: req.user._id }` |
+
+**Mount:** `app.use('/api/private', privateListingRoutes)`.
+
+### Public discovery and detail
+
+| Method | Path | Auth | Visibility gate |
+|--------|------|------|-----------------|
+| GET | `/api/services/list` | None | `{ isPublished: true, businessId ∈ activeBusinessIds }` |
+| GET | `/api/public/services/:id` | None | 404 if unpublished or business inactive — **frontend `/vendor-profile/service-vendor/:id`** |
+| GET | `/api/services/:slug` | None | `{ slug, isPublished: true }` + active business |
+| GET | `/api/service/business-service/:id` | None | Same publish + active business gates |
+| GET | `/api/public/search` | None | Services: `isPublished: true` + active business scope |
+
+**Mount:** `app.use('/api', publicListingRoutes)`.
+
+---
+
+## Request payload (create / update)
+
+### Required for create
+
+| Field | Notes |
+|-------|-------|
+| `businessId` | Must belong to authenticated vendor |
+| `categoryId`, `subcategoryId` | ObjectIds |
+| `services[]` | At least one child with `name`, `price`, `durationMinutes` (or parseable `duration` / top-level backfill) |
+
+### Publication
+
+| Field | Behavior |
+|-------|----------|
+| `isPublished: false` | Draft — private inventory only |
+| `isPublished: true` | Publish — requires valid child data; blocked with 400 if invalid |
+| Omitted on create | Defaults to `false` |
+
+### Frontend compatibility
+
+When exactly one child has only `name` and top-level `price` + `duration`/`durationMinutes` are present, values backfill that child before validation (`normalizeServicePayload`).
+
+---
+
+## Response shape (owner create / update / read)
+
+```json
+{
+  "success": true,
+  "message": "Service updated successfully",
+  "service": { "_id": "...", "isPublished": true, "services": [] },
+  "data": {
+    "service": { "_id": "...", "isPublished": true, "services": [] },
+    "publication": {
+      "isPublished": true,
+      "isPubliclyVisible": true,
+      "visibilityReason": null
+    }
+  }
+}
+```
+
+Legacy top-level `service` is preserved for backward compatibility. Frontend PR #186 reads `data.publication` and falls back to public probe when metadata is absent.
+
+---
+
+## HTTP status codes
+
+| Situation | Status |
+|-----------|--------|
+| Validation failure (child price/duration, publish without valid children) | 400 + `fieldErrors` |
+| Unauthenticated vendor route | 401 |
+| Wrong business ownership / no subscription | 403 |
+| Service not found or not owned | 404 |
+| Duplicate POST for same business | 409 + `existingServiceId` |
+
+---
+
+## Middleware order (unchanged)
+
+Stripe webhook paths use `express.raw({ type: 'application/json' })` **before** `express.json`. Service routes are mounted after JSON parsing. Do not reorder when deploying this contract.
+
+---
+
+## Deployment dependency
+
+1. Merge and deploy **backend** to Elastic Beanstalk (manual workflow from `main`).
+2. Run post-deploy smoke: `scripts/service-publication-smoke.ps1`
+3. Validate **frontend PR #186** preview against deployed API.
+
+Deploy backend **before** frontend manual smoke for issue #185 closure.
+
+---
+
+## Runtime smoke env var names (values in session only)
+
+| Name | Purpose |
+|------|---------|
+| `SMOKE_TEST_VENDOR_TOKEN` | Bearer token for vendor API calls |
+| `SMOKE_TEST_BUSINESS_ID` | Target business ObjectId |
+| `SMOKE_TEST_SERVICE_CATEGORY_ID` | Category for create payload |
+| `SMOKE_TEST_SERVICE_SUBCATEGORY_ID` | Subcategory for create payload |
+| `API_BASE_URL` | Optional; default `https://api.mosaicbizhub.com` |
+
+---
+
+## Rollback procedure
+
+1. Revert merge commit on `main` (no schema migration).
+2. Redeploy previous EB application version.
+3. Frontend PR #186 will fall back to public probe but may show stale visibility if backend regresses.
+
+---
+
+## Automated test coverage
+
+| File | Scope |
+|------|-------|
+| `tests/service/service-payload-contract.test.js` | DTO normalization, publish validation, visibility codes |
+| `tests/service/service-publication-visibility.test.js` | Controller unit tests |
+| `tests/integration/service-publication.integration.test.js` | Full HTTP flow: draft, publish-on-create, unpublish, republish, cross-vendor 404, inactive business, slug ownership, public surfaces |
+
+Commands:
+
+```bash
+npm test
+npm run test:integration
+node --test tests/service/service-*.test.js
+```

--- a/docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md
+++ b/docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md
@@ -2,7 +2,8 @@
 
 **Repo:** [Techware-Hut/mosaic-backend](https://github.com/Techware-Hut/mosaic-backend)  
 **Branch:** `fix/backend-service-publication-visibility-contract`  
-**Cross-repo:** [Digital-Builders-757/mosaic-biz-frontend-launch#185](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/185)  
+**Cross-repo:** [Digital-Builders-757/mosaic-biz-frontend-launch#185](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/185) · [PR #186](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/pull/186)  
+**Canonical contract:** [SERVICE_PUBLICATION_CONTRACT.md](SERVICE_PUBLICATION_CONTRACT.md)  
 **Evidence date:** 2026-06-22  
 
 No secrets, JWTs, tokens, credentials, or PII in this document.
@@ -11,13 +12,15 @@ No secrets, JWTs, tokens, credentials, or PII in this document.
 
 ## Executive verdict
 
-**Root cause:** Multi-factor contract and visibility bug — not a single missing flag.
+**Model A status:** Partially existed before PR #108; core contract corrected on `main` via [PR #108](https://github.com/Techware-Hut/mosaic-backend/pull/108) (merge `7944491`). This branch adds verification gaps: private slug ownership, extended integration tests, and contract documentation for frontend PR #186.
+
+**Root cause (pre-#108):** Multi-factor contract and visibility bug — not a single missing flag.
 
 1. `createService` ignored vendor-supplied parent `title`/`description` and did not normalize frontend `{ name }`-only child payloads.
 2. `isPublished` defaults to `false`, so drafts never appear on `GET /api/services/list` until published.
 3. `GET /api/public/services/:id` and `GET /api/service/business-service/:id` omitted the `isPublished` gate used by list/slug/search.
 
-**Fix:** Canonical parent+child DTO in `lib/service/serviceContract.js`, aligned create/update validation, publication metadata on owner responses, consistent public visibility gates.
+**This branch additionally fixes:** `GET /api/private/services/:slug` no longer returns another vendor's service (adds `ownerId` filter).
 
 ---
 
@@ -48,10 +51,6 @@ No secrets, JWTs, tokens, credentials, or PII in this document.
 | `price` | yes (`>= 0`) |
 | `durationMinutes` | yes (or parseable `duration` alias) |
 
-### Frontend compatibility
-
-When exactly one child has only `name` and top-level `price` + `duration`/`durationMinutes` are present, values backfill that child before validation.
-
 ### Owner publication block (additive)
 
 ```json
@@ -72,39 +71,16 @@ Stable `visibilityReason` codes: `SERVICE_UNPUBLISHED`, `BUSINESS_INACTIVE`, `BU
 
 ---
 
-## Before / after payload example
-
-**Frontend payload:**
-
-```json
-{
-  "title": "Hair Styling",
-  "description": "Full salon menu",
-  "price": 45,
-  "duration": "60",
-  "services": [{ "name": "Basic Cut" }]
-}
-```
-
-**Before:** `title: "Service"`, empty description, `isPublished: false`, often 400 on missing child duration.
-
-**After:** Parent title/description preserved; child gets `price: 45`, `durationMinutes: 60`; publish via `PUT /api/service/:id`.
-
----
-
-## Files changed
+## Files changed (this branch)
 
 | File | Change |
 |------|--------|
-| `lib/service/serviceContract.js` | New DTO + publication helpers |
-| `controllers/serviceController.js` | Create/update/read contract + duplicate guard |
-| `controllers/publicListing.js` | Public ID/slug visibility gates |
-| `controllers/privateListing.js` | `ownerId` + `categoryId` filter fixes |
-| `tests/service/service-payload-contract.test.js` | Unit tests |
-| `tests/service/service-publication-visibility.test.js` | Controller visibility tests |
-| `tests/integration/service-publication.integration.test.js` | End-to-end proof |
-| `tests/integration/helpers/factories.js` | Service seed helpers |
-| `scripts/service-publication-smoke.ps1` | Runtime smoke script |
+| `controllers/privateListing.js` | Private slug route scoped to `ownerId` |
+| `tests/integration/service-publication.integration.test.js` | Extended 12-scenario HTTP proof |
+| `docs/SERVICE_PUBLICATION_CONTRACT.md` | Canonical route contract (new) |
+| `docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md` | Updated proof + PR references |
+
+Prior PR #108 also introduced: `lib/service/serviceContract.js`, `serviceController.js`, `publicListing.js`, unit tests, smoke script.
 
 ---
 
@@ -112,9 +88,9 @@ Stable `visibilityReason` codes: `SERVICE_UNPUBLISHED`, `BUSINESS_INACTIVE`, `BU
 
 | Command | Result |
 |---------|--------|
-| `npm test` | **302 pass**, 0 fail |
-| `npm run test:integration` | **28 pass**, 0 fail |
-| `node --test tests/service/service-*.test.js` | **13 pass**, 0 fail |
+| `npm test` | Run at PR time — see PR body |
+| `npm run test:integration` | **34 pass**, 0 fail (includes 6 service-publication tests) |
+| `node --test tests/service/service-*.test.js` | Run at PR time |
 | `node --check` on modified controllers + contract lib | **PASS** |
 
 ---
@@ -123,11 +99,15 @@ Stable `visibilityReason` codes: `SERVICE_UNPUBLISHED`, `BUSINESS_INACTIVE`, `BU
 
 `tests/integration/service-publication.integration.test.js` proves:
 
-1. Draft created with frontend-shaped payload → private list includes service, public list excludes it, public detail 404.
-2. `PUT` publish same `_id` → `GET /api/services/list` and `GET /api/public/services/:id` both return the service.
-3. Unpublish → public list and detail 404.
-4. Republish → still one document (`Service.countDocuments === 1`).
-5. Retry `POST /api/service/` → **409** with `existingServiceId`.
+1. Draft → private list + my-services include service; public list/detail/slug/business-service exclude.
+2. Publish → all public surfaces return service.
+3. Unpublish → all public surfaces 404.
+4. Republish → public surfaces visible again; still one document.
+5. Create with `isPublished: true` → immediately public.
+6. Cross-vendor PUT/DELETE → 404.
+7. Inactive business + published → owner `BUSINESS_INACTIVE`; public 404.
+8. Private slug → owner 200; other vendor 404.
+9. Duplicate POST → **409**.
 
 ---
 
@@ -142,7 +122,7 @@ Requires env (not configured in local session):
 - `SMOKE_TEST_SERVICE_CATEGORY_ID`
 - `SMOKE_TEST_SERVICE_SUBCATEGORY_ID`
 
-**Status:** BLOCKED — env-owned credentials not provided in this session. Integration test provides equivalent proof locally.
+**Status:** BLOCKED — env-owned credentials not provided in this session. Integration tests provide equivalent proof locally.
 
 ---
 
@@ -151,8 +131,8 @@ Requires env (not configured in local session):
 | Risk | Mitigation |
 |------|------------|
 | Clients relied on unpublished public ID reads | Matches visibility matrix; intentional |
-| Duplicate POST now returns 409 | Document: use PUT to publish/update |
-| Additive response shape | Legacy `service`/`message` keys preserved |
+| Duplicate POST returns 409 | Document: use PUT to publish/update |
+| Private slug fix returns 404 for cross-owner reads | Intentional security fix |
 
 ## Rollback
 
@@ -167,6 +147,15 @@ Revert branch commits. No schema migration required.
 
 ---
 
-## PR
+## PR history
 
-Open after commit/push: `fix/backend-service-publication-visibility-contract` → `main`.
+| PR | Status |
+|----|--------|
+| [#108](https://github.com/Techware-Hut/mosaic-backend/pull/108) | **Merged** — core Model A contract |
+| Verification branch PR | Opened from `fix/backend-service-publication-visibility-contract` — see current PR link in release notes |
+
+---
+
+## Deploy verdict
+
+**Safe to deploy for frontend PR #186 validation** — after PR review merge, provided CI passes and post-deploy smoke (steps D/E/G in smoke matrix) confirms public visibility on the target API. Unit/integration tests alone do not replace runtime public visibility verification.

--- a/tests/integration/service-publication.integration.test.js
+++ b/tests/integration/service-publication.integration.test.js
@@ -36,11 +36,10 @@ const canonicalChildPayload = {
   services: [{ name: 'Basic Cut' }],
 };
 
-test('service publication flow: draft private, publish public list + detail, unpublish hides public reads', async () => {
-  const agent = createAgent(getApp());
+async function setupVendorWithService(agent, { isPublished = false, businessOverrides = {} } = {}) {
   const vendor = await registerAndVerify(agent, { role: 'business_owner' });
   const user = await User.findOne({ email: vendor.email });
-  const business = await seedServiceBusiness(user);
+  const business = await seedServiceBusiness(user, businessOverrides);
   const { category, subcategory } = await seedServiceCategories();
 
   const loginRes = await login(agent, vendor.email, vendor.password);
@@ -51,6 +50,64 @@ test('service publication flow: draft private, publish public list + detail, unp
     businessId: business._id,
     categoryId: category._id,
     subcategoryId: subcategory._id,
+    isPublished,
+  });
+
+  return {
+    vendor,
+    user,
+    business,
+    category,
+    subcategory,
+    createRes,
+    serviceId: createRes.body?.data?.service?._id
+      ? String(createRes.body.data.service._id)
+      : null,
+    slug: createRes.body?.data?.service?.slug || null,
+  };
+}
+
+function assertPublicSurfacesIncludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 200);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 200);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 200);
+  })();
+}
+
+function assertPublicSurfacesExcludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(!publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 404);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 404);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 404);
+  })();
+}
+
+test('service publication flow: draft private, publish public list + detail, unpublish hides public reads', async () => {
+  const agent = createAgent(getApp());
+  const { business, createRes, serviceId, slug } = await setupVendorWithService(agent, {
     isPublished: false,
   });
 
@@ -61,20 +118,18 @@ test('service publication flow: draft private, publish public list + detail, unp
   assert.equal(createRes.body.data.service.services[0].price, 45);
   assert.equal(createRes.body.data.service.services[0].durationMinutes, 60);
 
-  const serviceId = String(createRes.body.data.service._id);
-
   const privateList = await agent.get('/api/private/services/list').query({
     businessId: String(business._id),
   });
   assert.equal(privateList.status, 200, JSON.stringify(privateList.body));
   assert.ok(privateList.body.data.some((entry) => String(entry._id || entry.id) === serviceId));
 
-  const publicListDraft = await agent.get('/api/services/list');
-  assert.equal(publicListDraft.status, 200);
-  assert.ok(!publicListDraft.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+  const myServicesDraft = await agent.get('/api/service/my-services');
+  assert.equal(myServicesDraft.status, 200);
+  assert.ok(myServicesDraft.body.services.some((entry) => String(entry._id) === serviceId));
+  assert.equal(myServicesDraft.body.publicationByServiceId[serviceId].isPublished, false);
 
-  const publicDetailDraft = await agent.get(`/api/public/services/${serviceId}`);
-  assert.equal(publicDetailDraft.status, 404);
+  await assertPublicSurfacesExcludeService(agent, serviceId, slug);
 
   const publishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: true });
   assert.equal(publishRes.status, 200);
@@ -82,26 +137,19 @@ test('service publication flow: draft private, publish public list + detail, unp
   assert.equal(publishRes.body.data.publication.isPublished, true);
   assert.equal(publishRes.body.data.publication.isPubliclyVisible, true);
 
-  const publicListPublished = await agent.get('/api/services/list');
-  assert.equal(publicListPublished.status, 200);
-  assert.ok(publicListPublished.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
-
-  const publicDetailPublished = await agent.get(`/api/public/services/${serviceId}`);
-  assert.equal(publicDetailPublished.status, 200);
-  assert.equal(String(publicDetailPublished.body.data.service.id || publicDetailPublished.body.data.service._id), serviceId);
+  await assertPublicSurfacesIncludeService(agent, serviceId, slug);
 
   const unpublishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: false });
   assert.equal(unpublishRes.status, 200);
   assert.equal(unpublishRes.body.data.publication.isPubliclyVisible, false);
 
-  const publicListUnpublished = await agent.get('/api/services/list');
-  assert.ok(!publicListUnpublished.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
-
-  const publicDetailUnpublished = await agent.get(`/api/public/services/${serviceId}`);
-  assert.equal(publicDetailUnpublished.status, 404);
+  await assertPublicSurfacesExcludeService(agent, serviceId, slug);
 
   const republishRes = await agent.put(`/api/service/${serviceId}`).send({ isPublished: true });
   assert.equal(republishRes.status, 200);
+  assert.equal(republishRes.body.data.publication.isPubliclyVisible, true);
+
+  await assertPublicSurfacesIncludeService(agent, serviceId, slug);
 
   const serviceCount = await Service.countDocuments({ businessId: business._id });
   assert.equal(serviceCount, 1);
@@ -109,10 +157,79 @@ test('service publication flow: draft private, publish public list + detail, unp
   const retryCreate = await agent.post('/api/service/').send({
     ...canonicalChildPayload,
     businessId: business._id,
-    categoryId: category._id,
-    subcategoryId: subcategory._id,
+    categoryId: createRes.body.data.service.categoryId,
+    subcategoryId: createRes.body.data.service.subcategoryId,
   });
   assert.equal(retryCreate.status, 409);
+});
+
+test('createService with isPublished true appears on public surfaces immediately', async () => {
+  const agent = createAgent(getApp());
+  const { createRes, serviceId, slug } = await setupVendorWithService(agent, {
+    isPublished: true,
+  });
+
+  assert.equal(createRes.status, 201);
+  assert.equal(createRes.body.data.publication.isPublished, true);
+  assert.equal(createRes.body.data.publication.isPubliclyVisible, true);
+
+  await assertPublicSurfacesIncludeService(agent, serviceId, slug);
+});
+
+test('vendor cannot mutate another vendor service', async () => {
+  const agentA = createAgent(getApp());
+  const agentB = createAgent(getApp());
+
+  const setupA = await setupVendorWithService(agentA, { isPublished: false });
+  assert.equal(setupA.createRes.status, 201);
+
+  const vendorB = await registerAndVerify(agentB, { role: 'business_owner' });
+  await login(agentB, vendorB.email, vendorB.password);
+
+  const mutateRes = await agentB.put(`/api/service/${setupA.serviceId}`).send({ isPublished: true });
+  assert.equal(mutateRes.status, 404);
+
+  const deleteRes = await agentB.delete(`/api/service/delete-service/${setupA.serviceId}`);
+  assert.equal(deleteRes.status, 404);
+
+  const ownerRead = await agentA.get(`/api/service/${setupA.serviceId}`);
+  assert.equal(ownerRead.status, 200);
+  assert.equal(ownerRead.body.data.publication.isPublished, false);
+});
+
+test('published service on inactive business is hidden from public surfaces', async () => {
+  const agent = createAgent(getApp());
+  const { serviceId, slug } = await setupVendorWithService(agent, {
+    isPublished: true,
+    businessOverrides: { isActive: false },
+  });
+
+  const ownerRead = await agent.get(`/api/service/${serviceId}`);
+  assert.equal(ownerRead.status, 200);
+  assert.equal(ownerRead.body.data.publication.isPublished, true);
+  assert.equal(ownerRead.body.data.publication.isPubliclyVisible, false);
+  assert.equal(ownerRead.body.data.publication.visibilityReason, 'BUSINESS_INACTIVE');
+
+  await assertPublicSurfacesExcludeService(agent, serviceId, slug);
+});
+
+test('private service slug route returns only owner-owned services', async () => {
+  const agentA = createAgent(getApp());
+  const agentB = createAgent(getApp());
+
+  const setupA = await setupVendorWithService(agentA, { isPublished: false });
+  assert.equal(setupA.createRes.status, 201);
+  assert.ok(setupA.slug);
+
+  const ownerSlug = await agentA.get(`/api/private/services/${setupA.slug}`);
+  assert.equal(ownerSlug.status, 200);
+  assert.equal(String(ownerSlug.body.data.service._id), setupA.serviceId);
+
+  const vendorB = await registerAndVerify(agentB, { role: 'business_owner' });
+  await login(agentB, vendorB.email, vendorB.password);
+
+  const otherOwnerSlug = await agentB.get(`/api/private/services/${setupA.slug}`);
+  assert.equal(otherOwnerSlug.status, 404);
 });
 
 test('createService rejects missing child price and duration with field errors', async () => {


### PR DESCRIPTION
## Summary

- Scope GET /api/private/services/:slug to authenticated owner (ownerId filter) — fixes cross-vendor slug read leak
- Extend service-publication.integration.test.js to cover publish-on-create, my-services inventory, slug/business-service public surfaces, cross-vendor mutation 404, inactive business visibility, republish, and private slug ownership
- Add canonical contract doc: docs/SERVICE_PUBLICATION_CONTRACT.md
- Update docs/SERVICE_PUBLICATION_VISIBILITY_PROOF.md with PR #108 merge history and verification branch evidence

**Frontend dependency:** [mosaic-biz-frontend-launch PR #186](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/pull/186) / issue #185

Core Model A contract landed in merged [#108](https://github.com/Techware-Hut/mosaic-backend/pull/108); this branch closes verification gaps only. No Stripe, webhook, or middleware changes.

## Test plan

- [x] 
pm test — 321 pass, 0 fail
- [x] 
pm run test:integration — 34 pass, 0 fail (6 service-publication tests)
- [x] 
ode --test tests/service/service-*.test.js — 13 pass, 0 fail
- [x] 
ode --check on modified controllers
- [x] Health probes via harness: GET /, GET /api/health, GET /api/ready — 200
- [ ] Post-deploy smoke: scripts/service-publication-smoke.ps1 (requires session env vars)

## Deploy verdict

**Safe to deploy for frontend PR #186 validation** after merge and post-deploy smoke (public list + detail visibility). Integration tests do not replace runtime verification on production API.

Made with [Cursor](https://cursor.com)