### PR TITLE
Standardize representative API errors

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -5,6 +5,7 @@ const Subscription = require('../models/Subscription');
 const SubscriptionPlan = require('../models/SubscriptionPlan');
 const { validationResult } = require('express-validator');
 const deleteCloudinaryFile = require('../utils/deleteCloudinaryFile');
+const { sendError, sendForbidden, sendNotFound } = require('../utils/apiError');
 const { PutObjectCommand, S3Client } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const mongoose = require('mongoose');
@@ -572,12 +573,18 @@ exports.getProductById = async (req, res) => {
       .lean();
 
     if (!product || product.isDeleted) {
-      return res.status(404).json({ error: 'Product not found' });
+      return sendNotFound(req, res, 'Product not found', {
+        code: 'PRODUCT_NOT_FOUND',
+        includeLegacyError: true,
+      });
     }
 
     // Check ownership
     if (product.ownerId.toString() !== req.user._id.toString()) {
-      return res.status(403).json({ error: 'Unauthorized' });
+      return sendForbidden(req, res, 'Unauthorized', {
+        code: 'PRODUCT_OWNER_REQUIRED',
+        includeLegacyError: true,
+      });
     }
 
     // Get variants
@@ -620,7 +627,10 @@ exports.getProductById = async (req, res) => {
 
   } catch (err) {
     console.error('Error in getProductById:', err);
-    return res.status(500).json({ error: 'Internal server error' });
+    return sendError(req, res, 500, {
+      message: 'Internal server error',
+      includeLegacyError: true,
+    });
   }
 };
 
