### PR TITLE
chore: deploy backend automatically from main

### DIFF
--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -2,10 +2,9 @@ name: Deploy to Elastic Beanstalk
 
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
-  # Re-enable after first successful manual deploy and production environment + AWS OIDC role are confirmed.
+  push:
+    branches:
+      - main
 
 concurrency:
   group: deploy-production

--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -22,9 +22,9 @@ Process guide for AI agents and developers working on `Techware-Hut/mosaic-backe
 | --- | --- |
 | One issue per branch | Branch name: `sprint/backend-<short-description>` |
 | One PR per issue | Do not bundle unrelated fixes |
-| No direct commits to `main` | Always use a feature branch |
+| No direct commits to `main` | Always use a feature branch; promote via `staging` only |
 | No merge | Human merges after review |
-| No deploy | Human runs EB deploy via GHA `workflow_dispatch` |
+| No manual deploy | Agents must not trigger GHA deploy workflows; merge to `main` triggers auto-deploy |
 | No secrets | Never commit `.env`, paste values in docs, or log credentials |
 | No fake proof | Do not invent smoke results, payment success, or production evidence |
 | No live Stripe charges | Test mode only unless written approval exists |
@@ -37,7 +37,7 @@ Process guide for AI agents and developers working on `Techware-Hut/mosaic-backe
 
 ## Before coding
 
