### PR TITLE
Align marketplace vendor eligibility

### DIFF
--- a/controllers/admin/business.Controller.js
+++ b/controllers/admin/business.Controller.js
@@ -10,6 +10,9 @@ const {
   recordAdminAuditFailure,
   buildFieldChangeSummary,
 } = require("../../services/adminAuditService");
+const {
+  isPublicMarketplaceBusiness,
+} = require("../../lib/marketplace/businessEligibility");
 
 const parseBoolean = (value) => {
   if (value === true || value === "true" || value === 1 || value === "1") return true;
@@ -94,7 +97,7 @@ exports.toggleBusinessStatus = async (req, res) => {
       return res.status(404).json({ success: false, message: "Business not found." });
     }
 
-    const nextIsApproved = !business.isApproved;
+    const nextIsApproved = true;
     const previousIsApproved = business.isApproved;
     const previousIsActive = business.isActive;
 
@@ -127,7 +130,7 @@ exports.toggleBusinessStatus = async (req, res) => {
 
     await business.save();
 
-    const statusText = nextIsApproved ? "approved and activated" : "disapproved and deactivated";
+    const statusText = "approved and activated";
 
     // ---- Email to both owner and business email (deduped) ----
     try {
@@ -179,6 +182,7 @@ exports.toggleBusinessStatus = async (req, res) => {
       success: true,
       message: `Business has been ${statusText} successfully.`,
       data: business,
+      publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
     });
   } catch (error) {
     console.error(error);
@@ -270,10 +274,16 @@ exports.patchBusinessActivationStatus = async (req, res) => {
       note: remark || null,
     });
 
+    const publicMarketplaceEligible = isPublicMarketplaceBusiness(business);
+    const activationMessage = nextIsActive && !publicMarketplaceEligible
+      ? "Business has been activated, but it will remain hidden until it is approved."
+      : `Business has been ${nextIsActive ? "activated" : "deactivated"} successfully.`;
+
     return res.status(200).json({
       success: true,
-      message: `Business has been ${nextIsActive ? "activated" : "deactivated"} successfully.`,
+      message: activationMessage,
       data: business,
+      publicMarketplaceEligible,
     });
   } catch (error) {
     console.error(error);

--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -24,7 +24,7 @@ const PENDING_REVIEW_STATUSES = Object.freeze(['submitted']);
 
 exports.PENDING_REVIEW_STATUSES = PENDING_REVIEW_STATUSES;
 
-const syncBusinessPoints = async (application, badge) => {
+const syncBusinessPoints = async (application, badge, options = {}) => {
   const ownerId = application.userId?._id || application.userId;
   const update = {
     points: application.totalVerificationPoints,
@@ -32,6 +32,10 @@ const syncBusinessPoints = async (application, badge) => {
 
   if (badge !== undefined) {
     update.badge = badge;
+  }
+
+  if (options.isApproved !== undefined) {
+    update.isApproved = options.isApproved;
   }
 
   await Business.findOneAndUpdate(
@@ -590,7 +594,9 @@ exports.finalizeVerification = async (req, res) => {
     await application.save();
 
     // ✅ Sync business
-    await syncBusinessPoints(application, badge);
+    await syncBusinessPoints(application, badge, {
+      isApproved: application.status === 'verified',
+    });
 
     const vendorEmail = application.userId?.email;
     const vendorName = application.userId?.name;

--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -14,6 +14,9 @@ const {
   serializeTaxSettings,
 } = require("../utils/vendorTax");
 const { toPublicBusinessCard } = require("../lib/listing/publicListingDto");
+const {
+  publicMarketplaceBusinessFilter,
+} = require("../lib/marketplace/businessEligibility");
 
 exports.createBusiness = async (req, res) => {
   try {
@@ -772,11 +775,9 @@ exports.getProductBusinesses = async (req, res) => {
       limit = 10,
     } = req.query;
 
-    const filters = {
+    const filters = publicMarketplaceBusinessFilter({
       listingType: "product",
-      isActive: true,
-      isApproved: true,
-    };
+    });
 
     if (search) filters.businessName = { $regex: search, $options: "i" };
     if (city) filters["address.city"] = city;
@@ -894,6 +895,7 @@ exports.getBusinessBySlugPublic = async (req, res) => {
     const business = await Business.findOne({
       slug,
       isActive: true,
+      isApproved: true,
       listingType: "product", // ✅ Only product businesses
     })
       .select(

--- a/controllers/customer/cartController.js
+++ b/controllers/customer/cartController.js
@@ -13,6 +13,10 @@ const {
     buildTaxAwareAmounts,
     extractTaxFromInclusiveAmount,
 } = require('../../utils/vendorTax');
+const {
+    getPublicMarketplaceBusinessBlock,
+    isPublicMarketplaceBusiness,
+} = require('../../lib/marketplace/businessEligibility');
 
 const toNum = (value) => {
     if (value && typeof value === 'object' && value.$numberDecimal != null) {
@@ -263,6 +267,18 @@ const addItemToCart = async (req, res) => {
 
         // Determine business via product (safer)
         const businessId = product.businessId;
+        const business = await Business.findById(businessId)
+            .select('isApproved isActive businessName')
+            .lean();
+        const marketplaceBlock = getPublicMarketplaceBusinessBlock(business, {
+            ineligibleMessage:
+                'This vendor is not approved and active for the public marketplace.',
+        });
+        if (marketplaceBlock) {
+            return res.status(marketplaceBlock.status).json({
+                message: marketplaceBlock.message,
+            });
+        }
 
         // Find or create user's cart
         let cart = await Cart.findOne({ userId: req.user._id });
@@ -366,13 +382,30 @@ const getCart = async (req, res) => {
             });
         }
 
-        const businessDoc = cart.businessId
-            ? await Business.findById(cart.businessId)
-                .select('businessName slug shippingSettings taxSettings owner')
+        const cartBusinessIds = [...new Set(
+            [
+                cart.businessId,
+                ...(Array.isArray(cart.items) ? cart.items.map((item) => item.businessId) : []),
+            ]
+                .filter(Boolean)
+                .map(String)
+        )];
+
+        const businesses = cartBusinessIds.length
+            ? await Business.find({ _id: { $in: cartBusinessIds } })
+                .select('businessName slug shippingSettings taxSettings owner isApproved isActive')
                 .lean()
+            : [];
+
+        const businessById = new Map(
+            businesses.map((business) => [String(business._id), business])
+        );
+        const businessDoc = cart.businessId
+            ? businessById.get(String(cart.businessId)) || null
             : null;
 
-        const invalidItems = []; // To track invalid items removed from the cart
+        const invalidItems = [];
+        const removedItems = [];
 
         // Map the cart items to include only the necessary data for the frontend
         const cartItems = cart.items.map(cartItem => {
@@ -383,13 +416,37 @@ const getCart = async (req, res) => {
             if (!product || !variant) {
                 // If the product or variant is invalid, remove the cart item
                 invalidItems.push(cartItem._id);  // Track the invalid item
+                removedItems.push({
+                    cartItemId: cartItem._id,
+                    productId: cartItem.productId?._id || cartItem.productId || null,
+                    reason: 'unavailable_listing',
+                });
                 return null; // Return null to exclude this item from the response
+            }
+
+            const itemBusiness = businessById.get(String(cartItem.businessId || cart.businessId));
+            if (!isPublicMarketplaceBusiness(itemBusiness)) {
+                invalidItems.push(cartItem._id);
+                removedItems.push({
+                    cartItemId: cartItem._id,
+                    productId: product._id,
+                    businessId: cartItem.businessId,
+                    reason: 'ineligible_vendor',
+                    message: 'Vendor is not approved and active for the public marketplace.',
+                });
+                return null;
             }
 
             const selectedVariant = resolveVariantSelection(variant, cartItem.variant);
             if (!selectedVariant) {
                 // If size not found in the variant, remove the cart item
                 invalidItems.push(cartItem._id);
+                removedItems.push({
+                    cartItemId: cartItem._id,
+                    productId: product._id,
+                    businessId: cartItem.businessId,
+                    reason: 'unavailable_variant_selection',
+                });
                 return null; // Exclude this item from the response
             }
 
@@ -463,12 +520,21 @@ const getCart = async (req, res) => {
             };
         });
 
+        const items = cartItems.filter(item => item !== null);
+        const totalItems = items.reduce((sum, item) => sum + (Number(item.quantity) || 0), 0);
+
         // Remove invalid items from the cart
         if (invalidItems.length > 0) {
             await CartItem.deleteMany({ _id: { $in: invalidItems } });  // Remove invalid items
+            await Cart.updateOne(
+                { _id: cart._id },
+                {
+                    $pull: { items: { $in: invalidItems } },
+                    $set: { totalItems },
+                }
+            );
         }
 
-        const items = cartItems.filter(item => item !== null);
         const pricing = await buildCartPricing({
             cartDoc: cart,
             items,
@@ -476,11 +542,21 @@ const getCart = async (req, res) => {
             businessDoc,
         });
 
+        const removedForIneligibleVendor = removedItems.some(
+            (item) => item.reason === 'ineligible_vendor'
+        );
+
         return res.status(200).json({
-            message: invalidItems.length > 0 ? 'Some items were removed from the cart as they were unpublished or deleted.' : 'Cart retrieved successfully',
+            message: invalidItems.length > 0
+                ? (removedForIneligibleVendor
+                    ? 'Some items were removed from the cart because their vendor is no longer approved and active.'
+                    : 'Some items were removed from the cart as they were unpublished or deleted.')
+                : 'Cart retrieved successfully',
             cart: {
                 ...cart.toObject(),
                 items,  // Filter out the null values (removed items)
+                totalItems,
+                removedItems,
                 pricing,
             },
         });

--- a/controllers/featuredProducts.controller.js
+++ b/controllers/featuredProducts.controller.js
@@ -1,11 +1,16 @@
 const Product = require('../models/Product');
 const Business = require('../models/Business');
 const { toPublicListingCard } = require('../lib/listing/publicListingDto');
+const {
+  publicMarketplaceBusinessFilter,
+} = require('../lib/marketplace/businessEligibility');
 
 const FEATURED_MAX_LIMIT = 50;
 
 async function getVisibleBusinessIds() {
-  const businesses = await Business.find({ isActive: true }).select('_id').lean();
+  const businesses = await Business.find(
+    publicMarketplaceBusinessFilter()
+  ).select('_id').lean();
   return businesses.map((business) => business._id);
 }
 

--- a/controllers/productListingController.js
+++ b/controllers/productListingController.js
@@ -8,6 +8,9 @@ const ProductSubcategory = require('../models/ProductSubcategory');
 const Product = require('../models/Product');
 const Business = require('../models/Business');
 const { toPublicListingCard } = require('../lib/listing/publicListingDto');
+const {
+  publicMarketplaceBusinessFilter,
+} = require('../lib/marketplace/businessEligibility');
 
 // tiny helper: clip a number into a safe range (with default)
 const clip = (n, lo, hi, d) => {
@@ -17,9 +20,9 @@ const clip = (n, lo, hi, d) => {
 };
 
 async function getVisibleBusinessIds() {
-  const businesses = await Business.find({
-    isActive: true,
-  })
+  const businesses = await Business.find(
+    publicMarketplaceBusinessFilter()
+  )
     .select('_id')
     .lean();
 
@@ -121,6 +124,7 @@ async function listProductsRanked(req, res) {
         $match: {
           'business.listingType': listingType,
           'business.isActive': true,
+          'business.isApproved': true,
         }
       });
     }
@@ -130,6 +134,7 @@ async function listProductsRanked(req, res) {
       pipeline.push({
         $match: {
           'business.isActive': true,
+          'business.isApproved': true,
           $or: [
             { 'business.address.city': new RegExp(location, 'i') },
             { 'business.address.state': new RegExp(location, 'i') }
@@ -151,6 +156,7 @@ async function listProductsRanked(req, res) {
       pipeline.push({
         $match: {
           'business.isActive': true,
+          'business.isApproved': true,
           'minorityTypeData.name': new RegExp(minority.replace('-', ' '), 'i')
         }
       });

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -28,11 +28,14 @@ const {
   mergeBusinessIdFilter,
   buildKeywordRegex,
 } = require('../lib/listing/publicSearchFilters');
+const {
+  publicMarketplaceBusinessFilter,
+} = require('../lib/marketplace/businessEligibility');
 
 const getVisibleBusinessIds = async () => {
-  const businesses = await Business.find({
-    isActive: true,
-  }).select('_id').lean();
+  const businesses = await Business.find(
+    publicMarketplaceBusinessFilter()
+  ).select('_id').lean();
 
   return businesses.map((business) => business._id.toString());
 };
@@ -80,7 +83,7 @@ async function mapProductsWithBusinessMeta(products, listingType = 'product') {
   const [verifiedMap, tagsMap, businesses] = await Promise.all([
     loadVerifiedByBusinessIds(businessIds),
     loadTagsByBusinessIds(businessIds),
-    Business.find({ _id: { $in: businessIds }, isActive: true })
+    Business.find(publicMarketplaceBusinessFilter({ _id: { $in: businessIds } }))
       .select('_id badge tags')
       .lean(),
   ]);
@@ -227,10 +230,9 @@ exports.getAllServices = async (req, res) => {
         .filter(Boolean)
         .map((value) => badgeValueMap[value] || value);
 
-      const badgeBusinesses = await Business.find({
-        isActive: true,
-        badge: { $in: requestedBadges }
-      }).select('_id').lean();
+      const badgeBusinesses = await Business.find(
+        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
+      ).select('_id').lean();
 
       const badgeBusinessIds = badgeBusinesses.map((b) => b._id.toString());
 
@@ -281,10 +283,9 @@ exports.getAllServices = async (req, res) => {
         .filter(Boolean)
     )];
 
-    const serviceBusinesses = await Business.find({
-      _id: { $in: serviceBusinessIds },
-      isActive: true,
-    })
+    const serviceBusinesses = await Business.find(
+      publicMarketplaceBusinessFilter({ _id: { $in: serviceBusinessIds } })
+    )
       .select('_id businessName description logo email phone address socialLinks badge')
       .lean();
 
@@ -365,10 +366,9 @@ exports.getServiceBySlug = async (req, res) => {
       return res.status(404).json({ success: false, message: 'Service not found' });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: service.businessId,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: service.businessId })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({ success: false, message: 'Service not found' });
@@ -434,10 +434,9 @@ exports.getServiceById = async (req, res) => {
       });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: service.businessId?._id,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: service.businessId?._id })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({
@@ -658,10 +657,9 @@ exports.getAllFood = async (req, res) => {
         .filter(Boolean)
         .map((value) => badgeValueMap[value] || value);
 
-      const badgeBusinesses = await Business.find({
-        isActive: true,
-        badge: { $in: requestedBadges }
-      }).select('_id').lean();
+      const badgeBusinesses = await Business.find(
+        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
+      ).select('_id').lean();
 
       const badgeBusinessIds = badgeBusinesses.map((b) => b._id);
 
@@ -747,10 +745,9 @@ exports.getFoodById = async (req, res) => {
       });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: food.businessId?._id,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: food.businessId?._id })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({
@@ -1126,10 +1123,9 @@ if (price) {
         .filter(Boolean)
         .map((value) => badgeValueMap[value] || value);
 
-      const badgeBusinesses = await Business.find({
-        isActive: true,
-        badge: { $in: requestedBadges }
-      }).select('_id').lean();
+      const badgeBusinesses = await Business.find(
+        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
+      ).select('_id').lean();
 
       const badgeBusinessIds = badgeBusinesses.map((b) => b._id.toString());
 
@@ -1361,12 +1357,16 @@ exports.getProductsByFilters = async (req, res) => {
 
 
 
-// Route: /api/products/:productId
+// Route: /api/public/product/:productId
 exports.getProductById = async (req, res) => {
   try {
     const { productId } = req.params;
 
-    const product = await Product.findById(productId)
+    const product = await Product.findOne({
+      _id: productId,
+      isPublished: true,
+      isDeleted: false,
+    })
       .populate({
         path: "businessId",
         select: "businessName owner taxSettings"
@@ -1380,10 +1380,9 @@ exports.getProductById = async (req, res) => {
       });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: product.businessId?._id,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: product.businessId?._id })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({
@@ -1553,10 +1552,9 @@ exports.getVendorProfile = async (req, res) => {
   try {
     const { businessId } = req.params;
 
-    const business = await Business.findOne({
-      _id: businessId,
-      isActive: true,
-    })
+    const business = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: businessId })
+    )
     .select('businessName description logo coverImage email phone address socialLinks website listingType badge metrics businessHours')
     .lean();
 
@@ -1595,10 +1593,9 @@ exports.getProductsByBusinessId = async (req, res) => {
     const { businessId } = req.params;
     const { page = 1, limit = 10, sort } = req.query;
 
-    const visibleBusiness = await Business.findOne({
-      _id: businessId,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: businessId })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.json({

--- a/docs/MARKETPLACE_VENDOR_ELIGIBILITY.md
+++ b/docs/MARKETPLACE_VENDOR_ELIGIBILITY.md
@@ -1,0 +1,86 @@
+# Marketplace Vendor Eligibility
+
+**Type:** Source of truth  
+**Last updated:** 2026-06-23  
+**Frontend mirror:** `Digital-Builders-757/mosaic-biz-frontend-launch/docs/MARKETPLACE_VENDOR_ELIGIBILITY.md`
+
+This document explains the difference between admin business status and public marketplace visibility.
+
+## Rule
+
+A business is public on Mosaic only when both flags are true:
+
+```js
+business.isApproved === true && business.isActive === true
+```
+
+Backend helper:
+
+- `lib/marketplace/businessEligibility.js`
+- `isPublicMarketplaceBusiness(business)`
+- `publicMarketplaceBusinessFilter(extra)`
+
+## Status Meanings
+
+| State | Field(s) | Effect |
+| --- | --- | --- |
+| Approved | `Business.isApproved` | Vendor application/admin approval is complete |
+| Admin active | `Business.isActive` | Admin has not disabled the business record |
+| Public on marketplace | `isApproved && isActive` | Business and listings may appear on public marketplace surfaces |
+| Checkout ready | Public on marketplace + Stripe Connect ready | Orders can be initiated and paid |
+
+`isActive` alone does not list a vendor publicly. `isApproved` alone does not override deactivation.
+
+## Enforced Backend Surfaces
+
+| Endpoint | Controller | Behavior |
+| --- | --- | --- |
+| `GET /api/business` | `controllers/businessController.js` | Returns only eligible product businesses |
+| `GET /api/products/list` | `controllers/publicListing.js` | Products must be published, not deleted, and owned by an eligible business |
+| `GET /api/ranked` | `controllers/productListingController.js` | Ranked feed is scoped to eligible businesses |
+| `GET /api/public/search` | `controllers/publicListing.js`, `lib/listing/publicSearchFilters.js` | Search filters are intersected with eligible business IDs |
+| `GET /api/public/product/:id` | `controllers/publicListing.js` | 404 for unpublished/deleted products or ineligible businesses |
+| `GET /api/public/products/business/:businessId` | `controllers/publicListing.js` | Empty list for ineligible business IDs |
+| `GET /api/public/product/vendor-profile/:businessId` | `controllers/publicListing.js` | 404 for ineligible business IDs |
+| `GET /api/featured-products` | `controllers/featuredProducts.controller.js` | Preserves `{ products, pagination }`; excludes ineligible business products |
+| `POST /api/cart/add` | `controllers/customer/cartController.js` | 403 with clear message for ineligible vendors |
+| `GET /api/cart` | `controllers/customer/cartController.js` | Removes stale lines for unavailable listings or ineligible vendors |
+| `POST /api/orders/initiate` | `controllers/orderController.js` | Checks eligibility, then Stripe Connect readiness |
+
+## Admin Flow
+
+| Action | Backend behavior |
+| --- | --- |
+| Stage-1 finalize approved | Sets onboarding `status: "verified"` and syncs `Business.isApproved = true` when a Business exists |
+| Stage-1 finalize rejected | Sets onboarding `status: "rejected"` and syncs `Business.isApproved = false` when a Business exists |
+| `POST /admin/api/business/approve/:id` | Idempotently sets `isApproved = true` and `isActive = true` after `onboardingStatus === "completed"` |
+| `PATCH /admin/api/business/status/:id` | Updates `isActive` only; returns `publicMarketplaceEligible` so admins can see activation is not approval |
+
+## Customer Messages
+
+Cart add:
+
+```text
+This vendor is not approved and active for the public marketplace.
+```
+
+Cart read after stale line cleanup:
+
+```text
+Some items were removed from the cart because their vendor is no longer approved and active.
+```
+
+Order initiate:
+
+```text
+This vendor is not approved and active for checkout.
+```
+
+## QA Checklist
+
+1. Business with `isActive: true`, `isApproved: false` is hidden from directory, list, search, ranked, featured, product detail, vendor profile, and storefront products.
+2. `POST /api/cart/add` rejects that business's product.
+3. `GET /api/cart` removes any stale lines for that business.
+4. Admin activation leaves `isApproved: false` and `publicMarketplaceEligible: false`.
+5. Admin approve sets `isApproved: true` and `isActive: true`.
+6. Eligible vendor with Stripe Connect ready can still initiate checkout.

--- a/docs/MARKETPLACE_VISIBILITY_MATRIX.md
+++ b/docs/MARKETPLACE_VISIBILITY_MATRIX.md
@@ -1,122 +1,65 @@
-# Marketplace Visibility Matrix (Issue #77)
+# Marketplace Visibility Matrix
 
-**Date:** 2026-06-18  
-**Branch:** `sprint/backend-deploy-smoke-sentry-18-27`  
-**Related:** [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md), [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md)
+**Type:** Reference
+**Last updated:** 2026-06-23
+**Source of truth:** [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md), [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md)
 
----
+This matrix summarizes the backend fields that gate public browse, search, featured, ranked, detail, cart, and checkout visibility.
 
-## Purpose
+## Core Fields
 
-Document which listing and business fields gate **browse**, **search**, **featured**, **ranked**, **detail**, and **checkout** visibility for public marketplace APIs.
-
----
-
-## Core visibility fields
-
-| Field | Model | Meaning | Public browse/search |
-| --- | --- | --- | --- |
-| `Business.isActive` | `Business` | Vendor business enabled for marketplace | **Required** — inactive businesses excluded from all public lists |
-| `Product.isPublished` | `Product` | Vendor published listing | **Required** for product lists, search, featured, ranked, detail |
-| `Product.isDeleted` | `Product` | Soft delete | **Excluded** when `true` |
-| `Product.isFeatured` | `Product` | Featured carousel flag | Required only on `/api/featured-products` |
-| `Service.isPublished` | `Service` | Service listing published | **Required** for service lists and search |
-| `Food.isPublished` | `Food` | Food listing published | **Required** for food lists and search |
-| `Food.isDeleted` | `Food` | Soft delete | **Excluded** when `true` |
-| `VendorOnboardingStage1.status` | Onboarding | `verified` = admin approved Stage 1 | Used for **verified badge** in search metadata, not a hard list filter |
-| `Business.isApproved` | `Business` | Legacy/admin approval flag | **Not** used as primary public list gate (active + published drive browse) |
-
-**Checkout / payment** is out of scope for this matrix — governed by cart, order, and Stripe Connect routes with separate auth and business rules.
-
----
-
-## Visibility by surface
-
-### Browse lists (`controllers/publicListing.js`)
-
-| Endpoint | Route | Listing filters | Business scope |
-| --- | --- | --- | --- |
-| Services list | `GET /api/services/list` | `isPublished: true` | `getVisibleBusinessIds()` → `Business.isActive: true` |
-| Products list | `GET /api/products/list` | `isPublished: true`, `isDeleted: false` | Active businesses only |
-| Food list | `GET /api/food/list` | `isPublished: true`, `isDeleted: false` | Active businesses only |
-| Products by business | `GET /api/products/business/:businessId` | `isPublished: true`, `isDeleted: false` | Target business must be `isActive: true` |
-| Vendor profile | `GET /api/vendor/:businessId` | N/A (business card) | `isActive: true` or 404 |
-
-Helper: `getVisibleBusinessIds()` in [`controllers/publicListing.js`](../controllers/publicListing.js) loads all `Business.find({ isActive: true })`.
-
-### Unified search
-
-| Endpoint | Route | Rules |
+| Field | Model | Public behavior |
 | --- | --- | --- |
-| Public search | `GET /api/public/search` | `parsePublicSearchQuery()` caps `limit` at 50; intersects keyword/location/tag/verified filters with active businesses; each listing type requires `isPublished` (+ `isDeleted: false` for products/food) |
+| `Business.isApproved` | `Business` | Required for all public marketplace business/listing surfaces |
+| `Business.isActive` | `Business` | Required for all public marketplace business/listing surfaces |
+| `Product.isPublished` | `Product` | Required for public product list/detail/search/featured/ranked |
+| `Product.isDeleted` | `Product` | Excluded when `true` |
+| `Product.isFeatured` | `Product` | Required only for `GET /api/featured-products` |
+| `Service.isPublished` | `Service` | Required for public service list/detail/search |
+| `Food.isPublished` | `Food` | Required for public food list/detail/search |
+| `Food.isDeleted` | `Food` | Excluded when `true` |
+| `VendorOnboardingStage1.status` | Onboarding | Used for verified metadata/filtering, not a replacement for `Business.isApproved` |
 
-Verified filter uses `VendorOnboardingStage1.status === 'verified'` — narrows **business IDs**, not individual listing publish flags.
+Public business eligibility is centralized in `lib/marketplace/businessEligibility.js`.
 
-### Featured feed
+## Public Surfaces
 
-| Endpoint | Route | Rules |
+| Endpoint | Listing filters | Business scope |
 | --- | --- | --- |
-| Featured products | `GET /api/featured-products` | `isFeatured: true`, `isPublished: true`, `isDeleted: false`, `businessId ∈ active businesses` |
+| `GET /api/business` | `listingType: "product"` | `isApproved: true`, `isActive: true` |
+| `GET /api/products/list` | `isPublished: true`, `isDeleted: false` | Eligible businesses only |
+| `GET /api/ranked` | `isPublished: true`, `isDeleted: false` | Eligible businesses only |
+| `GET /api/public/search` | Published listings; products exclude deleted | Search filters intersect eligible businesses |
+| `GET /api/public/product/:id` | `isPublished: true`, `isDeleted: false` | 404 when business is ineligible |
+| `GET /api/public/products/business/:businessId` | `isPublished: true`, `isDeleted: false` | Empty list when business is ineligible |
+| `GET /api/public/product/vendor-profile/:businessId` | Business card/profile | 404 when business is ineligible |
+| `GET /api/featured-products` | `isFeatured: true`, `isPublished: true`, `isDeleted: false` | Eligible businesses only; response wrapper unchanged |
 
-Implementation: [`controllers/featuredProducts.controller.js`](../controllers/featuredProducts.controller.js).
+## Cart And Checkout
 
-### Ranked / similar products
-
-| Endpoint | Route | Rules |
-| --- | --- | --- |
-| Ranked products | `GET /api/ranked` | `isPublished: true`, `isDeleted: false`, active business scope |
-| Similar products | `GET /api/:id/similar` | Same ranked handler via `attachSimilarQuery` |
-
-Implementation: [`controllers/productListingController.js`](../controllers/productListingController.js) — `listProductsRanked`.
-
-### Detail by ID / slug
-
-| Surface | Gate |
+| Endpoint | Eligibility behavior |
 | --- | --- |
-| Product by ID | Active business + published product |
-| Service by slug / ID | `isPublished: true` + active business |
-| Food by ID | Published + not deleted + active business |
+| `POST /api/cart/add` | Rejects products from ineligible vendors |
+| `GET /api/cart` | Removes stale ineligible vendor lines |
+| `POST /api/orders/initiate` | Requires eligible business, then Stripe Connect readiness |
 
-Unpublished or inactive-business listings return empty/404 — never leak draft content in public DTOs (`toPublicListingCard`).
+## Decision Matrix
 
----
+| Scenario | Browse/search | Featured | Cart add | Checkout |
+| --- | --- | --- | --- | --- |
+| Published product, approved + active business | Yes | Yes, if featured | Yes | Yes, if Connect ready |
+| Published product, active but unapproved business | No | No | No | No |
+| Published product, approved but inactive business | No | No | No | No |
+| Unpublished product, approved + active business | No | No | No | No |
+| Deleted product, approved + active business | No | No | No | No |
 
-## Decision matrix (quick reference)
+## Tests
 
-| Scenario | Visible in browse/search? | Visible in featured? | Visible in ranked? |
-| --- | --- | --- | --- |
-| Published product, active business | Yes | Only if `isFeatured` | Yes |
-| Unpublished product, active business | No | No | No |
-| Published product, inactive business | No | No | No |
-| Draft vendor onboarding, no listings | No | No | No |
-| Verified badge, unpublished listing | No (badge irrelevant until published) | No | No |
-
----
-
-## Automated test coverage
-
-| Test file | What it proves |
+| Test file | Coverage |
 | --- | --- |
-| [`tests/marketplace/featured-products-response.test.js`](../tests/marketplace/featured-products-response.test.js) | Featured query scopes to active businesses; limit capped at 50; DTO mapping |
-| [`tests/marketplace/ranked-products-visibility.test.js`](../tests/marketplace/ranked-products-visibility.test.js) | Ranked feed excludes unpublished / inactive-business products |
-| [`tests/marketplace/public-search-filters.test.js`](../tests/marketplace/public-search-filters.test.js) | Search filter parsing, limit cap 50, verified/location helpers |
-| [`tests/marketplace/public-listing-dto.test.js`](../tests/marketplace/public-listing-dto.test.js) | Public card shape — no internal fields leaked |
-
-Deploy smoke: `GET /api/featured-products` included in `npm run smoke:backend` ([`docs/TEST_MATRIX.md`](TEST_MATRIX.md)).
-
----
-
-## Known gaps (document only — not launch blockers)
-
-| Gap | Tracking |
-| --- | --- |
-| No centralized visibility middleware — rules duplicated across controllers | Future refactor |
-| `Business.isApproved` not enforced on all public paths | Align with product policy if required |
-| Moderation / takedown workflow beyond `isActive` | Post-launch admin tooling (#34) |
-| Food/Service compound indexes for publish+delete queries | [#53](DATABASE_INDEX_AUDIT.md) |
-
----
-
-## Issue #77 resolution
-
-Acceptance criteria satisfied: visibility rules documented, mapped to source files, and linked to existing automated tests. No contract-breaking code changes required.
+| `tests/integration/marketplace.integration.test.js` | Ineligible vendor hidden from public surfaces, cart add rejected, stale cart line stripped, admin approve/activate semantics |
+| `tests/marketplace/featured-products-response.test.js` | Featured products scope by approved + active businesses while preserving wrapper |
+| `tests/marketplace/ranked-products-visibility.test.js` | Ranked products use approved + active business scope |
+| `tests/marketplace/public-search-filters.test.js` | Search business filters use approved + active business scope |
+| `tests/admin/vendor-onboarding-finalize.test.js` | Finalize syncs `Business.isApproved` |
+| `tests/stripe/order-initiate-connect.test.js` | Checkout blocks unapproved/inactive businesses and still requires Connect |

--- a/docs/PLATFORM_OPERATING_MODEL.md
+++ b/docs/PLATFORM_OPERATING_MODEL.md
@@ -1,0 +1,172 @@
+# Mosaic Biz Hub - Platform Operating Model
+
+**Type:** Source of truth  
+**Audience:** PM, QA, frontend, backend, stakeholders  
+**Last updated:** 2026-06-23  
+**Frontend mirror:** `Digital-Builders-757/mosaic-biz-frontend-launch/docs/PLATFORM_OPERATING_MODEL.md`
+
+This document describes what the platform is supposed to do. When older backend docs, route comments, or implementation details disagree with this file, treat this as the intended operating model and file or fix the defect.
+
+Related backend docs:
+
+- [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md)
+- [API_SURFACE.md](API_SURFACE.md)
+- [PAYMENT_FLOW.md](PAYMENT_FLOW.md)
+- [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md)
+- [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md)
+
+## One-Sentence Summary
+
+Mosaic Biz Hub is a managed multi-vendor marketplace where approved minority-owned businesses operate independent storefronts, customers discover and purchase from them, Stripe processes and routes payments, vendors fulfill their own orders, and admins govern trust, access, and marketplace activity.
+
+Mosaic is not a warehouse or shipping company. It is the digital shopping center, payment coordinator, and trust layer.
+
+## Roles
+
+| Role | Real-world equivalent | Backend anchors |
+| --- | --- | --- |
+| Customer | Shopper | `User.role = "customer"`, `/api/cart`, `/api/orders/*` |
+| Vendor (`business_owner`) | Independent shopkeeper | `User.role = "business_owner"`, `Business`, `VendorOnboardingStage1` |
+| Admin | Mall manager / trust officer | `User.role = "admin"`, `/admin/*`, `/admin/api/*`, `/api/admin/*` |
+| Backend API | Rules engine and ledger | Express routes, Mongoose models, Stripe webhooks |
+| Stripe | Cash register and payout network | PaymentIntents + Connect accounts |
+| Carrier | USPS, UPS, FedEx, courier | Outside Mosaic in MVP |
+
+## Commercial Heartbeat
+
+```text
+Vendor applies -> Admin approves -> Vendor completes profile
+  -> Vendor selects plan -> Vendor connects Stripe
+  -> Vendor creates listings -> Customer discovers listings
+  -> Customer adds to cart -> Backend creates order + PaymentIntent
+  -> Stripe confirms payment by webhook -> Vendor accepts order
+  -> Vendor ships + enters tracking -> Customer receives order
+```
+
+Products, services, and food share the marketplace shell but use different backend models and fulfillment flows. Do not assume product checkout proves service booking or food ordering.
+
+## Vendor Eligibility And Public Visibility
+
+A business is public on Mosaic only when:
+
+```js
+business.isApproved === true && business.isActive === true
+```
+
+Backend helper: `lib/marketplace/businessEligibility.js`.
+
+| Field | Meaning |
+| --- | --- |
+| `Business.isApproved` | Admin/application approval is complete |
+| `Business.isActive` | Admin has not disabled the business |
+| Both true | Business and listings may appear publicly |
+
+Admin "Active" alone does not mean public. Admin approval alone does not override deactivation.
+
+Public endpoints that enforce this rule:
+
+- `GET /api/business`
+- `GET /api/products/list`
+- `GET /api/ranked`
+- `GET /api/public/search`
+- `GET /api/public/product/:id`
+- `GET /api/public/products/business/:businessId`
+- `GET /api/public/product/vendor-profile/:businessId`
+- `GET /api/featured-products`
+- `POST /api/cart/add`
+- `GET /api/cart`
+
+Checkout additionally requires Stripe Connect readiness. Public listing does not require Connect; purchasability does.
+
+## Vendor Journey
+
+1. Register as `business_owner`.
+2. Complete Stage 1 application and upload documents.
+3. Pay the verification fee.
+4. Submit application (`POST /api/vendor-onboarding/submit`).
+5. Admin finalizes application.
+6. Approved vendors complete business profile, subscription, Stripe Connect, shipping, tax, and listings.
+
+On Stage-1 approval, backend stores `VendorOnboardingStage1.status = "verified"` and sets `Business.isApproved = true` when a linked business exists. Business activation remains separate.
+
+## Customer Journey
+
+1. Browse products, services, foods, vendors, search, ranked, and featured surfaces.
+2. View listing detail and vendor profile.
+3. Add items to cart. Checkout is single-vendor in the current implementation.
+4. Submit checkout. Backend validates stock, price, vendor eligibility, shipping, tax, and Connect readiness.
+5. Pay through Stripe Elements.
+6. Stripe webhook moves order from pending/created to paid/ordered.
+7. Track order as vendor accepts, ships, and enters tracking.
+
+The customer browser does not dictate final price. `POST /api/orders/initiate` recalculates and validates the order server-side.
+
+## Admin Journey
+
+Admins govern trust and marketplace operations. They do not sell inventory.
+
+| Area | Responsibility |
+| --- | --- |
+| Vendor applications | Review, approve/reject Stage 1 |
+| Businesses | Approve, activate/deactivate, investigate status mismatches |
+| Categories | Product, service, and food taxonomy |
+| Products | List, inspect, feature/unfeature |
+| Orders | View all orders and investigate payment/fulfillment issues |
+| Content | CMS pages, FAQs, testimonials |
+
+`POST /admin/api/business/approve/:id` is an idempotent approval action. It sets `isApproved: true` and `isActive: true` after onboarding is completed.
+
+`PATCH /admin/api/business/status/:id` changes `isActive` only. Activating an unapproved business leaves it hidden from public marketplace endpoints.
+
+## Shipping Model (MVP)
+
+Vendors set business-level shipping rates:
+
+- `GET /api/business/:id/shipping-settings`
+- `PUT /api/business/:id/shipping-settings`
+
+Supported systems:
+
+| System | Behavior |
+| --- | --- |
+| Flat rate | Same price for a selected delivery speed |
+| Quantity based | Tiered price by cart item count |
+
+For each system, vendors configure standard, express, and local rates plus optional free-shipping threshold. Mosaic does not buy shipping labels or calculate live USPS/UPS/FedEx rates in MVP. Vendors pack, ship, and enter tracking.
+
+## Orders And Payments
+
+Primary checkout route: `POST /api/orders/initiate`.
+
+Sequence:
+
+1. Customer sends checkout request.
+2. Backend validates cart items, stock, prices, vendor eligibility, Stripe Connect, shipping, and tax.
+3. Backend creates `Order` with pending payment state.
+4. Backend creates Stripe PaymentIntent with Connect destination.
+5. Frontend confirms payment with `clientSecret`.
+6. Stripe webhook `payment_intent.succeeded` marks orders paid/ordered.
+
+Product order status path:
+
+```text
+created -> ordered -> accepted -> shipped -> delivered
+```
+
+Alternate paths include `rejected`, `cancelled`, `returned`, and `refunded`.
+
+## API Path Conventions
+
+| Topic | Canonical path |
+| --- | --- |
+| Featured products | `GET /api/featured-products` |
+| Product CRUD router mount | `/api/product` (singular) |
+| Public product browse | `/api/products/list` (plural public browse route) |
+| Public vendor directory | `GET /api/business` |
+| Order initiation | `POST /api/orders/initiate` |
+
+Do not add or promote `/api/products/featured`; the canonical featured route is `GET /api/featured-products`.
+
+## Non-Goals
+
+This model does not change Stripe Connect onboarding routes, webhook handlers, payment webhook semantics, or the `GET /api/featured-products` response contract.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,22 @@ Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ---
 
+## Active Documentation
+
+Use this section before trusting older sprint, audit, or proof-pack docs.
+
+| Tier | Docs | Use for |
+| --- | --- | --- |
+| **Source of truth** | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md), [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md) | How the platform is supposed to work |
+| **Living** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md), [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Current ship state and next work |
+| **Reference** | [ARCHITECTURE.md](ARCHITECTURE.md), [API_SURFACE.md](API_SURFACE.md), [AUTH_FLOW.md](AUTH_FLOW.md), [PAYMENT_FLOW.md](PAYMENT_FLOW.md), [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Day-to-day development |
+| **Deep indexes** | [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md), [backend/BACKEND_ROUTE_REGISTRATION.md](backend/BACKEND_ROUTE_REGISTRATION.md), [backend/API_CONTRACT_AS_BUILT.md](backend/API_CONTRACT_AS_BUILT.md) | Route/API-level detail |
+| **Archive / evidence** | Proof packs, smoke docs, dated audits | Audit trail only; check source-of-truth and living docs before relying on them |
+
+Practical rule: if a behavior is not in the active source-of-truth docs, verify it against code and runtime before treating an older evidence doc as current.
+
+---
+
 ## Read first (by role)
 
 | If you are… | Read in this order |

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,22 @@
+# Backend Documentation Archive
+
+**Purpose:** dated QA proofs, smoke packs, sprint snapshots, and audit evidence.
+
+Files are not physically moved in this PR to avoid breaking links. Treat older proof and audit docs as historical evidence, not current operating rules. For current behavior, start with:
+
+- [../PLATFORM_OPERATING_MODEL.md](../PLATFORM_OPERATING_MODEL.md)
+- [../MARKETPLACE_VENDOR_ELIGIBILITY.md](../MARKETPLACE_VENDOR_ELIGIBILITY.md)
+- [../README.md](../README.md)
+
+## Archive Categories
+
+| Category | Existing locations |
+| --- | --- |
+| Launch and smoke proofs | `docs/*SMOKE*`, `docs/smoke/*`, `docs/*PROOF*`, `docs/*EVIDENCE*` |
+| Sprint and batch audits | `docs/*AUDIT*`, `docs/audit/*`, `docs/BACKEND_*BATCH*` |
+| As-built route/model snapshots | `docs/backend/*AS_BUILT*`, `docs/backend/*ROUTE*`, `docs/backend/*CONTRACT*` |
+| Deployment verification logs | `docs/*DEPLOY*`, `docs/deploy-verification.md` |
+
+## Rule
+
+If an archive/evidence doc conflicts with a source-of-truth doc or current code, trust source-of-truth plus runtime verification and update the stale doc or add an archive banner in the next documentation pass.

--- a/lib/listing/publicSearchFilters.js
+++ b/lib/listing/publicSearchFilters.js
@@ -6,6 +6,9 @@ const mongoose = require('mongoose');
 const Business = require('../../models/Business');
 const VendorOnboardingStage1 = require('../../models/VendorOnboardingStage1');
 const MinorityType = require('../../models/MinorityType');
+const {
+  publicMarketplaceBusinessFilter,
+} = require('../marketplace/businessEligibility');
 
 const GEO_UNSUPPORTED_KEYS = ['radius', 'lat', 'lng', 'nearMe', 'nearme', 'longitude', 'latitude'];
 
@@ -108,19 +111,32 @@ function shouldIncludeListingType(listingType, type) {
   return listingType === type;
 }
 
+async function filterPublicMarketplaceBusinessIds(ids = []) {
+  const objectIds = [...new Set(ids.map((id) => String(id)).filter(Boolean))]
+    .map((id) => toObjectId(id))
+    .filter(Boolean);
+
+  if (!objectIds.length) return [];
+
+  const businesses = await Business.find(
+    publicMarketplaceBusinessFilter({ _id: { $in: objectIds } })
+  ).select('_id').lean();
+
+  return businesses.map((business) => business._id);
+}
+
 async function resolveBusinessIdsByKeyword(keyword) {
   const keywordRegex = buildFlexibleMatchRegex(keyword);
   if (!keywordRegex) return [];
 
   const [businessMatches, vendorMatches] = await Promise.all([
-    Business.find({
-      isActive: true,
+    Business.find(publicMarketplaceBusinessFilter({
       $or: [
         { businessName: keywordRegex },
         { description: keywordRegex },
         { tags: keywordRegex },
       ],
-    }).select('_id').lean(),
+    })).select('_id').lean(),
     VendorOnboardingStage1.find({
       businessId: { $exists: true, $ne: null },
       $or: [
@@ -130,20 +146,28 @@ async function resolveBusinessIdsByKeyword(keyword) {
     }).select('businessId').lean(),
   ]);
 
-  return [...new Set([
+  const vendorBusinessIds = vendorMatches
+    .map((item) => item.businessId?.toString())
+    .filter(Boolean);
+  if (!vendorBusinessIds.length) {
+    return businessMatches.map((item) => item._id);
+  }
+
+  const ids = [...new Set([
     ...businessMatches.map((item) => item._id.toString()),
-    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
-  ])].map((id) => new mongoose.Types.ObjectId(id));
+    ...vendorBusinessIds,
+  ])];
+
+  return filterPublicMarketplaceBusinessIds(ids);
 }
 
 async function resolveBusinessIdsByTags(tag, tags) {
   const tagList = parseTagList(tag, tags);
   if (!tagList.length) return null;
 
-  const matches = await Business.find({
-    isActive: true,
+  const matches = await Business.find(publicMarketplaceBusinessFilter({
     $or: tagList.map((item) => ({ tags: new RegExp(`^${escapeRegex(item)}$`, 'i') })),
-  }).select('_id').lean();
+  })).select('_id').lean();
 
   return matches.map((business) => business._id);
 }
@@ -154,8 +178,9 @@ async function resolveVerifiedBusinessIds() {
     businessId: { $exists: true, $ne: null },
   }).select('businessId').lean();
 
-  return [...new Set(rows.map((row) => row.businessId?.toString()).filter(Boolean))]
-    .map((id) => new mongoose.Types.ObjectId(id));
+  return filterPublicMarketplaceBusinessIds(
+    rows.map((row) => row.businessId?.toString()).filter(Boolean)
+  );
 }
 
 async function resolveBusinessIdsByZip(zip) {
@@ -164,22 +189,28 @@ async function resolveBusinessIdsByZip(zip) {
 
   const zipRegex = new RegExp(`^${escapeRegex(normalizedZip)}$`, 'i');
   const [businessMatches, vendorMatches] = await Promise.all([
-    Business.find({
-      isActive: true,
+    Business.find(publicMarketplaceBusinessFilter({
       'address.zipCode': zipRegex,
-    }).select('_id').lean(),
+    })).select('_id').lean(),
     VendorOnboardingStage1.find({
       businessId: { $exists: true, $ne: null },
       'address.zipCode': zipRegex,
     }).select('businessId').lean(),
   ]);
 
+  const vendorBusinessIds = vendorMatches
+    .map((item) => item.businessId?.toString())
+    .filter(Boolean);
+  if (!vendorBusinessIds.length) {
+    return businessMatches.map((item) => item._id);
+  }
+
   const ids = [...new Set([
     ...businessMatches.map((item) => item._id.toString()),
-    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+    ...vendorBusinessIds,
   ])];
 
-  return ids.map((id) => new mongoose.Types.ObjectId(id));
+  return filterPublicMarketplaceBusinessIds(ids);
 }
 
 async function resolveBusinessIdsByDedicatedLocation({ city, state, country }) {
@@ -190,7 +221,7 @@ async function resolveBusinessIdsByDedicatedLocation({ city, state, country }) {
 
   if (!clauses.length) return null;
 
-  const businessFilter = { isActive: true, $and: clauses };
+  const businessFilter = publicMarketplaceBusinessFilter({ $and: clauses });
   const vendorFilter = {
     businessId: { $exists: true, $ne: null },
     $and: clauses.map((clause) => {
@@ -204,12 +235,19 @@ async function resolveBusinessIdsByDedicatedLocation({ city, state, country }) {
     VendorOnboardingStage1.find(vendorFilter).select('businessId').lean(),
   ]);
 
+  const vendorBusinessIds = vendorMatches
+    .map((item) => item.businessId?.toString())
+    .filter(Boolean);
+  if (!vendorBusinessIds.length) {
+    return businessMatches.map((item) => item._id);
+  }
+
   const ids = [...new Set([
     ...businessMatches.map((item) => item._id.toString()),
-    ...vendorMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+    ...vendorBusinessIds,
   ])];
 
-  return ids.map((id) => new mongoose.Types.ObjectId(id));
+  return filterPublicMarketplaceBusinessIds(ids);
 }
 
 async function resolveBusinessIdsForMinorityType(minorityType) {
@@ -233,22 +271,28 @@ async function resolveBusinessIdsForMinorityType(minorityType) {
     .map((id) => new mongoose.Types.ObjectId(id));
 
   const [businessMinorityMatches, vendorMinorityMatches] = await Promise.all([
-    Business.find({
-      isActive: true,
+    Business.find(publicMarketplaceBusinessFilter({
       ...(minorityTypeIds.length ? { minorityType: { $in: minorityTypeIds } } : { _id: null }),
-    }).select('_id').lean(),
+    })).select('_id').lean(),
     VendorOnboardingStage1.find({
       businessId: { $exists: true, $ne: null },
       minorityCategories: { $elemMatch: { $regex: minorityRegex } },
     }).select('businessId').lean(),
   ]);
 
+  const vendorBusinessIds = vendorMinorityMatches
+    .map((item) => item.businessId?.toString())
+    .filter(Boolean);
+  if (!vendorBusinessIds.length) {
+    return businessMinorityMatches.map((item) => item._id);
+  }
+
   const ids = [...new Set([
     ...businessMinorityMatches.map((item) => item._id.toString()),
-    ...vendorMinorityMatches.map((item) => item.businessId?.toString()).filter(Boolean),
+    ...vendorBusinessIds,
   ])];
 
-  return ids.map((id) => new mongoose.Types.ObjectId(id));
+  return filterPublicMarketplaceBusinessIds(ids);
 }
 
 async function resolveBusinessIdsByLocation({ location, city, state, country, zip }) {
@@ -266,8 +310,7 @@ async function resolveBusinessIdsByLocation({ location, city, state, country, zi
   if (locationText) {
     const locationRegex = buildFlexibleMatchRegex(locationText);
     const [businessLocationMatches, vendorLocationMatches] = await Promise.all([
-      Business.find({
-        isActive: true,
+      Business.find(publicMarketplaceBusinessFilter({
         $or: [
           { businessName: locationRegex },
           { 'address.street': locationRegex },
@@ -276,7 +319,7 @@ async function resolveBusinessIdsByLocation({ location, city, state, country, zi
           { 'address.country': locationRegex },
           { 'address.zipCode': locationRegex },
         ],
-      }).select('_id').lean(),
+      })).select('_id').lean(),
       VendorOnboardingStage1.find({
         businessId: { $exists: true, $ne: null },
         $or: [
@@ -290,10 +333,17 @@ async function resolveBusinessIdsByLocation({ location, city, state, country, zi
       }).select('businessId').lean(),
     ]);
 
-    sets.push([...new Set([
-      ...businessLocationMatches.map((item) => item._id.toString()),
-      ...vendorLocationMatches.map((item) => item.businessId?.toString()).filter(Boolean),
-    ])].map((id) => new mongoose.Types.ObjectId(id)));
+    const vendorBusinessIds = vendorLocationMatches
+      .map((item) => item.businessId?.toString())
+      .filter(Boolean);
+    if (!vendorBusinessIds.length) {
+      sets.push(businessLocationMatches.map((item) => item._id));
+    } else {
+      sets.push(await filterPublicMarketplaceBusinessIds([...new Set([
+        ...businessLocationMatches.map((item) => item._id.toString()),
+        ...vendorBusinessIds,
+      ])]));
+    }
   }
 
   if (!sets.length) return null;

--- a/lib/marketplace/businessEligibility.js
+++ b/lib/marketplace/businessEligibility.js
@@ -1,0 +1,48 @@
+const PUBLIC_MARKETPLACE_BUSINESS_FILTER = Object.freeze({
+  isApproved: true,
+  isActive: true,
+});
+
+const PUBLIC_MARKETPLACE_INELIGIBLE_MESSAGE =
+  'This vendor is not approved and active for the public marketplace.';
+
+function isPublicMarketplaceBusiness(business) {
+  return Boolean(
+    business &&
+    business.isApproved === true &&
+    business.isActive === true
+  );
+}
+
+function publicMarketplaceBusinessFilter(extra = {}) {
+  return {
+    ...extra,
+    ...PUBLIC_MARKETPLACE_BUSINESS_FILTER,
+  };
+}
+
+function getPublicMarketplaceBusinessBlock(business, options = {}) {
+  if (!business) {
+    return {
+      status: options.notFoundStatus || 404,
+      message: options.notFoundMessage || 'Vendor business not found.',
+    };
+  }
+
+  if (!isPublicMarketplaceBusiness(business)) {
+    return {
+      status: options.ineligibleStatus || 403,
+      message: options.ineligibleMessage || PUBLIC_MARKETPLACE_INELIGIBLE_MESSAGE,
+    };
+  }
+
+  return null;
+}
+
+module.exports = {
+  PUBLIC_MARKETPLACE_BUSINESS_FILTER,
+  PUBLIC_MARKETPLACE_INELIGIBLE_MESSAGE,
+  isPublicMarketplaceBusiness,
+  publicMarketplaceBusinessFilter,
+  getPublicMarketplaceBusinessBlock,
+};

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -30,7 +30,7 @@ const router = express.Router();
 // ============================================
 
 /**
- * @route   GET /api/products/upload-url
+ * @route   GET /api/product/upload-url
  * @desc    Get pre-signed URL for product image upload
  * @access  Private
  */
@@ -41,7 +41,7 @@ router.get(
 );
 
 /**
- * @route   GET /api/products/variant-upload-url
+ * @route   GET /api/product/variant-upload-url
  * @desc    Get pre-signed URL for variant image upload
  * @access  Private
  */
@@ -52,7 +52,7 @@ router.get(
 );
 
 /**
- * @route   GET /api/products/business/:businessId
+ * @route   GET /api/product/business/:businessId
  * @desc    Get all products for a business
  * @access  Private
  */
@@ -87,7 +87,7 @@ router.delete(
 // ============================================
 
 /**
- * @route   POST /api/products
+ * @route   POST /api/product
  * @desc    Create a new product with variants
  * @access  Private
  */
@@ -100,7 +100,7 @@ router.post(
 );
 
 /**
- * @route   GET /api/products/:productId
+ * @route   GET /api/product/:productId
  * @desc    Get single product by ID with all variants
  * @access  Private
  */
@@ -112,7 +112,7 @@ router.get(
 );
 
 /**
- * @route   PUT /api/products/:productId
+ * @route   PUT /api/product/:productId
  * @desc    Update a product
  * @access  Private
  */
@@ -124,7 +124,7 @@ router.put(
 );
 
 /**
- * @route   DELETE /api/products/delete-product/:productId
+ * @route   DELETE /api/product/delete-product/:productId
  * @desc    Soft delete a product and all its variants
  * @access  Private
  */
@@ -140,7 +140,7 @@ router.delete(
 // ============================================
 
 /**
- * @route   GET /api/products/get-variant/:productId/:variantId
+ * @route   GET /api/product/get-variant/:productId/:variantId
  * @desc    Get a single variant by ID
  * @access  Private
  */
@@ -152,7 +152,7 @@ router.get(
 );
 
 /**
- * @route   POST /api/products/add-variants/:productId
+ * @route   POST /api/product/add-variants/:productId
  * @desc    Add variants to an existing product
  * @access  Private
  */
@@ -165,7 +165,7 @@ router.post(
 );
 
 /**
- * @route   PUT /api/products/update-variant/:productId/:variantId
+ * @route   PUT /api/product/update-variant/:productId/:variantId
  * @desc    Update a specific variant
  * @access  Private
  */
@@ -178,7 +178,7 @@ router.put(
 );
 
 /**
- * @route   PATCH /api/products/update-variantstock/:variantId
+ * @route   PATCH /api/product/update-variantstock/:variantId
  * @desc    Update variant stock (increment/decrement/set)
  * @access  Private
  */
@@ -190,7 +190,7 @@ router.patch(
 );
 
 /**
- * @route   DELETE /api/products/delete-variant/:productId/:variantId
+ * @route   DELETE /api/product/delete-variant/:productId/:variantId
  * @desc    Soft delete a specific variant
  * @access  Private
  */

--- a/routes/publicListing.js
+++ b/routes/publicListing.js
@@ -30,7 +30,7 @@ router.get('/food/list', getAllFood);
 
 
 
-// GET /api/products/ranked?categoryId=&subcategoryId=&page=1&pageSize=24&maxPerVendor=3
+// GET /api/ranked?categoryId=&subcategoryId=&page=1&pageSize=24&maxPerVendor=3
 router.get('/ranked', listProductsRanked);
 router.get('/:id/similar', attachSimilarQuery , listProductsRanked)
 

--- a/tests/admin/vendor-onboarding-finalize.test.js
+++ b/tests/admin/vendor-onboarding-finalize.test.js
@@ -64,9 +64,12 @@ function loadController({ application, mailerCalls = {}, emailConfigured = true,
   process.env.MAIL_PASSWORD = emailConfigured ? 'app-password' : '';
 
   const vendorOnboardingMock = buildVendorOnboardingMock(application);
+  const businessUpdates = [];
 
   const businessMock = {
-    findOneAndUpdate: async () => {},
+    findOneAndUpdate: async (filter, update) => {
+      businessUpdates.push({ filter, update });
+    },
   };
 
   const mailerMock = {
@@ -104,12 +107,12 @@ function loadController({ application, mailerCalls = {}, emailConfigured = true,
   const controller = require(controllerPath);
   Module._load = originalLoad;
 
-  return { controller, mailerCalls };
+  return { controller, mailerCalls, businessUpdates };
 }
 
 test('finalizeVerification approves when required docs verified', async () => {
   const application = buildApplication();
-  const { controller, mailerCalls } = loadController({ application });
+  const { controller, mailerCalls, businessUpdates } = loadController({ application });
   const res = createResponse();
 
   await controller.finalizeVerification({ params: { applicationId: application.applicationId } }, res);
@@ -121,6 +124,7 @@ test('finalizeVerification approves when required docs verified', async () => {
   assert.equal(res.body.data.emailSent, true);
   assert.ok(mailerCalls.approved);
   assert.ok(mailerCalls.badge);
+  assert.equal(businessUpdates.at(-1).update.$set.isApproved, true);
 });
 
 test('finalizeVerification rejects when required docs missing', async () => {
@@ -131,7 +135,7 @@ test('finalizeVerification rejects when required docs missing', async () => {
       minorityDocs: false,
     },
   });
-  const { controller, mailerCalls } = loadController({ application });
+  const { controller, mailerCalls, businessUpdates } = loadController({ application });
   const res = createResponse();
 
   await controller.finalizeVerification({ params: { applicationId: application.applicationId } }, res);
@@ -141,6 +145,7 @@ test('finalizeVerification rejects when required docs missing', async () => {
   assert.equal(res.body.data.status, 'rejected');
   assert.ok(mailerCalls.rejection);
   assert.ok(mailerCalls.rejection.rejectionReason.includes('EIN document'));
+  assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
 });
 
 test('finalizeVerification blocks non-submitted applications', async () => {

--- a/tests/integration/marketplace.integration.test.js
+++ b/tests/integration/marketplace.integration.test.js
@@ -10,10 +10,15 @@ const { createAgent } = require('./helpers/client');
 const {
   registerAndVerify,
   login,
+  createAdminDirect,
   seedApprovedBusiness,
   seedPublishedProduct,
 } = require('./helpers/factories');
 const User = require('../../models/User');
+const Business = require('../../models/Business');
+const ProductVariant = require('../../models/ProductVariant');
+const Cart = require('../../models/Cart');
+const CartItem = require('../../models/CartItem');
 
 test.before(async () => {
   await startHarness();
@@ -68,4 +73,145 @@ test('missing product detail returns 404', async () => {
   const missingId = '507f1f77bcf86cd799439011';
   const res = await agent.get(`/api/public/product/${missingId}`);
   assert.equal(res.status, 404);
+});
+
+test('ineligible product vendor is hidden from public marketplace surfaces', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    isApproved: false,
+    isActive: true,
+    businessName: 'Ineligible Integration Vendor',
+  });
+  const product = await seedPublishedProduct(business, user);
+  product.isFeatured = true;
+  await product.save();
+
+  const directory = await agent.get('/api/business');
+  assert.equal(directory.status, 200);
+  assert.equal(directory.body.total, 0);
+
+  const list = await agent.get('/api/products/list');
+  assert.equal(list.status, 200);
+  assert.equal(list.body.total, 0);
+
+  const ranked = await agent.get('/api/ranked');
+  assert.equal(ranked.status, 200);
+  assert.deepEqual(ranked.body.items, []);
+
+  const search = await agent.get('/api/public/search').query({
+    keyword: 'Integration',
+    listingType: 'product',
+  });
+  assert.equal(search.status, 200);
+  assert.deepEqual(search.body.data.products, []);
+
+  const detail = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(detail.status, 404);
+
+  const profile = await agent.get(`/api/public/product/vendor-profile/${business._id}`);
+  assert.equal(profile.status, 404);
+
+  const storefront = await agent.get(`/api/public/products/business/${business._id}`);
+  assert.equal(storefront.status, 200);
+  assert.equal(storefront.body.total, 0);
+  assert.deepEqual(storefront.body.data, []);
+
+  const featured = await agent.get('/api/featured-products');
+  assert.equal(featured.status, 200);
+  assert.deepEqual(featured.body.products, []);
+});
+
+test('cart rejects ineligible vendors and strips stale ineligible lines', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser, {
+    isApproved: false,
+    isActive: true,
+  });
+  const product = await seedPublishedProduct(business, vendorUser);
+  const variant = await ProductVariant.create({
+    productId: product._id,
+    businessId: business._id,
+    ownerId: vendorUser._id,
+    attributes: { size: 'M' },
+    sku: `SKU-INELIGIBLE-${Date.now()}`,
+    price: 25,
+    stock: 5,
+    isPublished: true,
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+  const customerUser = await User.findOne({ email: customer.email });
+
+  const addRes = await customerAgent.post('/api/cart/add').send({
+    productId: product._id,
+    variantId: variant._id,
+    quantity: 1,
+    variant: 'M',
+  });
+  assert.equal(addRes.status, 403);
+  assert.match(addRes.body.message, /approved and active/i);
+
+  const staleLine = await CartItem.create({
+    userId: customerUser._id,
+    productId: product._id,
+    variantId: variant._id,
+    businessId: business._id,
+    quantity: 1,
+    variant: 'M',
+  });
+  await Cart.create({
+    userId: customerUser._id,
+    businessId: business._id,
+    items: [staleLine._id],
+    totalItems: 1,
+  });
+
+  const cartRes = await customerAgent.get('/api/cart');
+  assert.equal(cartRes.status, 200);
+  assert.match(cartRes.body.message, /vendor is no longer approved and active/i);
+  assert.deepEqual(cartRes.body.cart.items, []);
+  assert.equal(cartRes.body.cart.totalItems, 0);
+  assert.equal(cartRes.body.cart.removedItems[0].reason, 'ineligible_vendor');
+  assert.equal(await CartItem.findById(staleLine._id), null);
+});
+
+test('admin activation does not approve, while admin approve sets public eligibility', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser, {
+    isApproved: false,
+    isActive: false,
+    onboardingStatus: 'completed',
+  });
+
+  const admin = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, admin.email, admin.password);
+
+  const activateRes = await adminAgent
+    .patch(`/admin/api/business/status/${business._id}`)
+    .send({ isActive: true });
+
+  assert.equal(activateRes.status, 200);
+  assert.equal(activateRes.body.publicMarketplaceEligible, false);
+  assert.match(activateRes.body.message, /remain hidden until it is approved/i);
+
+  let reloaded = await Business.findById(business._id).lean();
+  assert.equal(reloaded.isActive, true);
+  assert.equal(reloaded.isApproved, false);
+
+  const approveRes = await adminAgent.post(`/admin/api/business/approve/${business._id}`);
+  assert.equal(approveRes.status, 200);
+  assert.equal(approveRes.body.publicMarketplaceEligible, true);
+
+  reloaded = await Business.findById(business._id).lean();
+  assert.equal(reloaded.isApproved, true);
+  assert.equal(reloaded.isActive, true);
 });

--- a/tests/marketplace/featured-products-response.test.js
+++ b/tests/marketplace/featured-products-response.test.js
@@ -27,6 +27,7 @@ function loadController(mockProduct, total = 1, options = {}) {
   const {
     visibleBusinessIds = ['507f1f77bcf86cd799439014'],
     capturedFindQuery = { value: null },
+    capturedBusinessFindQuery = { value: null },
     capturedLimit = { value: null },
   } = options;
 
@@ -58,11 +59,14 @@ function loadController(mockProduct, total = 1, options = {}) {
   };
 
   const Business = {
-    find: () => ({
+    find: (query) => {
+      capturedBusinessFindQuery.value = query;
+      return {
       select: () => ({
         lean: async () => visibleBusinessIds.map((id) => ({ _id: id })),
       }),
-    }),
+    };
+    },
   };
 
   const originalLoad = Module._load;
@@ -74,7 +78,12 @@ function loadController(mockProduct, total = 1, options = {}) {
   delete require.cache[controllerPath];
   const loaded = require(controllerPath);
   Module._load = originalLoad;
-  return { controller: loaded, capturedFindQuery, capturedLimit };
+  return {
+    controller: loaded,
+    capturedFindQuery,
+    capturedBusinessFindQuery,
+    capturedLimit,
+  };
 }
 
 test('getFeaturedProducts maps products through toPublicListingCard', async () => {
@@ -140,14 +149,14 @@ test('getFeaturedProducts preserves products and pagination wrapper', async () =
   assert.equal(res.body.products[0].priceLabel, 'Contact for price');
 });
 
-test('getFeaturedProducts scopes query to active businesses', async () => {
+test('getFeaturedProducts scopes query to approved active businesses', async () => {
   const mockProduct = {
     toObject() {
       return { _id: '507f1f77bcf86cd799439011', title: 'Featured' };
     },
   };
   const activeBusinessId = '507f1f77bcf86cd799439014';
-  const { controller, capturedFindQuery } = loadController(mockProduct, 1, {
+  const { controller, capturedFindQuery, capturedBusinessFindQuery } = loadController(mockProduct, 1, {
     visibleBusinessIds: [activeBusinessId],
   });
   const res = mockResponse();
@@ -156,12 +165,14 @@ test('getFeaturedProducts scopes query to active businesses', async () => {
 
   assert.equal(res.statusCode, 200);
   assert.ok(capturedFindQuery.value);
+  assert.equal(capturedBusinessFindQuery.value.isApproved, true);
+  assert.equal(capturedBusinessFindQuery.value.isActive, true);
   assert.equal(capturedFindQuery.value.isFeatured, true);
   assert.equal(capturedFindQuery.value.isPublished, true);
   assert.deepEqual(capturedFindQuery.value.businessId.$in, [activeBusinessId]);
 });
 
-test('getFeaturedProducts returns empty list when no active businesses', async () => {
+test('getFeaturedProducts returns empty list when no approved active businesses', async () => {
   const { controller } = loadController(null, 0, { visibleBusinessIds: [] });
   const res = mockResponse();
 

--- a/tests/marketplace/public-search-filters.test.js
+++ b/tests/marketplace/public-search-filters.test.js
@@ -45,7 +45,7 @@ test('resolveBusinessIdsForMinorityType returns null for empty input', async () 
   assert.equal(result, null);
 });
 
-test('resolveBusinessIdsByLocation applies city and state in a single query', async () => {
+test('resolveBusinessIdsByLocation applies city and state with approved active business scope', async () => {
   const id = '507f1f77bcf86cd799439012';
   let capturedFilter = null;
   const filters = loadFiltersWithMocks({
@@ -63,6 +63,7 @@ test('resolveBusinessIdsByLocation applies city and state in a single query', as
   assert.equal(result.length, 1);
   assert.equal(String(result[0]), id);
   assert.equal(capturedFilter.isActive, true);
+  assert.equal(capturedFilter.isApproved, true);
   assert.equal(capturedFilter.$and.length, 2);
 });
 
@@ -392,7 +393,7 @@ test('searchPublicListings preserves backward compatible response shape', async 
   assert.ok(Array.isArray(res.body.data.foods));
 });
 
-test('searchPublicListings defaults to active business scope when no filters', async () => {
+test('searchPublicListings defaults to approved active business scope when no filters', async () => {
   const activeBusinessId = '507f1f77bcf86cd799439011';
   let productFindFilter = null;
 
@@ -411,7 +412,7 @@ test('searchPublicListings defaults to active business scope when no filters', a
     if (String(request).includes('models/Business')) {
       return wrapModelFind({
         find: async (filter) => {
-          if (filter?.isActive === true) {
+          if (filter?.isActive === true && filter?.isApproved === true) {
             return [{ _id: activeBusinessId }];
           }
           return [];

--- a/tests/marketplace/ranked-products-visibility.test.js
+++ b/tests/marketplace/ranked-products-visibility.test.js
@@ -27,6 +27,7 @@ function loadRankedController(options = {}) {
   const {
     visibleBusinessIds = ['507f1f77bcf86cd799439014'],
     capturedFindQuery = { value: null },
+    capturedBusinessFindQuery = { value: null },
   } = options;
 
   const chain = {
@@ -57,11 +58,14 @@ function loadRankedController(options = {}) {
   };
 
   const Business = {
-    find: () => ({
+    find: (query) => {
+      capturedBusinessFindQuery.value = query;
+      return {
       select: () => ({
         lean: async () => visibleBusinessIds.map((id) => ({ _id: id })),
       }),
-    }),
+    };
+    },
   };
 
   const originalLoad = Module._load;
@@ -75,11 +79,11 @@ function loadRankedController(options = {}) {
   delete require.cache[controllerPath];
   const loaded = require(controllerPath);
   Module._load = originalLoad;
-  return { controller: loaded, capturedFindQuery };
+  return { controller: loaded, capturedFindQuery, capturedBusinessFindQuery };
 }
 
-test('listProductsRanked requires published products on simple path', async () => {
-  const { controller, capturedFindQuery } = loadRankedController();
+test('listProductsRanked requires published products from approved active businesses on simple path', async () => {
+  const { controller, capturedFindQuery, capturedBusinessFindQuery } = loadRankedController();
   const res = mockResponse();
 
   await controller.listProductsRanked({ query: { page: 1, pageSize: 24 } }, res);
@@ -87,5 +91,7 @@ test('listProductsRanked requires published products on simple path', async () =
   assert.ok(capturedFindQuery.value);
   assert.equal(capturedFindQuery.value.isDeleted, false);
   assert.equal(capturedFindQuery.value.isPublished, true);
+  assert.equal(capturedBusinessFindQuery.value.isApproved, true);
+  assert.equal(capturedBusinessFindQuery.value.isActive, true);
   assert.ok(Array.isArray(capturedFindQuery.value.businessId.$in));
 });

--- a/tests/stripe/order-initiate-connect.test.js
+++ b/tests/stripe/order-initiate-connect.test.js
@@ -458,7 +458,7 @@ test('initiateOrder blocks checkout when business is not approved', async () => 
   await initiateOrder(baseRequest(), res);
 
   assert.equal(res.statusCode, 403);
-  assert.match(res.body.message, /not approved/i);
+  assert.match(res.body.message, /approved and active/i);
   assert.equal(getPiCreateCalls().length, 0);
 });
 
@@ -472,7 +472,7 @@ test('initiateOrder blocks checkout when business is deactivated', async () => {
   await initiateOrder(baseRequest(), res);
 
   assert.equal(res.statusCode, 403);
-  assert.match(res.body.message, /unavailable/i);
+  assert.match(res.body.message, /approved and active/i);
   assert.equal(getPiCreateCalls().length, 0);
 });
 

--- a/tests/utils/checkout-paymentintent-response.test.js
+++ b/tests/utils/checkout-paymentintent-response.test.js
@@ -26,6 +26,25 @@ test('getBusinessCheckoutBlock blocks unapproved business', () => {
     stripeConnectAccountId: 'acct_test',
   });
   assert.equal(block.status, 403);
+  assert.match(block.message, /approved and active/i);
+});
+
+test('getBusinessCheckoutBlock blocks inactive business', () => {
+  const block = getBusinessCheckoutBlock({
+    isApproved: true,
+    isActive: false,
+    stripeConnectAccountId: 'acct_test',
+  });
+  assert.equal(block.status, 403);
+  assert.match(block.message, /approved and active/i);
+});
+
+test('getBusinessCheckoutBlock requires explicit approval and activation', () => {
+  const block = getBusinessCheckoutBlock({
+    stripeConnectAccountId: 'acct_test',
+  });
+  assert.equal(block.status, 403);
+  assert.match(block.message, /approved and active/i);
 });
 
 test('sanitizePaymentIntentForClient strips sensitive Stripe fields', () => {

--- a/utils/checkoutGuards.js
+++ b/utils/checkoutGuards.js
@@ -1,28 +1,13 @@
-/**
- * Business eligibility checks for customer checkout (Connect destination charge).
- */
+const {
+  getPublicMarketplaceBusinessBlock,
+} = require('../lib/marketplace/businessEligibility');
 
 function getBusinessCheckoutBlock(business) {
-  if (!business) {
-    return {
-      status: 404,
-      message: 'Vendor business not found.',
-    };
-  }
-
-  if (business.isApproved === false) {
-    return {
-      status: 403,
-      message: 'This vendor is not approved for checkout.',
-    };
-  }
-
-  if (business.isActive === false) {
-    return {
-      status: 403,
-      message: 'This vendor is temporarily unavailable for checkout.',
-    };
-  }
+  const marketplaceBlock = getPublicMarketplaceBusinessBlock(business, {
+    ineligibleMessage:
+      'This vendor is not approved and active for checkout.',
+  });
+  if (marketplaceBlock) return marketplaceBlock;
 
   if (!business.stripeConnectAccountId) {
     return {


### PR DESCRIPTION
## Summary
- Centralizes public marketplace eligibility with `isPublicMarketplaceBusiness`: public listing now requires `isApproved === true && isActive === true`.
- Filters public marketplace surfaces by eligible `businessId`, including business directory, product list/detail, ranked products, public search, vendor profile, business products, and featured products without changing the featured-products response contract.
- Rejects cart adds for ineligible vendors and cleans stale/ineligible cart lines on cart read.
- Aligns admin/vendor flows so approval sets `isApproved: true`, activation alone does not imply public listing, and order initiation verifies both flags before Stripe Connect.
- Adds backend source-of-truth docs and refreshes the docs hub/archive structure to match the frontend operating model.

## QA
- `git diff --check`
- `node --test tests/marketplace/featured-products-response.test.js tests/marketplace/ranked-products-visibility.test.js tests/marketplace/public-search-filters.test.js`
- `node --test tests/utils/checkout-paymentintent-response.test.js tests/admin/vendor-onboarding-finalize.test.js tests/stripe/order-initiate-connect.test.js`
- `node --test tests/integration/marketplace.integration.test.js`
- `npm test`
- `npm run test:integration`

## Manual QA Targets
- Ineligible business hidden from `/api/business`, `/api/products/list`, `/api/ranked`, `/api/public/search`, `/api/public/product/:id`, `/api/public/product/vendor-profile/:id`, `/api/public/products/business/:businessId`, and `/api/featured-products`.
- `POST /api/cart/add` rejects ineligible vendors with a clear approved-and-active message.
- `GET /api/cart` removes stale/ineligible vendor lines and reports removed items.
- Eligible vendor checkout still reaches the existing Stripe Connect readiness gate.
- Admin activation leaves unapproved vendors hidden; admin approval/finalize sets `isApproved: true`.