### PR TITLE
fix: add child service delete endpoint for vendor listings

### DIFF
--- a/controllers/serviceChildController.js
+++ b/controllers/serviceChildController.js
@@ -1,0 +1,82 @@
+const mongoose = require('mongoose');
+const Service = require('../models/Service');
+const Business = require('../models/Business');
+const deleteCloudinaryFile = require('../utils/deleteCloudinaryFile');
+const {
+  getMinimumChildServicePrice,
+  formatOwnerServiceResponse,
+} = require('../lib/service/serviceContract');
+
+const NOT_FOUND_MESSAGE = 'Service not found or unauthorized.';
+
+exports.deleteChildService = async (req, res) => {
+  try {
+    const { parentServiceId, childServiceId } = req.params;
+    const userId = req.user._id;
+
+    if (
+      !mongoose.Types.ObjectId.isValid(parentServiceId) ||
+      !mongoose.Types.ObjectId.isValid(childServiceId)
+    ) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const parentService = await Service.findOne({
+      _id: parentServiceId,
+      ownerId: userId,
+    });
+
+    if (!parentService) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const childToDelete = parentService.services.id(childServiceId);
+    if (!childToDelete) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const imagesToCleanup = [
+      childToDelete.image,
+      ...(Array.isArray(childToDelete.images) ? childToDelete.images : []),
+    ].filter(Boolean);
+
+    const remainingServices = parentService.services.filter(
+      (service) => String(service._id) !== String(childServiceId)
+    );
+
+    if (remainingServices.length > 0) {
+      parentService.services = remainingServices;
+      parentService.price = getMinimumChildServicePrice(remainingServices, 0);
+      parentService.duration = '';
+    } else {
+      parentService.services = [];
+      parentService.price = 0;
+      parentService.duration = '';
+      parentService.isPublished = false;
+    }
+
+    await parentService.save();
+
+    for (const image of imagesToCleanup) {
+      await deleteCloudinaryFile(image).catch(() => {});
+    }
+
+    const business = await Business.findById(parentService.businessId).select(
+      'isActive isApproved owner'
+    );
+
+    const response = formatOwnerServiceResponse(
+      parentService,
+      business,
+      'Child service deleted successfully.'
+    );
+
+    return res.status(200).json({
+      ...response,
+      deletedChildServiceId: String(childServiceId),
+    });
+  } catch (err) {
+    console.error('Failed to delete child service:', err.message);
+    return res.status(500).json({ error: 'Failed to delete child service.' });
+  }
+};

--- a/routes/serviceRoutes.js
+++ b/routes/serviceRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { createService, getMyServices, deleteService, updateService, getServiceById, getBusinessServiceById, getServiceUploadUrl, createParentService, addChildServices, getParentServices, getChildServices } = require('../controllers/serviceController');
+const { deleteChildService } = require('../controllers/serviceChildController');
 const authenticate = require('../middlewares/authenticate');
 const isBusinessOwner = require('../middlewares/isBusinessOwner');
 const isCustomer = require('../middlewares/isCustomer');
