### PR TITLE
Sync staging with main

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -88,6 +88,7 @@
 // module.exports = { createOrder };
 
 // controllers/orderController.js
+const mongoose = require("mongoose");
 const { v4: uuidv4 } = require("uuid");
 const Stripe = require("stripe");
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
@@ -117,6 +118,89 @@ const toNum = (value) => {
 
   return value == null ? null : Number(value);
 };
+
+const ADMIN_PAYMENT_BUCKETS = ["pending", "paid", "failed", "refunded"];
+const ADMIN_STATUS_BUCKETS = [
+  "created",
+  "ordered",
+  "accepted",
+  "rejected",
+  "shipped",
+  "delivered",
+  "cancelled",
+  "returned",
+  "refunded",
+];
+
+const toObjectIdIfValid = (value) => {
+  if (!value || !mongoose.Types.ObjectId.isValid(value)) return value;
+  return new mongoose.Types.ObjectId(value);
+};
+
+const buildAdminOrderMatch = (query = {}) => {
+  const {
+    status,
+    paymentStatus,
+    businessId,
+    vendorId,
+    userId,
+    from,
+    to,
+    q,
+  } = query;
+
+  const match = {};
+  if (status) match.status = status;
+  if (paymentStatus) match.paymentStatus = paymentStatus;
+  if (businessId) match.businessId = toObjectIdIfValid(businessId);
+  if (vendorId) match.vendorId = toObjectIdIfValid(vendorId);
+  if (userId) match.userId = toObjectIdIfValid(userId);
+  if (from || to) {
+    match.createdAt = {};
+    if (from) match.createdAt.$gte = new Date(from);
+    if (to) match.createdAt.$lte = new Date(to);
+  }
+  if (q) {
+    const searchClauses = [{ groupOrderId: q }];
+    if (mongoose.Types.ObjectId.isValid(q)) {
+      searchClauses.push({ _id: new mongoose.Types.ObjectId(q) });
+    }
+    match.$or = searchClauses;
+  }
+
+  return match;
+};
+
+const summarizeBuckets = (buckets, rows) => {
+  const summary = Object.fromEntries(buckets.map((bucket) => [bucket, 0]));
+  rows.forEach((row) => {
+    if (row?._id != null && Object.prototype.hasOwnProperty.call(summary, row._id)) {
+      summary[row._id] = row.count;
+    }
+  });
+  return summary;
+};
+
+const currencyExpression = { $ifNull: ["$currency", "USD"] };
+const amountExpression = (field, fallback = 0) => ({ $ifNull: [field, fallback] });
+
+const toCurrencySummary = (row) => ({
+  currency: row._id || "USD",
+  totalOrders: row.totalOrders || 0,
+  grossSalesAmount: row.grossSalesAmount || 0,
+  paidSalesAmount: row.paidSalesAmount || 0,
+  refundedSalesAmount: row.refundedSalesAmount || 0,
+  subtotalAmount: row.subtotalAmount || 0,
+  taxAmount: row.taxAmount || 0,
+  shippingAmount: row.shippingAmount || 0,
+});
+
+const toVendorSalesSummary = (row) => ({
+  vendorId: row.vendorId ? String(row.vendorId) : null,
+  currency: row.currency || "USD",
+  orderCount: row.orderCount || 0,
+  totalSalesAmount: row.totalSalesAmount || 0,
+});
 
 const getVariantAttribute = (variantDoc, key) => {
   if (!variantDoc?.attributes) return null;
@@ -1257,36 +1341,7 @@ exports.getAllOrdersAdmin = async (req, res) => {
     const page = parseInt(req.query.page, 10) || 1;
     const limit = parseInt(req.query.limit, 10) || 20;
     const skip = (page - 1) * limit;
-
-    const {
-      status, // e.g. 'ordered'
-      paymentStatus, // e.g. 'paid'
-      businessId,
-      vendorId,
-      userId,
-      from, // ISO date string
-      to, // ISO date string
-      q, // optional search: groupOrderId / order _id
-    } = req.query;
-
-    const match = {};
-    if (status) match.status = status;
-    if (paymentStatus) match.paymentStatus = paymentStatus;
-    if (businessId) match.businessId = businessId;
-    if (vendorId) match.vendorId = vendorId;
-    if (userId) match.userId = userId;
-    if (from || to) {
-      match.createdAt = {};
-      if (from) match.createdAt.$gte = new Date(from);
-      if (to) match.createdAt.$lte = new Date(to);
-    }
-    if (q) {
-      // search by groupOrderId or order _id string
-      match.$or = [
-        { groupOrderId: q },
-        { _id: q.match(/^[a-f\d]{24}$/i) ? q : undefined }, // only valid ObjectId strings
-      ].filter(Boolean);
-    }
+    const match = buildAdminOrderMatch(req.query);
 
     const [rows, total, paymentAgg, statusAgg] = await Promise.all([
       Order.find(match)
@@ -1308,32 +1363,6 @@ exports.getAllOrdersAdmin = async (req, res) => {
       ]),
     ]);
 
-    // normalize summaries so missing buckets show 0
-    const paymentBuckets = ["pending", "paid", "failed", "refunded"];
-    const statusBuckets = [
-      "created",
-      "ordered",
-      "accepted",
-      "rejected",
-      "shipped",
-      "delivered",
-      "cancelled",
-      "returned",
-      "refunded",
-    ];
-
-    const paymentSummary = Object.fromEntries(
-      paymentBuckets.map((k) => [k, 0])
-    );
-    paymentAgg.forEach((r) => {
-      paymentSummary[r._id] = r.count;
-    });
-
-    const statusSummary = Object.fromEntries(statusBuckets.map((k) => [k, 0]));
-    statusAgg.forEach((r) => {
-      statusSummary[r._id] = r.count;
-    });
-
     return res.status(200).json({
       success: true,
       message: "Orders fetched successfully",
@@ -1345,12 +1374,117 @@ exports.getAllOrdersAdmin = async (req, res) => {
         totalPages: Math.ceil(total / limit),
       },
       summary: {
-        payment: paymentSummary,
-        status: statusSummary,
+        payment: summarizeBuckets(ADMIN_PAYMENT_BUCKETS, paymentAgg),
+        status: summarizeBuckets(ADMIN_STATUS_BUCKETS, statusAgg),
       },
     });
   } catch (err) {
     console.error("getAllOrdersAdmin error:", err);
+    return res
+      .status(500)
+      .json({ success: false, message: "Internal server error" });
+  }
+};
+
+exports.getAdminSalesSummary = async (req, res) => {
+  try {
+    const match = buildAdminOrderMatch(req.query);
+    const paidVendorMatch =
+      match.paymentStatus && match.paymentStatus !== "paid"
+        ? null
+        : { ...match, paymentStatus: "paid" };
+    const vendorSalesPipeline = paidVendorMatch
+      ? [
+          { $match: paidVendorMatch },
+          {
+            $group: {
+              _id: {
+                vendorId: "$vendorId",
+                currency: currencyExpression,
+              },
+              orderCount: { $sum: 1 },
+              totalSalesAmount: { $sum: amountExpression("$totalAmount") },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              vendorId: "$_id.vendorId",
+              currency: "$_id.currency",
+              orderCount: 1,
+              totalSalesAmount: 1,
+            },
+          },
+          { $sort: { totalSalesAmount: -1 } },
+          { $limit: 10 },
+        ]
+      : null;
+
+    const [salesByCurrency, vendorSales, paymentAgg, statusAgg] = await Promise.all([
+      Order.aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: currencyExpression,
+            totalOrders: { $sum: 1 },
+            grossSalesAmount: { $sum: amountExpression("$totalAmount") },
+            paidSalesAmount: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$paymentStatus", "paid"] },
+                  amountExpression("$totalAmount"),
+                  0,
+                ],
+              },
+            },
+            refundedSalesAmount: {
+              $sum: {
+                $cond: [
+                  { $eq: ["$paymentStatus", "refunded"] },
+                  amountExpression("$totalAmount"),
+                  0,
+                ],
+              },
+            },
+            subtotalAmount: { $sum: amountExpression("$subtotalAmount") },
+            taxAmount: { $sum: amountExpression("$taxSummary.taxTotal") },
+            shippingAmount: { $sum: amountExpression("$shipping.amount") },
+          },
+        },
+        { $sort: { _id: 1 } },
+      ]),
+      vendorSalesPipeline
+        ? Order.aggregate(vendorSalesPipeline)
+        : Promise.resolve([]),
+      Order.aggregate([
+        { $match: match },
+        { $group: { _id: "$paymentStatus", count: { $sum: 1 } } },
+      ]),
+      Order.aggregate([
+        { $match: match },
+        { $group: { _id: "$status", count: { $sum: 1 } } },
+      ]),
+    ]);
+
+    return res.status(200).json({
+      success: true,
+      message: "Admin sales summary fetched successfully",
+      data: {
+        salesByCurrency: salesByCurrency.map(toCurrencySummary),
+        topVendors: vendorSales.map(toVendorSalesSummary),
+        platformRevenue: {
+          supported: false,
+          amount: null,
+          reason: "Order records do not persist platform fee amounts yet.",
+        },
+        summary: {
+          payment: summarizeBuckets(ADMIN_PAYMENT_BUCKETS, paymentAgg),
+          status: summarizeBuckets(ADMIN_STATUS_BUCKETS, statusAgg),
+        },
+      },
+    });
+  } catch (err) {
+    console.error("getAdminSalesSummary error:", err);
     return res
       .status(500)
       .json({ success: false, message: "Internal server error" });

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -5,6 +5,7 @@ const Subscription = require('../models/Subscription');
 const SubscriptionPlan = require('../models/SubscriptionPlan');
 const { validationResult } = require('express-validator');
 const deleteCloudinaryFile = require('../utils/deleteCloudinaryFile');
+const { sendError, sendForbidden, sendNotFound } = require('../utils/apiError');
 const { PutObjectCommand, S3Client } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const mongoose = require('mongoose');
@@ -572,12 +573,18 @@ exports.getProductById = async (req, res) => {
       .lean();
 
     if (!product || product.isDeleted) {
-      return res.status(404).json({ error: 'Product not found' });
+      return sendNotFound(req, res, 'Product not found', {
+        code: 'PRODUCT_NOT_FOUND',
+        includeLegacyError: true,
+      });
     }
 
     // Check ownership
     if (product.ownerId.toString() !== req.user._id.toString()) {
-      return res.status(403).json({ error: 'Unauthorized' });
+      return sendForbidden(req, res, 'Unauthorized', {
+        code: 'PRODUCT_OWNER_REQUIRED',
+        includeLegacyError: true,
+      });
     }
 
     // Get variants
@@ -620,7 +627,10 @@ exports.getProductById = async (req, res) => {
 
   } catch (err) {
     console.error('Error in getProductById:', err);
-    return res.status(500).json({ error: 'Internal server error' });
+    return sendError(req, res, 500, {
+      message: 'Internal server error',
+      includeLegacyError: true,
+    });
   }
 };
 
@@ -651,11 +661,17 @@ exports.updateProduct = async (req, res) => {
     const product = await Product.findById(productId);
 
     if (!product || product.isDeleted) {
-      return res.status(404).json({ error: "Product not found" });
+      return sendNotFound(req, res, "Product not found", {
+        code: "PRODUCT_NOT_FOUND",
+        includeLegacyError: true,
+      });
     }
 
     if (product.ownerId.toString() !== userId.toString()) {
-      return res.status(403).json({ error: "Unauthorized" });
+      return sendForbidden(req, res, "Unauthorized", {
+        code: "PRODUCT_OWNER_REQUIRED",
+        includeLegacyError: true,
+      });
     }
 
     const subscription = await Subscription.findOne({

--- a/controllers/reviewController.js
+++ b/controllers/reviewController.js
@@ -21,6 +21,42 @@ const getListingIdFromParams = (req) =>
 
 const validateObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
 
+const normalizeId = (value) => {
+  if (!value) return value;
+  return typeof value.toString === 'function' ? value.toString() : value;
+};
+
+const normalizeDate = (value) => {
+  if (!value) return value;
+  return value instanceof Date ? value.toISOString() : value;
+};
+
+const toPublicReviewUser = (user) => {
+  if (!user || typeof user !== 'object') return null;
+
+  return {
+    _id: normalizeId(user._id),
+    name: user.name || '',
+    profileImage: user.profileImage || '',
+  };
+};
+
+const toPublicReview = (review) => {
+  const source = review || {};
+
+  return {
+    _id: normalizeId(source._id),
+    userId: toPublicReviewUser(source.userId),
+    listingId: normalizeId(source.listingId),
+    listingType: source.listingType,
+    rating: source.rating,
+    comment: source.comment,
+    image: source.image || '',
+    createdAt: normalizeDate(source.createdAt),
+    updatedAt: normalizeDate(source.updatedAt),
+  };
+};
+
 const ensureListingExists = async (listingId, listingType) => {
   const Model = LISTING_MODELS[listingType];
   if (!Model) {
@@ -77,7 +113,7 @@ exports.listReviews = (listingType) => async (req, res) => {
           limit,
           totalPages: Math.ceil(total / limit),
         },
-        reviews,
+        reviews: reviews.map(toPublicReview),
       },
     });
   } catch (error) {
@@ -159,7 +195,7 @@ exports.upsertReview = (listingType) => async (req, res) => {
       success: true,
       message: isNewReview ? 'Review added successfully' : 'Review updated successfully',
       data: {
-        review: populatedReview,
+        review: toPublicReview(populatedReview),
         summary,
       },
     });

--- a/docs/backend/ERROR_RESPONSE_CONTRACT.md
+++ b/docs/backend/ERROR_RESPONSE_CONTRACT.md
@@ -1,0 +1,57 @@
+# Backend Error Response Contract
+
+**Issue:** #46
+**Last updated:** 2026-06-23
+
+## Standard Envelope
+
+Representative backend errors should move toward this shape:
+
+```json
+{
+  "success": false,
+  "message": "Human-safe summary",
+  "code": "STABLE_MACHINE_CODE",
+  "requestId": "optional-request-id",
+  "fieldErrors": {
+    "fieldName": "Field-safe message"
+  }
+}
+```
+
+Some legacy vendor/product clients still expect `error`. New helper calls may include `error` only when backward compatibility requires it.
+
+## Helper
+
+`utils/apiError.js` now centralizes:
+
+- `buildErrorPayload`
+- `sendError`
+- `sendUnauthorized`
+- `sendForbidden`
+- `sendNotFound`
+- `sendValidationError`
+
+The helper adds `success: false`, stable `code`, optional `requestId`, and normalized `fieldErrors`.
+
+## Applied In This Pass
+
+| Surface | Representative coverage |
+| --- | --- |
+| Auth middleware | 401 token/session failures now include stable codes and request IDs. |
+| Admin guard | 403 admin-only failures now include `success: false`, `code`, and `requestId`. |
+| Business owner/vendor guards | 403 vendor role, OTP, blocked/deleted, and stage-1 verification failures use the helper. |
+| Product owner reads/updates | 403/404/500 owner product responses preserve legacy `error` while adding the standard fields. |
+
+## Guardrails
+
+- Do not include raw exception messages in public 500 responses.
+- Do not include passwords, OTPs, tokens, Stripe secrets, payment intent client secrets, database URLs, or raw uploaded document metadata.
+- Preserve existing `message` strings unless a frontend change is coordinated.
+- Preserve legacy `error` only where existing clients or tests already depend on it.
+
+## Remaining Work
+
+- Convert more controllers opportunistically as they are touched.
+- Add field-level envelopes to express-validator routes after frontend forms are aligned.
+- Audit payment and webhook errors separately because those paths have Stripe-specific leakage risks.

--- a/docs/backend/LEGACY_ROUTE_DEAD_CODE_AUDIT.md
+++ b/docs/backend/LEGACY_ROUTE_DEAD_CODE_AUDIT.md
@@ -1,0 +1,92 @@
+# Legacy Route and Dead-Code Cleanup Audit
+
+**Issue:** #60
+**Last updated:** 2026-06-23
+
+## Summary
+
+This audit identifies duplicate, legacy, or cleanup-candidate backend surfaces without deleting runtime code. The current launch-safe policy is to keep canonical public APIs stable, add tests before removals, and deprecate aliases in small PRs.
+
+## Stripe and Payment Surfaces
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/stripeRoutes.js` + `controllers/stripeController.js` | Mounted at `/api/stripe` | Legacy subscription checkout/webhook surface. Keep until vendor subscription flow is fully mapped. |
+| `routes/stripe.routes.js` + `controllers/stripe.controller.js` | Mounted at `/stripe` | Newer Connect helper surface. Keep as canonical Connect self-service API for now. |
+| `routes/paymentRoutes.js` + `controllers/paymentController.js` | Mounted at `/api/payments` | Legacy customer PaymentIntent API. It remains guarded, but new order checkout is under orders. |
+| `controllers/stripePaymentController.js` | Used by order payment webhook and retrieve-intent polling | Keep. It contains sanitized PaymentIntent response helpers. |
+| `controllers/webhookController.js` | Webhook handlers | Keep. Must remain raw-body protected. |
+| `controllers/subscriptionController.js`, `controllers/subscriptions.controller.js`, `controllers/subscriptionPlanController.js` | Subscription/plan APIs | Overlapping naming. Do not merge until admin/vendor subscription flows are smoke-tested. |
+
+Cleanup order:
+
+1. Document the frontend callers for `/api/stripe`, `/stripe`, `/api/payments`, and `/api/orders/initiate`.
+2. Mark legacy `/api/payments/create-payment-intent` as deprecated in docs only.
+3. Add contract tests around the canonical checkout path before removing any legacy payment route.
+4. Split subscription controller naming cleanup into a separate PR after admin subscription pages are verified.
+
+## Listing and Marketplace Surfaces
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/publicListing.js` + `controllers/publicListing.js` | Mounted under `/api` | Canonical public browse/detail/search API surface. Preserve. |
+| `routes/privateListing.js` + `controllers/privateListing.js` | Mounted under `/api/private` | Vendor/private listing helpers. Keep until vendor dashboard callers are fully mapped. |
+| `controllers/productListingController.js` | Route usage needs follow-up verification | Candidate for future consolidation after route/caller scan. |
+| `controllers/productController.js`, `controllers/serviceController.js`, `controllers/foodController.js` | Owner CRUD surfaces | Keep. These are active vendor/admin flows. |
+| `controllers/featuredProducts.controller.js` + `routes/featuredProductRoutes.js` | Mounted under `/api`; exposes `GET /api/featured-products` | Canonical featured-products route. Preserve. Do not reintroduce `/api/products/featured`. |
+
+Cleanup order:
+
+1. Preserve `GET /api/featured-products` as canonical.
+2. Audit frontend callers for `/api/private/*` before changing `privateListing`.
+3. Consolidate DTO mapping through `lib/listing/publicListingDto.js` only when individual controller tests cover the affected response shapes.
+4. Avoid deleting `productListingController.js` until a route-level unused-file check confirms no import path depends on it.
+
+## CMS and Content Routes
+
+| Surface | Mount/status | Cleanup note |
+| --- | --- | --- |
+| `routes/admin/cmsRoutes.js` | Mounted at `/api/cms` and `/cms` | Active CMS surface despite admin folder naming. Requires auth review before route changes. |
+| `routes/cms/cmsRoutes.js` | Not mounted from `app.js` in this audit | Candidate for future removal or explicit archive once confirmed unused. |
+| `controllers/pubic/cms.controller.js` | Spelling indicates legacy/unused risk | Candidate for future archive after confirming no imports. |
+
+Cleanup order:
+
+1. Add a route registration test for CMS mounts before touching CMS files.
+2. Decide whether `/cms` should remain an alias for `/api/cms`.
+3. Archive or delete unmounted CMS files only after import checks pass.
+
+## Deprecated or Alias Routes
+
+| Route | Current posture |
+| --- | --- |
+| `/api/featured-products` | Canonical public featured product route. |
+| `/api/products/featured` | Must stay absent. Existing contract tests guard this. |
+| `/api/payments/create-payment-intent` | Legacy but guarded. Keep until checkout caller inventory is complete. |
+| `/api/orders/initiate` | Canonical customer checkout initiation path. |
+
+## Files Not Safe To Delete Yet
+
+- `controllers/stripeController.js`
+- `controllers/stripe.controller.js`
+- `controllers/stripePaymentController.js`
+- `controllers/paymentController.js`
+- `controllers/privateListing.js`
+- `controllers/productListingController.js`
+- `routes/cms/cmsRoutes.js`
+- `controllers/pubic/cms.controller.js`
+
+## Recommended PR Order
+
+1. Add route/caller inventory tests for CMS and payment surfaces.
+2. Deprecate legacy payment docs and keep runtime behavior unchanged.
+3. Remove or archive unmounted CMS files after import tests prove they are unused.
+4. Consolidate listing DTO helpers only after public browse/search/detail tests cover all listing types.
+5. Rename or split subscription controllers after subscription admin/vendor pages have a passing smoke pack.
+
+## Verification
+
+This is a documentation-only audit. Runtime verification for the same branch:
+
+- `npm test`
+- `npm run test:contract`

--- a/middlewares/authenticate.js
+++ b/middlewares/authenticate.js
@@ -1,16 +1,14 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const { clearAuthCookies } = require('../utils/cookieHelper');
+const { sendUnauthorized } = require('../utils/apiError');
 
-function deny(res, message, { clearCookies = false } = {}) {
+function deny(req, res, message, { clearCookies = false, code } = {}) {
   if (clearCookies) {
     clearAuthCookies(res);
   }
 
-  return res.status(401).json({
-    success: false,
-    message,
-  });
+  return sendUnauthorized(req, res, message, { code });
 }
 
 module.exports = async (req, res, next) => {
@@ -21,7 +19,7 @@ module.exports = async (req, res, next) => {
   const token = bearerToken || cookieToken;
 
   if (!token) {
-    return deny(res, 'Authentication required');
+    return deny(req, res, 'Authentication required', { code: 'AUTHENTICATION_REQUIRED' });
   }
 
   try {
@@ -29,12 +27,18 @@ module.exports = async (req, res, next) => {
     const userId = decoded.userId || decoded.sub;
 
     if (!userId) {
-      return deny(res, 'Invalid authentication token', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Invalid authentication token', {
+        clearCookies: Boolean(cookieToken),
+        code: 'INVALID_AUTH_TOKEN',
+      });
     }
 
     const user = await User.findById(userId);
     if (!user) {
-      return deny(res, 'Authenticated user not found', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Authenticated user not found', {
+        clearCookies: Boolean(cookieToken),
+        code: 'AUTH_USER_NOT_FOUND',
+      });
     }
 
     const tokenSessionVersion = Number.isInteger(decoded.sessionVersion)
@@ -43,12 +47,18 @@ module.exports = async (req, res, next) => {
     const currentSessionVersion = user.sessionVersion || 0;
 
     if (tokenSessionVersion !== currentSessionVersion) {
-      return deny(res, 'Session expired. Please log in again.', { clearCookies: Boolean(cookieToken) });
+      return deny(req, res, 'Session expired. Please log in again.', {
+        clearCookies: Boolean(cookieToken),
+        code: 'SESSION_EXPIRED',
+      });
     }
 
     req.user = user;
     next();
   } catch (err) {
-    return deny(res, 'Invalid or expired authentication token', { clearCookies: Boolean(cookieToken) });
+    return deny(req, res, 'Invalid or expired authentication token', {
+      clearCookies: Boolean(cookieToken),
+      code: 'INVALID_OR_EXPIRED_AUTH_TOKEN',
+    });
   }
 };

--- a/middlewares/isAdmin.js
+++ b/middlewares/isAdmin.js
@@ -1,6 +1,10 @@
+const { sendForbidden } = require('../utils/apiError');
+
 module.exports = (req, res, next) => {
-  if (req.user.role !== 'admin') {
-    return res.status(403).json({ message: 'Access denied: Admin only' });
+  if (req.user?.role !== 'admin') {
+    return sendForbidden(req, res, 'Access denied: Admin only', {
+      code: 'ADMIN_REQUIRED',
+    });
   }
   next();
 };

--- a/middlewares/isBusinessOwner.js
+++ b/middlewares/isBusinessOwner.js
@@ -1,8 +1,9 @@
+const { sendForbidden } = require('../utils/apiError');
+
 module.exports = (req, res, next) => {
-  if (req.user.role !== 'business_owner') {
-    return res.status(403).json({
-      success: false,
-      message: 'Access denied: Business Owner only',
+  if (req.user?.role !== 'business_owner') {
+    return sendForbidden(req, res, 'Access denied: Business Owner only', {
+      code: 'BUSINESS_OWNER_REQUIRED',
     });
   }
   next();

--- a/middlewares/requireVerifiedVendor.js
+++ b/middlewares/requireVerifiedVendor.js
@@ -1,4 +1,5 @@
 const VendorOnboarding = require('../models/VendorOnboardingStage1');
+const { sendForbidden, sendUnauthorized } = require('../utils/apiError');
 
 function createRequireVerifiedVendor(options = {}) {
   const { requireStage1Verified = false } = options;
@@ -7,23 +8,33 @@ function createRequireVerifiedVendor(options = {}) {
     const user = req.user;
 
     if (!user) {
-      return res.status(401).json({ message: 'Unauthorized' });
+      return sendUnauthorized(req, res, 'Unauthorized', {
+        code: 'AUTHENTICATION_REQUIRED',
+      });
     }
 
     if (user.role !== 'business_owner') {
-      return res.status(403).json({ message: 'Only vendors allowed' });
+      return sendForbidden(req, res, 'Only vendors allowed', {
+        code: 'VENDOR_REQUIRED',
+      });
     }
 
     if (!user.isOtpVerified) {
-      return res.status(403).json({ message: 'OTP verification required' });
+      return sendForbidden(req, res, 'OTP verification required', {
+        code: 'OTP_VERIFICATION_REQUIRED',
+      });
     }
 
     if (user.isBlocked) {
-      return res.status(403).json({ message: 'Account is blocked' });
+      return sendForbidden(req, res, 'Account is blocked', {
+        code: 'ACCOUNT_BLOCKED',
+      });
     }
 
     if (user.isDeleted) {
-      return res.status(403).json({ message: 'Account is deleted' });
+      return sendForbidden(req, res, 'Account is deleted', {
+        code: 'ACCOUNT_DELETED',
+      });
     }
 
     if (requireStage1Verified) {
@@ -32,8 +43,8 @@ function createRequireVerifiedVendor(options = {}) {
         .lean();
 
       if (!onboarding || onboarding.status !== 'verified') {
-        return res.status(403).json({
-          message: 'Stage 1 vendor verification required',
+        return sendForbidden(req, res, 'Stage 1 vendor verification required', {
+          code: 'STAGE1_VERIFICATION_REQUIRED',
         });
       }
     }

--- a/routes/admin/adminOrderRoutes.js
+++ b/routes/admin/adminOrderRoutes.js
@@ -1,11 +1,12 @@
 const express = require('express');
-const { getAllOrdersAdmin } = require('../../controllers/orderController');
+const { getAdminSalesSummary, getAllOrdersAdmin } = require('../../controllers/orderController');
 const authenticate = require('../../middlewares/authenticate');
 const isAdmin = require('../../middlewares/isAdmin');
 
 const router = express.Router();
 
 // Admin order list — alias for GET /api/orders/admin (frontend /admin/api/* pattern)
+router.get('/summary', authenticate, isAdmin, getAdminSalesSummary);
 router.get('/', authenticate, isAdmin, getAllOrdersAdmin);
 
 module.exports = router;

--- a/tests/admin/admin-order-routes-guard.test.js
+++ b/tests/admin/admin-order-routes-guard.test.js
@@ -14,9 +14,15 @@ test('admin order list route is guarded', () => {
   assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllOrdersAdmin\)/);
 });
 
-test('admin order routes only register guarded list handler', () => {
+test('admin sales summary route is guarded', () => {
+  const source = fs.readFileSync(adminOrderRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/summary', authenticate, isAdmin, getAdminSalesSummary\)/);
+});
+
+test('admin order routes only register guarded read handlers', () => {
   const source = fs.readFileSync(adminOrderRoutesPath, 'utf8');
   const routeMatches = [...source.matchAll(/router\.(get|post|put|patch|delete)\(/g)];
 
-  assert.equal(routeMatches.length, 1, 'expected only admin order list route');
+  assert.equal(routeMatches.length, 2, 'expected only admin order read routes');
 });

--- a/tests/admin/admin-order-summary.test.js
+++ b/tests/admin/admin-order-summary.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const orderControllerPath = path.resolve(__dirname, '../../controllers/orderController.js');
+
+function loadOrderController({ aggregateResponses }) {
+  const pipelines = [];
+  const Order = {
+    aggregate: async (pipeline) => {
+      pipelines.push(pipeline);
+      return aggregateResponses.shift() || [];
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Order') return Order;
+    if (request === 'stripe') return function Stripe() {
+      return { refunds: { create: async () => ({}) } };
+    };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[orderControllerPath];
+  const controller = require(orderControllerPath);
+  Module._load = originalLoad;
+  return { controller, pipelines };
+}
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('getAdminSalesSummary returns sales and vendor totals without platform fee invention', async () => {
+  const vendorId = '507f1f77bcf86cd799439011';
+  const { controller, pipelines } = loadOrderController({
+    aggregateResponses: [
+      [
+        {
+          _id: 'USD',
+          totalOrders: 3,
+          grossSalesAmount: 12000,
+          paidSalesAmount: 9000,
+          refundedSalesAmount: 3000,
+          subtotalAmount: 10000,
+          taxAmount: 700,
+          shippingAmount: 1300,
+        },
+      ],
+      [{ vendorId, currency: 'USD', orderCount: 2, totalSalesAmount: 9000 }],
+      [{ _id: 'paid', count: 2 }],
+      [{ _id: 'ordered', count: 2 }],
+    ],
+  });
+  const res = makeRes();
+
+  await controller.getAdminSalesSummary(
+    {
+      query: {
+        paymentStatus: 'paid',
+        from: '2026-01-01T00:00:00.000Z',
+        to: '2026-01-31T23:59:59.999Z',
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data.salesByCurrency, [
+    {
+      currency: 'USD',
+      totalOrders: 3,
+      grossSalesAmount: 12000,
+      paidSalesAmount: 9000,
+      refundedSalesAmount: 3000,
+      subtotalAmount: 10000,
+      taxAmount: 700,
+      shippingAmount: 1300,
+    },
+  ]);
+  assert.deepEqual(res.body.data.topVendors, [
+    {
+      vendorId,
+      currency: 'USD',
+      orderCount: 2,
+      totalSalesAmount: 9000,
+    },
+  ]);
+  assert.deepEqual(res.body.data.platformRevenue, {
+    supported: false,
+    amount: null,
+    reason: 'Order records do not persist platform fee amounts yet.',
+  });
+  assert.equal(res.body.data.summary.payment.paid, 2);
+  assert.equal(res.body.data.summary.payment.pending, 0);
+  assert.equal(res.body.data.summary.status.ordered, 2);
+  assert.equal(pipelines[0][0].$match.paymentStatus, 'paid');
+  assert.ok(pipelines[0][0].$match.createdAt.$gte instanceof Date);
+});
+
+test('getAdminSalesSummary omits paid top vendors for non-paid payment filters', async () => {
+  const { controller, pipelines } = loadOrderController({
+    aggregateResponses: [
+      [{ _id: 'USD', totalOrders: 1, grossSalesAmount: 3000, refundedSalesAmount: 3000 }],
+      [{ _id: 'refunded', count: 1 }],
+      [{ _id: 'refunded', count: 1 }],
+    ],
+  });
+  const res = makeRes();
+
+  await controller.getAdminSalesSummary(
+    { query: { paymentStatus: 'refunded' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data.topVendors, []);
+  assert.equal(pipelines.length, 3);
+  assert.equal(pipelines[0][0].$match.paymentStatus, 'refunded');
+});

--- a/tests/api-error-response.test.js
+++ b/tests/api-error-response.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildErrorPayload,
+  sendForbidden,
+  sendValidationError,
+} = require('../utils/apiError');
+const isAdmin = require('../middlewares/isAdmin');
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('buildErrorPayload includes stable code, success flag, and requestId', () => {
+  const payload = buildErrorPayload(
+    { requestId: 'req-error-001' },
+    {
+      status: 403,
+      message: 'Access denied',
+      code: 'ADMIN_REQUIRED',
+    }
+  );
+
+  assert.deepEqual(payload, {
+    success: false,
+    message: 'Access denied',
+    code: 'ADMIN_REQUIRED',
+    requestId: 'req-error-001',
+  });
+});
+
+test('sendValidationError normalizes field errors without leaking raw request values', () => {
+  const res = mockResponse();
+
+  sendValidationError(
+    { requestId: 'req-validation-001' },
+    res,
+    {
+      email: 'Email is required',
+      password: 'Password is too short',
+    }
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'VALIDATION_FAILED');
+  assert.equal(res.body.message, 'Validation failed');
+  assert.equal(res.body.error, 'Validation failed');
+  assert.deepEqual(res.body.fieldErrors, {
+    email: 'Email is required',
+    password: 'Password is too short',
+  });
+  assert.equal(res.body.requestId, 'req-validation-001');
+});
+
+test('sendForbidden can preserve legacy error field for existing clients', () => {
+  const res = mockResponse();
+
+  sendForbidden({ requestId: 'req-legacy-001' }, res, 'Unauthorized', {
+    code: 'PRODUCT_OWNER_REQUIRED',
+    includeLegacyError: true,
+  });
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.message, 'Unauthorized');
+  assert.equal(res.body.error, 'Unauthorized');
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'PRODUCT_OWNER_REQUIRED');
+});
+
+test('isAdmin uses standardized error envelope', () => {
+  const res = mockResponse();
+  let calledNext = false;
+
+  isAdmin({ requestId: 'req-admin-001', user: { role: 'customer' } }, res, () => {
+    calledNext = true;
+  });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, 'Access denied: Admin only');
+  assert.equal(res.body.code, 'ADMIN_REQUIRED');
+  assert.equal(res.body.requestId, 'req-admin-001');
+});

--- a/tests/launch/backend-launch-contract.test.js
+++ b/tests/launch/backend-launch-contract.test.js
@@ -150,6 +150,7 @@ test('admin order list requires authenticate and isAdmin', () => {
   const source = readSource(adminOrderRoutesPath);
 
   assert.match(source, /router\.get\('\/', authenticate, isAdmin, getAllOrdersAdmin\)/);
+  assert.match(source, /router\.get\('\/summary', authenticate, isAdmin, getAdminSalesSummary\)/);
 });
 
 test('GET /api/orders/admin requires authenticate and isAdmin', () => {

--- a/tests/reviews/review-controller.test.js
+++ b/tests/reviews/review-controller.test.js
@@ -1,0 +1,277 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(__dirname, '../../controllers/reviewController.js');
+const validListingId = '507f1f77bcf86cd799439011';
+const validReviewId = '507f1f77bcf86cd799439012';
+const validUserId = '507f1f77bcf86cd799439013';
+
+const makeRes = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const makeListingModel = (listing = { _id: validListingId, isDeleted: false }) => ({
+  findById: () => ({
+    select: () => ({
+      lean: async () => listing,
+    }),
+  }),
+});
+
+const makeReviewFindChain = (reviews) => ({
+  populate() {
+    return this;
+  },
+  sort() {
+    return this;
+  },
+  skip() {
+    return this;
+  },
+  limit() {
+    return this;
+  },
+  lean: async () => reviews,
+});
+
+const loadController = ({ Review, listingModel = makeListingModel(), reviewService = {} }) => {
+  const service = {
+    LISTING_MODELS: {
+      product: listingModel,
+      service: listingModel,
+      food: listingModel,
+    },
+    getReviewSummary: async () => ({
+      totalReviews: 1,
+      averageRating: 5,
+      ratingBreakdown: { 5: 1, 4: 0, 3: 0, 2: 0, 1: 0 },
+    }),
+    refreshListingReviewStats: async () => ({
+      totalReviews: 1,
+      averageRating: 5,
+      ratingBreakdown: { 5: 1, 4: 0, 3: 0, 2: 0, 1: 0 },
+    }),
+    ...reviewService,
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Review') return Review;
+    if (request === '../services/reviewService') return service;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+  return controller;
+};
+
+test('listReviews returns only safe public review fields', async () => {
+  const createdAt = new Date('2026-01-01T00:00:00.000Z');
+  const updatedAt = new Date('2026-01-02T00:00:00.000Z');
+  const rawReview = {
+    _id: validReviewId,
+    userId: {
+      _id: validUserId,
+      name: 'E2E Customer',
+      profileImage: 'https://example.test/customer.png',
+      email: 'customer@example.test',
+      passwordHash: 'secret',
+      otp: 'secret',
+      sessionVersion: 4,
+    },
+    listingId: validListingId,
+    listingType: 'product',
+    rating: 5,
+    comment: 'Great product.',
+    image: 'https://example.test/review.png',
+    createdAt,
+    updatedAt,
+    __v: 0,
+    internalNote: 'do not expose',
+  };
+
+  const Review = {
+    find: () => makeReviewFindChain([rawReview]),
+    countDocuments: async () => 1,
+  };
+  const controller = loadController({ Review });
+  const res = makeRes();
+
+  await controller.listReviews('product')(
+    { params: { productId: validListingId }, query: { page: '1', limit: '10' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  const review = res.body.data.reviews[0];
+  assert.deepEqual(Object.keys(review).sort(), [
+    '_id',
+    'comment',
+    'createdAt',
+    'image',
+    'listingId',
+    'listingType',
+    'rating',
+    'updatedAt',
+    'userId',
+  ].sort());
+  assert.deepEqual(Object.keys(review.userId).sort(), ['_id', 'name', 'profileImage'].sort());
+  assert.equal(review.userId.email, undefined);
+  assert.equal(review.userId.passwordHash, undefined);
+  assert.equal(review.__v, undefined);
+  assert.equal(review.internalNote, undefined);
+  assert.equal(review.createdAt, createdAt.toISOString());
+});
+
+test('upsertReview rejects ratings outside the 1 to 5 range', async () => {
+  const Review = {
+    findOne: async () => null,
+  };
+  const controller = loadController({ Review });
+  const res = makeRes();
+
+  await controller.upsertReview('product')(
+    {
+      params: { productId: validListingId },
+      user: { _id: validUserId },
+      body: { rating: 6, comment: 'Too much.' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /between 1 and 5/i);
+});
+
+test('upsertReview updates an existing customer review instead of creating a duplicate', async () => {
+  let savedReview;
+  let refreshArgs;
+  const existingReview = {
+    _id: validReviewId,
+    userId: validUserId,
+    listingId: validListingId,
+    listingType: 'product',
+    rating: 3,
+    comment: 'Old comment.',
+    save: async function save() {
+      savedReview = { rating: this.rating, comment: this.comment, image: this.image };
+    },
+  };
+
+  const Review = {
+    findOne: async (query) => {
+      assert.equal(query.userId, validUserId);
+      assert.equal(query.listingId, validListingId);
+      assert.equal(query.listingType, 'product');
+      return existingReview;
+    },
+    findById: () => ({
+      populate: () => ({
+        lean: async () => ({
+          _id: validReviewId,
+          userId: { _id: validUserId, name: 'E2E Customer', profileImage: '' },
+          listingId: validListingId,
+          listingType: 'product',
+          rating: 4,
+          comment: 'Updated comment.',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-02T00:00:00.000Z',
+          __v: 0,
+        }),
+      }),
+    }),
+  };
+  const controller = loadController({
+    Review,
+    reviewService: {
+      refreshListingReviewStats: async (listingId, listingType) => {
+        refreshArgs = { listingId, listingType };
+        return { totalReviews: 1, averageRating: 4, ratingBreakdown: { 4: 1 } };
+      },
+    },
+  });
+  const res = makeRes();
+
+  await controller.upsertReview('product')(
+    {
+      params: { productId: validListingId },
+      user: { _id: validUserId },
+      body: { rating: 4, comment: 'Updated comment.' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.message, 'Review updated successfully');
+  assert.deepEqual(savedReview, { rating: 4, comment: 'Updated comment.', image: undefined });
+  assert.deepEqual(refreshArgs, { listingId: validListingId, listingType: 'product' });
+  assert.equal(res.body.data.review.__v, undefined);
+});
+
+test('deleteReview scopes deletion to the requesting customer', async () => {
+  let capturedQuery;
+  const Review = {
+    findOne: async (query) => {
+      capturedQuery = query;
+      return null;
+    },
+  };
+  const controller = loadController({ Review });
+  const res = makeRes();
+
+  await controller.deleteReview('product')(
+    {
+      params: { productId: validListingId, reviewId: validReviewId },
+      user: { _id: validUserId },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(capturedQuery, {
+    _id: validReviewId,
+    listingId: validListingId,
+    listingType: 'product',
+    userId: validUserId,
+  });
+});
+
+test('product, service, and food review mutations require customer auth middleware', () => {
+  const routeChecks = [
+    {
+      file: path.resolve(__dirname, '../../routes/productRoutes.js'),
+      post: /router\.post\(\s*['"]\/:productId\/reviews['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*upsertReview/,
+      del: /router\.delete\(\s*['"]\/:productId\/reviews\/:reviewId['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*deleteReview/,
+    },
+    {
+      file: path.resolve(__dirname, '../../routes/serviceRoutes.js'),
+      post: /router\.post\(\s*['"]\/:serviceId\/reviews['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*upsertReview/,
+      del: /router\.delete\(\s*['"]\/:serviceId\/reviews\/:reviewId['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*deleteReview/,
+    },
+    {
+      file: path.resolve(__dirname, '../../routes/foodRoutes.js'),
+      post: /router\.post\(\s*['"]\/:foodId\/reviews['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*upsertReview/,
+      del: /router\.delete\(\s*['"]\/:foodId\/reviews\/:reviewId['"][\s\S]*authenticate[\s\S]*isCustomer[\s\S]*deleteReview/,
+    },
+  ];
+
+  for (const check of routeChecks) {
+    const source = fs.readFileSync(check.file, 'utf8');
+    assert.match(source, check.post, `${path.basename(check.file)} review POST is not customer-guarded`);
+    assert.match(source, check.del, `${path.basename(check.file)} review DELETE is not customer-guarded`);
+  }
+});

--- a/utils/apiError.js
+++ b/utils/apiError.js
@@ -1,0 +1,101 @@
+const STATUS_CODES = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  409: "CONFLICT",
+  422: "VALIDATION_FAILED",
+  429: "RATE_LIMITED",
+  500: "INTERNAL_SERVER_ERROR",
+};
+
+function getRequestId(req) {
+  const requestId = req?.requestId || req?.headers?.["x-request-id"];
+  return typeof requestId === "string" && requestId.trim()
+    ? requestId.trim().slice(0, 128)
+    : undefined;
+}
+
+function normalizeFieldErrors(fieldErrors) {
+  if (!fieldErrors || typeof fieldErrors !== "object" || Array.isArray(fieldErrors)) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    Object.entries(fieldErrors)
+      .filter(([key, value]) => key && value != null)
+      .map(([key, value]) => [String(key), String(value)])
+  );
+}
+
+function buildErrorPayload(req, {
+  status = 500,
+  message = "Internal server error",
+  code,
+  fieldErrors,
+  includeLegacyError = false,
+} = {}) {
+  const payload = {
+    success: false,
+    message,
+    code: code || STATUS_CODES[status] || "ERROR",
+  };
+  const requestId = getRequestId(req);
+  const normalizedFieldErrors = normalizeFieldErrors(fieldErrors);
+
+  if (requestId) payload.requestId = requestId;
+  if (normalizedFieldErrors && Object.keys(normalizedFieldErrors).length > 0) {
+    payload.fieldErrors = normalizedFieldErrors;
+  }
+  if (includeLegacyError) {
+    payload.error = message;
+  }
+
+  return payload;
+}
+
+function sendError(req, res, status, options = {}) {
+  return res.status(status).json(buildErrorPayload(req, { ...options, status }));
+}
+
+function sendValidationError(req, res, fieldErrors, message = "Validation failed") {
+  return sendError(req, res, 400, {
+    message,
+    code: "VALIDATION_FAILED",
+    fieldErrors,
+    includeLegacyError: true,
+  });
+}
+
+function sendUnauthorized(req, res, message = "Authentication required", options = {}) {
+  return sendError(req, res, 401, {
+    message,
+    code: options.code || "AUTHENTICATION_REQUIRED",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+function sendForbidden(req, res, message = "Forbidden", options = {}) {
+  return sendError(req, res, 403, {
+    message,
+    code: options.code || "FORBIDDEN",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+function sendNotFound(req, res, message = "Not found", options = {}) {
+  return sendError(req, res, 404, {
+    message,
+    code: options.code || "NOT_FOUND",
+    includeLegacyError: options.includeLegacyError,
+  });
+}
+
+module.exports = {
+  buildErrorPayload,
+  sendError,
+  sendForbidden,
+  sendNotFound,
+  sendUnauthorized,
+  sendValidationError,
+};


### PR DESCRIPTION
## Summary
- Brings `staging` up to date with `main` so both branches reflect the same merged backend work before the next session.
- Includes PR #115 staging merge plus three feature merges already on `main`:
  - **#116** — Public review API proof (`codex/backend-reviews-api-proof`)
  - **#117** — Admin sales summary endpoint (`codex/backend-admin-sales-summary`)
  - **#118** — Standardized representative API errors (`codex/backend-error-consistency`)
- Touches order/product/review controllers, auth middleware, `utils/apiError.js`, docs, and related tests (~16 files, +1068 / -91 lines).

## Test plan
- [ ] CI passes on this PR
- [ ] Confirm `staging` deploy/preview (if applicable) starts cleanly after merge
- [ ] Smoke: admin sales summary endpoint returns expected shape
- [ ] Smoke: public review API routes respond per contract
- [ ] Smoke: representative error responses match `docs/backend/ERROR_RESPONSE_CONTRACT.md`