-1. `git checkout main && git pull origin main`
+1. `git checkout staging && git pull origin staging`
 2. Confirm working tree is clean (`git status`)
 3. Read docs listed in [Read order](#read-order-mandatory) above
 4. Inspect existing tests for the area you will change (`tests/<domain>/`)
@@ -75,11 +75,13 @@ Examples: `docs(agent): architecture knowledge pack (#50)` · `fix(checkout): bl
 
 | Action | Who | How |
 | --- | --- | --- |
-| Merge to `main` | Human reviewer | GitHub PR merge |
-| Production deploy | Release owner | Manual GHA workflow: [deploy-eb-production.yml](../.github/workflows/deploy-eb-production.yml) |
+| Merge to `staging` | Human reviewer | GitHub PR merge from feature branch |
+| Merge to `main` | Human reviewer | GitHub PR merge from `staging` only |
+| Production deploy | Automatic on push/merge to `main` | [deploy-eb-production.yml](../.github/workflows/deploy-eb-production.yml) (tests must pass first) |
+| Manual redeploy | Release owner | GHA `workflow_dispatch` on [deploy-eb-production.yml](../.github/workflows/deploy-eb-production.yml) |
 | Post-deploy smoke | QA / release owner | [production-smoke-checklist.md](production-smoke-checklist.md) tiers P0–P6 |
 | Deploy evidence | Release owner | Append to [deploy-verification.md](deploy-verification.md) |
-| Push-to-main auto-deploy | **Disabled** | Intentionally commented out in deploy workflow |
+| Push-to-main auto-deploy | **Enabled** | Push/merge to `main` triggers deploy workflow |
 
 Agents must **not** trigger deploy workflows, change EB env vars, or mark launch items complete without evidence.
 

--- a/docs/BACKEND_LLM_INSTRUCTIONS.md
+++ b/docs/BACKEND_LLM_INSTRUCTIONS.md
@@ -16,7 +16,7 @@ Use this document as project instructions for LLM coding assistants working on *
 | **Language** | Plain JavaScript (CommonJS). No TypeScript, no build step |
 | **Entry** | [`index.js`](../index.js) → [`app.js`](../app.js) |
 | **Default port** | `3001` (`PORT` env var) |
-| **Deploy target** | AWS Elastic Beanstalk (`us-east-1`), manual GitHub Actions deploy from `main` |
+| **Deploy target** | AWS Elastic Beanstalk (`us-east-1`), auto GitHub Actions deploy on push/merge to `main` (manual `workflow_dispatch` also available) |
 | **Tests** | `npm test` → Node built-in test runner (~168 tests across 37 files) |
 | **Docs hub** | [LLM_CONTEXT.md](LLM_CONTEXT.md) (start here for safe edits) |
 
@@ -469,11 +469,12 @@ Full route map: [API_SURFACE.md](API_SURFACE.md)
 
 ### Branch flow
 
-`sprint/backend-*` → PR → human merge → `main` → **manual** GHA EB deploy (push-to-main auto-deploy is disabled)
+`feature/*` or `sprint/backend-*` → PR → **`staging`** → PR → **`main`** → **auto** GHA EB deploy. Never open feature PRs directly to `main`. Manual `workflow_dispatch` remains for redeploys.
 
 ### Production deploy
 
-- Workflow: [`.github/workflows/deploy-eb-production.yml`](../.github/workflows/deploy-eb-production.yml)
+- Workflow: [`.github/workflows/deploy-eb-production.yml`](../.github/workflows/deploy-eb-production.yml) — triggers on push/merge to `main` and via `workflow_dispatch`
+- Deploy job requires the `test` job to pass; gated by GitHub `production` environment when configured
 - EB app: `mosaic-biz-hub-backend`, env: `mosaic-backend-env`
 - Region: `us-east-1`
 

--- a/docs/LLM_CONTEXT.md
+++ b/docs/LLM_CONTEXT.md
@@ -19,7 +19,7 @@ For full route maps and lifecycle detail, see [ARCHITECTURE.md](ARCHITECTURE.md)
 | Entry | `index.js` → `app.js` |
 | Default port | `3001` |
 | Production API | `https://api.mosaicbizhub.com` |
-| Deploy target | AWS Elastic Beanstalk (manual GHA deploy from `main`) |
+| Deploy target | AWS Elastic Beanstalk (auto GHA deploy on push/merge to `main`; manual `workflow_dispatch` also available) |
 | **MVP program status** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) |
 
 ---
@@ -404,7 +404,7 @@ POST finalizeVerification  → status verified → syncBusinessFromOnboarding �
 | [production-smoke-checklist.md](production-smoke-checklist.md) | Post-deploy smoke tiers P0–P6 |
 | [production-env-checklist.md](production-env-checklist.md) | EB env var audit |
 
-**Branch flow:** `sprint/backend-*` → PR → human merge → `main` → manual GHA EB deploy. Push-to-main auto-deploy is **disabled**.
+**Branch flow:** `feature/*` or `sprint/backend-*` → PR → **`staging`** → PR → **`main`** → auto GHA EB deploy. Never open feature PRs directly to `main`. Manual `workflow_dispatch` remains for redeploys.
 
 ---
 
@@ -432,7 +432,8 @@ POST finalizeVerification  → status verified → syncBusinessFromOnboarding �
 ## Release-control guardrails (agents)
 
 - One issue per branch; one PR per issue
-- No direct commits to `main`; no merge; no deploy
+- Branch from `staging`; promote via PR to `staging`, then PR `staging` → `main` only
+- No direct commits to `main`; no merge; no manual deploy triggers
 - No secrets in docs, logs, or screenshots
 - No fake production proof or live Stripe charges
 - Do not edit deploy workflows without explicit issue scope + written approval

--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -70,12 +70,12 @@ flowchart LR
 | 2 | Complete [STAGING.md](../STAGING.md) integration checklist | Backend engineer + reviewer | **Provisional** |
 | 3 | Open PR `staging` → `main`; obtain approvals | Reviewer + release owner | **Provisional** |
 | 4 | Confirm rollback readiness (SHA, EB path) | Release owner + infra owner | **Provisional** |
-| 5 | Deploy exact `main` commit to EB | Infrastructure owner | — |
+| 5 | Auto-deploy exact `main` commit to EB via GHA | GitHub Actions (on push/merge to `main`) | — |
 | 6 | **Confirm deployed commit on EB** | **Infrastructure / deployment owner** | **Required before final smoke** |
 | 7 | Run post-deploy smoke on `https://api.mosaicbizhub.com` | Release owner | **Provisional until commit confirmed** |
 | 8 | Fill proof pack; Go/No-Go decision | Release owner | **Final launch sign-off** |
 
-**No auto-deploy on merge.** Merging to `main` does not update EB until the infrastructure owner deploys.
+**Auto-deploy on merge.** Merging or pushing to `main` triggers the deploy workflow after tests pass. Manual `workflow_dispatch` remains available for redeploys.
 
 **Critical rule:** Final launch sign-off requires the **deployment owner to confirm the commit SHA running on EB** matches the intended `main` release. Baseline health probes on the custom domain (while an older commit is still live) are **not** sufficient for sign-off.
 

--- a/docs/PUSH_TO_MAIN_DEPLOY_CRITERIA.md
+++ b/docs/PUSH_TO_MAIN_DEPLOY_CRITERIA.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#23 Define criteria for re-enabling push-to-main deployment](https://github.com/Techware-Hut/mosaic-backend/issues/23)  
 **Workflow:** [`.github/workflows/deploy-eb-production.yml`](../.github/workflows/deploy-eb-production.yml)  
-**Current state:** `push:` to `main` is **commented out** — deploy is manual `workflow_dispatch` only.
+**Current state:** `push:` to `main` is **enabled** — deploy runs automatically on push/merge to `main`. Manual `workflow_dispatch` also available.
 
 ---
 

--- a/docs/github-actions-eb-setup.md
+++ b/docs/github-actions-eb-setup.md
@@ -186,7 +186,7 @@ The deploy workflow (`.github/workflows/deploy-eb-production.yml`):
 4. Passes temporary credentials to `einaregilsson/beanstalk-deploy@v22`
 5. Runs post-deploy health probes on `https://api.mosaicbizhub.com`
 
-Push-to-`main` auto-deploy is **temporarily disabled** in the workflow (only `workflow_dispatch` runs until AWS OIDC and the GitHub `production` environment are confirmed). After first successful manual deploy, re-enable the push trigger in the workflow. When enabled, deploys are gated by the GitHub **`production`** environment.
+Push-to-`main` auto-deploy is **enabled** in the workflow. Push/merge to `main` triggers deploy; `workflow_dispatch` remains for manual redeploys. Deploys are gated by the deploy workflow `test` job and the GitHub **`production`** environment when configured.
 
 ---
 
@@ -203,7 +203,7 @@ Push-to-`main` auto-deploy is **temporarily disabled** in the workflow (only `wo
 9. [ ] Run [production-smoke-checklist.md](production-smoke-checklist.md) minimum tier
 10. [ ] Update [deploy-verification.md](deploy-verification.md) with deployed SHA
 
-After first successful manual deploy, re-enable push-to-`main` in the workflow; auto-deploy will then be gated by the `production` environment when configured.
+Push-to-`main` auto-deploy is enabled; deploys run automatically on push/merge to `main` and are gated by the `production` environment when configured. Use `workflow_dispatch` for manual redeploys.
 
 Remove obsolete deploy secrets if they were ever added (not used by OIDC):
 


### PR DESCRIPTION
## Summary

Enables automatic production deployment to AWS Elastic Beanstalk when commits are pushed or merged into `main`. Manual `workflow_dispatch` remains available for redeploys.

Updates LLM and ops docs to reflect auto-deploy and the canonical branch flow: **feature branch → `staging` → `main`** (never feature → `main` directly).

## What changed

- Uncommented `push: branches: [main]` in `.github/workflows/deploy-eb-production.yml`
- Synced deploy/branch-flow wording in LLM and ops docs

## Deployment behavior

- **Triggers:** push/merge to `main` **and** manual `workflow_dispatch`
- **Gate:** deploy job requires `test` job to pass (`needs: test`)
- **Environment:** GitHub `production` environment (OIDC unchanged)
- **Post-deploy probes:** unchanged (health, auth 401, readiness/release identity, CORS, featured-products)
- **Concurrency:** `deploy-production`, `cancel-in-progress: false`

## Branch flow (reminder)

`feature/*` or `sprint/backend-*` → PR → **`staging`** → PR → **`main`** → auto deploy

## Branch protection report

GitHub API (read-only): classic branch protection **not configured** on `main` or `staging`; repository rulesets empty. Documentation ([STAGING.md](../STAGING.md), [PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md)) still intends PR review and CI before promotion — consider enabling GitHub branch protection separately.

## Rollback

1. Revert this PR or re-comment the `push:` trigger in the deploy workflow
2. Follow [PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) if a bad deploy occurred
3. Use `workflow_dispatch` to redeploy a known-good SHA

## Test plan

- [x] `npm test` — **338/338 pass**
- [x] YAML syntax validated (PyYAML parse)
- [ ] CI passes on this PR
- [ ] After merge: confirm deploy workflow runs on push to `main` (not tested in this PR)

## What was not tested

- Live Elastic Beanstalk deployment
- GitHub `production` environment approval flow
- Post-deploy probes against production API
- Actual workflow trigger on merge (requires merge; explicitly excluded)

## Application code

No changes to application, payment, webhook, auth, CORS, or Stripe code.