@@ -24,6 +25,13 @@ router.get(
   authenticate,
   isBusinessOwner,
   getChildServices
+);
+
+router.delete(
+  '/:parentServiceId/child-services/:childServiceId',
+  authenticate,
+  isBusinessOwner,
+  deleteChildService
 );
 
 router.post(

--- a/tests/integration/service-child-delete.integration.test.js
+++ b/tests/integration/service-child-delete.integration.test.js
@@ -1,0 +1,250 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedServiceBusiness,
+  seedServiceCategories,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Service = require('../../models/Service');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+const twoChildPayload = {
+  title: 'Integration Hair Styling',
+  description: 'Full salon menu for child delete proof',
+  services: [
+    { name: 'Basic Cut', price: 30, duration: '30' },
+    { name: 'Premium Cut', price: 50, duration: '60' },
+  ],
+};
+
+async function setupVendorWithTwoChildren(agent, { isPublished = false, businessOverrides = {} } = {}) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user, businessOverrides);
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const createRes = await agent.post('/api/service/').send({
+    ...twoChildPayload,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished,
+  });
+
+  const service = createRes.body?.data?.service;
+  const parentServiceId = service?._id ? String(service._id) : null;
+  const childAId = service?.services?.[0]?._id ? String(service.services[0]._id) : null;
+  const childBId = service?.services?.[1]?._id ? String(service.services[1]._id) : null;
+
+  return {
+    vendor,
+    user,
+    business,
+    category,
+    subcategory,
+    createRes,
+    parentServiceId,
+    childAId,
+    childBId,
+    slug: service?.slug || null,
+  };
+}
+
+function assertPublicSurfacesIncludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 200);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 200);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 200);
+  })();
+}
+
+function assertPublicSurfacesExcludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(!publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 404);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 404);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 404);
+  })();
+}
+
+test('owner deletes one of two child services without deleting parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: true });
+
+  assert.equal(setup.createRes.status, 201);
+  assert.equal(setup.createRes.body.data.service.services.length, 2);
+
+  const deleteRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childBId}`
+  );
+
+  assert.equal(deleteRes.status, 200);
+  assert.equal(deleteRes.body.success, true);
+  assert.equal(deleteRes.body.deletedChildServiceId, setup.childBId);
+  assert.equal(deleteRes.body.data.service.services.length, 1);
+  assert.equal(String(deleteRes.body.data.service.services[0]._id), setup.childAId);
+  assert.equal(deleteRes.body.data.service.price, 30);
+  assert.equal(deleteRes.body.data.service.isPublished, true);
+  assert.equal(deleteRes.body.data.publication.isPublished, true);
+  assert.equal(deleteRes.body.data.publication.isPubliclyVisible, true);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.ok(parentInDb, 'parent service must remain in database');
+  assert.equal(parentInDb.services.length, 1);
+  assert.equal(String(parentInDb.services[0]._id), setup.childAId);
+  assert.equal(parentInDb.price, 30);
+  assert.equal(parentInDb.isPublished, true);
+
+  await assertPublicSurfacesIncludeService(agent, setup.parentServiceId, setup.slug);
+});
+
+test('owner deleting final child unpublishes parent and hides public listing', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: true });
+
+  assert.equal(setup.createRes.status, 201);
+
+  const deleteFirst = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childBId}`
+  );
+  assert.equal(deleteFirst.status, 200);
+
+  const deleteFinal = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childAId}`
+  );
+
+  assert.equal(deleteFinal.status, 200);
+  assert.equal(deleteFinal.body.success, true);
+  assert.equal(deleteFinal.body.deletedChildServiceId, setup.childAId);
+  assert.deepEqual(deleteFinal.body.data.service.services, []);
+  assert.equal(deleteFinal.body.data.service.price, 0);
+  assert.equal(deleteFinal.body.data.service.duration, '');
+  assert.equal(deleteFinal.body.data.service.isPublished, false);
+  assert.equal(deleteFinal.body.data.publication.isPublished, false);
+  assert.equal(deleteFinal.body.data.publication.isPubliclyVisible, false);
+
+  const parentCount = await Service.countDocuments({ _id: setup.parentServiceId });
+  assert.equal(parentCount, 1);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.ok(parentInDb);
+  assert.equal(parentInDb.services.length, 0);
+  assert.equal(parentInDb.price, 0);
+  assert.equal(parentInDb.isPublished, false);
+
+  await assertPublicSurfacesExcludeService(agent, setup.parentServiceId, setup.slug);
+});
+
+test('another business_owner cannot delete child service', async () => {
+  const agentA = createAgent(getApp());
+  const agentB = createAgent(getApp());
+
+  const setupA = await setupVendorWithTwoChildren(agentA, { isPublished: true });
+  assert.equal(setupA.createRes.status, 201);
+
+  const vendorB = await registerAndVerify(agentB, { role: 'business_owner' });
+  await login(agentB, vendorB.email, vendorB.password);
+
+  const deleteRes = await agentB.delete(
+    `/api/service/${setupA.parentServiceId}/child-services/${setupA.childBId}`
+  );
+  assert.equal(deleteRes.status, 404);
+
+  const parentInDb = await Service.findById(setupA.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+  assert.ok(parentInDb.services.some((child) => String(child._id) === setupA.childAId));
+  assert.ok(parentInDb.services.some((child) => String(child._id) === setupA.childBId));
+});
+
+test('invalid parent or child id returns safe 404 without modifying parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const invalidParentRes = await agent.delete(
+    `/api/service/not-a-valid-id/child-services/${setup.childAId}`
+  );
+  assert.equal(invalidParentRes.status, 404);
+
+  const invalidChildRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/not-a-valid-id`
+  );
+  assert.equal(invalidChildRes.status, 404);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+});
+
+test('missing child id returns 404 and does not modify parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const missingChildId = new mongoose.Types.ObjectId();
+  const deleteRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${missingChildId}`
+  );
+
+  assert.equal(deleteRes.status, 404);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+});
+
+test('existing parent deletion route still deletes entire parent service', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const deleteRes = await agent.delete(`/api/service/delete-service/${setup.parentServiceId}`);
+  assert.equal(deleteRes.status, 200);
+  assert.equal(deleteRes.body.message, 'Service deleted successfully.');
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb, null);
+});


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/service/:parentServiceId/child-services/:childServiceId` so business owners can remove one embedded child service without deleting the parent listing.
- Recalculates parent price from remaining children, auto-unpublishes when the last child is removed, and performs best-effort S3 cleanup after save.
- Preserves existing `DELETE /api/service/delete-service/:id` parent deletion behavior.

## Root cause

The vendor dashboard sent child subdocument IDs to `DELETE /api/service/delete-service/:id`, which looks up a top-level `Service._id` and returned 404.

## Test plan

- [x] `npm test` — 345 passed
- [x] `npm run test:contract` — 20 passed
- [x] `npm run test:integration` — 44 passed (includes 6 new child-delete scenarios)
- [x] Smoke: `GET /api/health` → 200, `GET /api/ready` → 200
- [ ] Frontend switches to new route before vendor delete goes live

## Integration proof

New file `tests/integration/service-child-delete.integration.test.js` verifies:
1. Owner deletes one of two children — parent remains, price recalculates, publication preserved
2. Owner deletes final child — parent remains empty, unpublished, hidden from public surfaces
3. Cross-vendor delete returns 404 with no data change
4. Invalid IDs return safe 404
5. Missing child ID returns 404
6. Existing parent delete route still works