@@ -651,11 +661,17 @@ exports.updateProduct = async (req, res) => {
     const product = await Product.findById(productId);
 
     if (!product || product.isDeleted) {
-      return res.status(404).json({ error: "Product not found" });
+      return sendNotFound(req, res, "Product not found", {
+        code: "PRODUCT_NOT_FOUND",
+        includeLegacyError: true,
+      });
     }
 
     if (product.ownerId.toString() !== userId.toString()) {
-      return res.status(403).json({ error: "Unauthorized" });
+      return sendForbidden(req, res, "Unauthorized", {
+        code: "PRODUCT_OWNER_REQUIRED",
+        includeLegacyError: true,
+      });
     }
 
     const subscription = await Subscription.findOne({

--- a/docs/backend/ERROR_RESPONSE_CONTRACT.md
+++ b/docs/backend/ERROR_RESPONSE_CONTRACT.md
@@ -1,0 +1,57 @@
+# Backend Error Response Contract
+
+**Issue:** #46
+**Last updated:** 2026-06-23
+
+## Standard Envelope
+
+Representative backend errors should move toward this shape:
+
+```json
+{
+  "success": false,
+  "message": "Human-safe summary",
+  "code": "STABLE_MACHINE_CODE",
+  "requestId": "optional-request-id",
+  "fieldErrors": {
+    "fieldName": "Field-safe message"
+  }
+}
+```
+
+Some legacy vendor/product clients still expect `error`. New helper calls may include `error` only when backward compatibility requires it.
+
+## Helper
+
+`utils/apiError.js` now centralizes:
+
+- `buildErrorPayload`
+- `sendError`
+- `sendUnauthorized`
+- `sendForbidden`
+- `sendNotFound`
+- `sendValidationError`
+
+The helper adds `success: false`, stable `code`, optional `requestId`, and normalized `fieldErrors`.
+
+## Applied In This Pass
+
+| Surface | Representative coverage |
+| --- | --- |
+| Auth middleware | 401 token/session failures now include stable codes and request IDs. |
+| Admin guard | 403 admin-only failures now include `success: false`, `code`, and `requestId`. |
+| Business owner/vendor guards | 403 vendor role, OTP, blocked/deleted, and stage-1 verification failures use the helper. |
+| Product owner reads/updates | 403/404/500 owner product responses preserve legacy `error` while adding the standard fields. |
+
+## Guardrails
+
+- Do not include raw exception messages in public 500 responses.
+- Do not include passwords, OTPs, tokens, Stripe secrets, payment intent client secrets, database URLs, or raw uploaded document metadata.
+- Preserve existing `message` strings unless a frontend change is coordinated.
+- Preserve legacy `error` only where existing clients or tests already depend on it.
+
+## Remaining Work
+
+- Convert more controllers opportunistically as they are touched.
+- Add field-level envelopes to express-validator routes after frontend forms are aligned.
+- Audit payment and webhook errors separately because those paths have Stripe-specific leakage risks.

--- a/docs/backend/LEGACY_ROUTE_DEAD_CODE_AUDIT.md
+++ b/docs/backend/LEGACY_ROUTE_DEAD_CODE_AUDIT.md
@@ -1,0 +1,92 @@
+# Legacy Route and Dead-Code Cleanup Audit
+
+**Issue:** #60
+**Last updated:** 2026-06-23
+
+## Summary
+
+This audit identifies duplicate, legacy, or cleanup-candidate backend surfaces without deleting runtime code. The current launch-safe policy is to keep canonical public APIs stable, add tests before removals, and deprecate aliases in small PRs.
+
+## Stripe and Payment Surfaces
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/stripeRoutes.js` + `controllers/stripeController.js` | Mounted at `/api/stripe` | Legacy subscription checkout/webhook surface. Keep until vendor subscription flow is fully mapped. |
+| `routes/stripe.routes.js` + `controllers/stripe.controller.js` | Mounted at `/stripe` | Newer Connect helper surface. Keep as canonical Connect self-service API for now. |
+| `routes/paymentRoutes.js` + `controllers/paymentController.js` | Mounted at `/api/payments` | Legacy customer PaymentIntent API. It remains guarded, but new order checkout is under orders. |
+| `controllers/stripePaymentController.js` | Used by order payment webhook and retrieve-intent polling | Keep. It contains sanitized PaymentIntent response helpers. |
+| `controllers/webhookController.js` | Webhook handlers | Keep. Must remain raw-body protected. |
+| `controllers/subscriptionController.js`, `controllers/subscriptions.controller.js`, `controllers/subscriptionPlanController.js` | Subscription/plan APIs | Overlapping naming. Do not merge until admin/vendor subscription flows are smoke-tested. |
+
+Cleanup order:
+
+1. Document the frontend callers for `/api/stripe`, `/stripe`, `/api/payments`, and `/api/orders/initiate`.
+2. Mark legacy `/api/payments/create-payment-intent` as deprecated in docs only.
+3. Add contract tests around the canonical checkout path before removing any legacy payment route.
+4. Split subscription controller naming cleanup into a separate PR after admin subscription pages are verified.
+
+## Listing and Marketplace Surfaces
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/publicListing.js` + `controllers/publicListing.js` | Mounted under `/api` | Canonical public browse/detail/search API surface. Preserve. |
+| `routes/privateListing.js` + `controllers/privateListing.js` | Mounted under `/api/private` | Vendor/private listing helpers. Keep until vendor dashboard callers are fully mapped. |
+| `controllers/productListingController.js` | Route usage needs follow-up verification | Candidate for future consolidation after route/caller scan. |
+| `controllers/productController.js`, `controllers/serviceController.js`, `controllers/foodController.js` | Owner CRUD surfaces | Keep. These are active vendor/admin flows. |
+| `controllers/featuredProducts.controller.js` + `routes/featuredProductRoutes.js` | Mounted under `/api`; exposes `GET /api/featured-products` | Canonical featured-products route. Preserve. Do not reintroduce `/api/products/featured`. |
+
+Cleanup order:
+
+1. Preserve `GET /api/featured-products` as canonical.
+2. Audit frontend callers for `/api/private/*` before changing `privateListing`.
+3. Consolidate DTO mapping through `lib/listing/publicListingDto.js` only when individual controller tests cover the affected response shapes.
+4. Avoid deleting `productListingController.js` until a route-level unused-file check confirms no import path depends on it.
+
+## CMS and Content Routes
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/admin/cmsRoutes.js` | Mounted at `/api/cms` and `/cms` | Active CMS surface despite admin folder naming. Requires auth review before route changes. |
+| `routes/cms/cmsRoutes.js` | Not mounted from `app.js` in this audit | Candidate for future removal or explicit archive once confirmed unused. |
+| `controllers/pubic/cms.controller.js` | Spelling indicates legacy/unused risk | Candidate for future archive after confirming no imports. |
+
+Cleanup order:
+
+1. Add a route registration test for CMS mounts before touching CMS files.
+2. Decide whether `/cms` should remain an alias for `/api/cms`.
+3. Archive or delete unmounted CMS files only after import checks pass.
+
+## Deprecated or Alias Routes
+
+| Route | Current posture |
+| --- | --- |
+| `/api/featured-products` | Canonical public featured product route. |
+| `/api/products/featured` | Must stay absent. Existing contract tests guard this. |
+| `/api/payments/create-payment-intent` | Legacy but guarded. Keep until checkout caller inventory is complete. |
+| `/api/orders/initiate` | Canonical customer checkout initiation path. |
+
+## Files Not Safe To Delete Yet
+
+- `controllers/stripeController.js`
+- `controllers/stripe.controller.js`
+- `controllers/stripePaymentController.js`
+- `controllers/paymentController.js`
+- `controllers/privateListing.js`
+- `controllers/productListingController.js`
+- `routes/cms/cmsRoutes.js`
+- `controllers/pubic/cms.controller.js`
+
+## Recommended PR Order
+
+1. Add route/caller inventory tests for CMS and payment surfaces.
+2. Deprecate legacy payment docs and keep runtime behavior unchanged.
+3. Remove or archive unmounted CMS files after import tests prove they are unused.
+4. Consolidate listing DTO helpers only after public browse/search/detail tests cover all listing types.
+5. Rename or split subscription controllers after subscription admin/vendor pages have a passing smoke pack.
+
+## Verification
+
+This is a documentation-only audit. Runtime verification for the same branch:
+
+- `npm test`
+- `npm run test:contract`

--- a/middlewares/authenticate.js
+++ b/middlewares/authenticate.js
@@ -1,16 +1,14 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const { clearAuthCookies } = require('../utils/cookieHelper');
+const { sendUnauthorized } = require('../utils/apiError');
 
-function deny(res, message, { clearCookies = false } = {}) {
+function deny(req, res, message, { clearCookies = false, code } = {}) {
   if (clearCookies) {
     clearAuthCookies(res);
   }
 
-  return res.status(401).json({
-    success: false,
-    message,
-  });
+  return sendUnauthorized(req, res, message, { code });
 }
 
 module.exports = async (req, res, next) => {
@@ -21,7 +19,7 @@ module.exports = async (req, res, next) => {
   const token = bearerToken || cookieToken;
 
   if (!token) {
-    return deny(res, 'Authentication required');
+    return deny(req, res, 'Authentication required', { code: 'AUTHENTICATION_REQUIRED' });
   }
 
   try {
@@ -29,12 +27,18 @@ module.exports = async (req, res, next) => {
     const userId = decoded.userId || decoded.sub;
 
     if (!userId) {
-      return deny(res, 'Invalid authentication token', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Invalid authentication token', {
+        clearCookies: Boolean(cookieToken),
+        code: 'INVALID_AUTH_TOKEN',
+      });
     }
 
     const user = await User.findById(userId);
     if (!user) {
-      return deny(res, 'Authenticated user not found', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Authenticated user not found', {
+        clearCookies: Boolean(cookieToken),
+        code: 'AUTH_USER_NOT_FOUND',
+      });
     }
 
     const tokenSessionVersion = Number.isInteger(decoded.sessionVersion)
@@ -43,12 +47,18 @@ module.exports = async (req, res, next) => {
     const currentSessionVersion = user.sessionVersion || 0;
 
     if (tokenSessionVersion !== currentSessionVersion) {
-      return deny(res, 'Session expired. Please log in again.', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Session expired. Please log in again.', {
+        clearCookies: Boolean(cookieToken),
+        code: 'SESSION_EXPIRED',
+      });
     }
 
     req.user = user;
     next();
   } catch (err) {
-    return deny(res, 'Invalid or expired authentication token', { clearCookies: Boolean(cookieToken) });
+    return deny(req, res, 'Invalid or expired authentication token', {
+      clearCookies: Boolean(cookieToken),
+      code: 'INVALID_OR_EXPIRED_AUTH_TOKEN',
+    });
   }
 };

--- a/middlewares/isAdmin.js
+++ b/middlewares/isAdmin.js
@@ -1,6 +1,10 @@
+const { sendForbidden } = require('../utils/apiError');
+
 module.exports = (req, res, next) => {
-  if (req.user.role !== 'admin') {
-    return res.status(403).json({ message: 'Access denied: Admin only' });
+  if (req.user?.role !== 'admin') {
+    return sendForbidden(req, res, 'Access denied: Admin only', {
+      code: 'ADMIN_REQUIRED',
+    });
   }
   next();
 };

--- a/middlewares/isBusinessOwner.js
+++ b/middlewares/isBusinessOwner.js
@@ -1,8 +1,9 @@
+const { sendForbidden } = require('../utils/apiError');
+
 module.exports = (req, res, next) => {
-  if (req.user.role !== 'business_owner') {
-    return res.status(403).json({
-      success: false,
-      message: 'Access denied: Business Owner only',
+  if (req.user?.role !== 'business_owner') {
+    return sendForbidden(req, res, 'Access denied: Business Owner only', {
+      code: 'BUSINESS_OWNER_REQUIRED',
     });
   }
   next();

--- a/middlewares/requireVerifiedVendor.js
+++ b/middlewares/requireVerifiedVendor.js
@@ -1,4 +1,5 @@
 const VendorOnboarding = require('../models/VendorOnboardingStage1');
+const { sendForbidden, sendUnauthorized } = require('../utils/apiError');
 
 function createRequireVerifiedVendor(options = {}) {
   const { requireStage1Verified = false } = options;
@@ -7,23 +8,33 @@ function createRequireVerifiedVendor(options = {}) {
     const user = req.user;
 
     if (!user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return sendUnauthorized(req, res, 'Unauthorized', {
+        code: 'AUTHENTICATION_REQUIRED',
+      });
     }
 
     if (user.role !== 'business_owner') {
-      return res.status(403).json({ message: 'Only vendors allowed' });
+      return sendForbidden(req, res, 'Only vendors allowed', {
+        code: 'VENDOR_REQUIRED',
+      });
     }
 
     if (!user.isOtpVerified) {
-      return res.status(403).json({ message: 'OTP verification required' });
+      return sendForbidden(req, res, 'OTP verification required', {
+        code: 'OTP_VERIFICATION_REQUIRED',
+      });
     }
 
     if (user.isBlocked) {
-      return res.status(403).json({ message: 'Account is blocked' });
+      return sendForbidden(req, res, 'Account is blocked', {
+        code: 'ACCOUNT_BLOCKED',
+      });
     }
 
     if (user.isDeleted) {
-      return res.status(403).json({ message: 'Account is deleted' });
+      return sendForbidden(req, res, 'Account is deleted', {
+        code: 'ACCOUNT_DELETED',
+      });
     }
 
     if (requireStage1Verified) {
@@ -32,8 +43,8 @@ function createRequireVerifiedVendor(options = {}) {
         .lean();
 
       if (!onboarding || onboarding.status !== 'verified') {
-        return res.status(403).json({
-          message: 'Stage 1 vendor verification required',
+        return sendForbidden(req, res, 'Stage 1 vendor verification required', {
+          code: 'STAGE1_VERIFICATION_REQUIRED',
         });
       }
     }

--- a/tests/api-error-response.test.js
+++ b/tests/api-error-response.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildErrorPayload,
+  sendForbidden,
+  sendValidationError,
+} = require('../utils/apiError');
+const isAdmin = require('../middlewares/isAdmin');
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('buildErrorPayload includes stable code, success flag, and requestId', () => {
+  const payload = buildErrorPayload(
+    { requestId: 'req-error-001' },
+    {
+      status: 403,
+      message: 'Access denied',
+      code: 'ADMIN_REQUIRED',
+    }
+  );
+
+  assert.deepEqual(payload, {
+    success: false,
+    message: 'Access denied',
+    code: 'ADMIN_REQUIRED',
+    requestId: 'req-error-001',
+  });
+});
+
+test('sendValidationError normalizes field errors without leaking raw request values', () => {
+  const res = mockResponse();
+
+  sendValidationError(
+    { requestId: 'req-validation-001' },
+    res,
+    {
+      email: 'Email is required',
+      password: 'Password is too short',
+    }
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'VALIDATION_FAILED');
+  assert.equal(res.body.message, 'Validation failed');
+  assert.equal(res.body.error, 'Validation failed');
+  assert.deepEqual(res.body.fieldErrors, {
+    email: 'Email is required',
+    password: 'Password is too short',
+  });
+  assert.equal(res.body.requestId, 'req-validation-001');
+});
+
+test('sendForbidden can preserve legacy error field for existing clients', () => {
+  const res = mockResponse();
+
+  sendForbidden({ requestId: 'req-legacy-001' }, res, 'Unauthorized', {
+    code: 'PRODUCT_OWNER_REQUIRED',
+    includeLegacyError: true,
+  });
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Unauthorized');
+  assert.equal(res.body.error, 'Unauthorized');
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'PRODUCT_OWNER_REQUIRED');
+});
+
+test('isAdmin uses standardized error envelope', () => {
+  const res = mockResponse();
+  let calledNext = false;
+
+  isAdmin({ requestId: 'req-admin-001', user: { role: 'customer' } }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, 'Access denied: Admin only');
+  assert.equal(res.body.code, 'ADMIN_REQUIRED');
+  assert.equal(res.body.requestId, 'req-admin-001');
+});

--- a/utils/apiError.js
+++ b/utils/apiError.js
@@ -1,0 +1,101 @@
+const STATUS_CODES = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  409: "CONFLICT",
+  422: "VALIDATION_FAILED",
+  429: "RATE_LIMITED",
+  500: "INTERNAL_SERVER_ERROR",
+};
+
+function getRequestId(req) {
+  const requestId = req?.requestId || req?.headers?.["x-request-id"];
+  return typeof requestId === "string" && requestId.trim()
+    ? requestId.trim().slice(0, 128)
+    : undefined;
+}
+
+function normalizeFieldErrors(fieldErrors) {
+  if (!fieldErrors || typeof fieldErrors !== "object" || Array.isArray(fieldErrors)) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(fieldErrors)
+      .filter(([key, value]) => key && value != null)
+      .map(([key, value]) => [String(key), String(value)])
+  );
+}
+
+function buildErrorPayload(req, {
+  status = 500,
+  message = "Internal server error",
+  code,
+  fieldErrors,
+  includeLegacyError = false,
+} = {}) {
+  const payload = {
+    success: false,
+    message,
+    code: code || STATUS_CODES[status] || "ERROR",
+  };
+  const requestId = getRequestId(req);
+  const normalizedFieldErrors = normalizeFieldErrors(fieldErrors);
+
+  if (requestId) payload.requestId = requestId;
+  if (normalizedFieldErrors && Object.keys(normalizedFieldErrors).length > 0) {
+    payload.fieldErrors = normalizedFieldErrors;
+  }
+  if (includeLegacyError) {
+    payload.error = message;
+  }
+
+  return payload;
+}
+
+function sendError(req, res, status, options = {}) {
+  return res.status(status).json(buildErrorPayload(req, { ...options, status }));
+}
+
+function sendValidationError(req, res, fieldErrors, message = "Validation failed") {
+  return sendError(req, res, 400, {
+    message,
+    code: "VALIDATION_FAILED",
+    fieldErrors,
+    includeLegacyError: true,
+  });
+}
+
+function sendUnauthorized(req, res, message = "Authentication required", options = {}) {
+  return sendError(req, res, 401, {
+    message,
+    code: options.code || "AUTHENTICATION_REQUIRED",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+function sendForbidden(req, res, message = "Forbidden", options = {}) {
+  return sendError(req, res, 403, {
+    message,
+    code: options.code || "FORBIDDEN",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+function sendNotFound(req, res, message = "Not found", options = {}) {
+  return sendError(req, res, 404, {
+    message,
+    code: options.code || "NOT_FOUND",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+module.exports = {
+  buildErrorPayload,
+  sendError,
+  sendForbidden,
+  sendNotFound,
+  sendUnauthorized,
+  sendValidationError,
+};


### PR DESCRIPTION
## Summary
- Add a shared `utils/apiError.js` helper for standard safe error envelopes with stable codes, request IDs, and field errors.
- Apply the helper to representative auth, admin, business-owner/vendor guard, and product owner error paths while preserving legacy `message`/`error` fields where clients already expect them.
- Add focused tests and docs for the backend error response contract.
- Add a legacy route/dead-code cleanup audit covering duplicate Stripe/payment, listing, CMS, and alias surfaces with recommended PR order.

## Verification
- `node --check utils/apiError.js`
- `node --check middlewares/authenticate.js middlewares/isAdmin.js middlewares/isBusinessOwner.js middlewares/requireVerifiedVendor.js controllers/productController.js`
- `node --test tests/api-error-response.test.js tests/admin/is-admin-middleware.test.js tests/vendor/require-verified-vendor.test.js tests/vendor/vendor-listing-ownership.test.js tests/auth/password-reset-session-invalidation.test.js`
- `npm test`
- `npm run test:contract`

Closes #60.
Refs #46. This is a representative standardization slice; broader payment/webhook/controller conversion remains separate.
