### PR TITLE
audit: backend route manifest and frontend contract risk report

### DIFF
--- a/controllers/serviceChildController.js
+++ b/controllers/serviceChildController.js
@@ -1,0 +1,82 @@
+const mongoose = require('mongoose');
+const Service = require('../models/Service');
+const Business = require('../models/Business');
+const deleteCloudinaryFile = require('../utils/deleteCloudinaryFile');
+const {
+  getMinimumChildServicePrice,
+  formatOwnerServiceResponse,
+} = require('../lib/service/serviceContract');
+
+const NOT_FOUND_MESSAGE = 'Service not found or unauthorized.';
+
+exports.deleteChildService = async (req, res) => {
+  try {
+    const { parentServiceId, childServiceId } = req.params;
+    const userId = req.user._id;
+
+    if (
+      !mongoose.Types.ObjectId.isValid(parentServiceId) ||
+      !mongoose.Types.ObjectId.isValid(childServiceId)
+    ) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const parentService = await Service.findOne({
+      _id: parentServiceId,
+      ownerId: userId,
+    });
+
+    if (!parentService) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const childToDelete = parentService.services.id(childServiceId);
+    if (!childToDelete) {
+      return res.status(404).json({ error: NOT_FOUND_MESSAGE });
+    }
+
+    const imagesToCleanup = [
+      childToDelete.image,
+      ...(Array.isArray(childToDelete.images) ? childToDelete.images : []),
+    ].filter(Boolean);
+
+    const remainingServices = parentService.services.filter(
+      (service) => String(service._id) !== String(childServiceId)
+    );
+
+    if (remainingServices.length > 0) {
+      parentService.services = remainingServices;
+      parentService.price = getMinimumChildServicePrice(remainingServices, 0);
+      parentService.duration = '';
+    } else {
+      parentService.services = [];
+      parentService.price = 0;
+      parentService.duration = '';
+      parentService.isPublished = false;
+    }
+
+    await parentService.save();
+
+    for (const image of imagesToCleanup) {
+      await deleteCloudinaryFile(image).catch(() => {});
+    }
+
+    const business = await Business.findById(parentService.businessId).select(
+      'isActive isApproved owner'
+    );
+
+    const response = formatOwnerServiceResponse(
+      parentService,
+      business,
+      'Child service deleted successfully.'
+    );
+
+    return res.status(200).json({
+      ...response,
+      deletedChildServiceId: String(childServiceId),
+    });
+  } catch (err) {
+    console.error('Failed to delete child service:', err.message);
+    return res.status(500).json({ error: 'Failed to delete child service.' });
+  }
+};

--- a/docs/contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md
+++ b/docs/contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md
@@ -1,0 +1,458 @@
+# Backend Frontend Contract Risk Report
+
+**Type:** Launch readiness audit evidence  
+**Generated:** 2026-06-24  
+**Branch:** `audit/backend-frontend-contract-integrity`  
+**Baseline:** `main` + merged `fix/backend-vendor-child-service-delete` (PR #124)  
+**Companion:** [`BACKEND_ROUTE_MANIFEST.md`](./BACKEND_ROUTE_MANIFEST.md)  
+**Production API host:** `https://api.mosaicbizhub.com`
+
+---
+
+## Executive summary
+
+Static audit of **309 registered route rows** (52 mount registrations, including duplicate mounts) found **no missing Stripe raw-body webhook ordering issues** and **confirmed payment-intent is authenticated in code** — but several **documentation files still describe it as unauthenticated**, which is a launch-risk for QA and frontend guards.
+
+Top contract risks for frontend integration:
+
+1. **P0 — Discount mutations lack business ownership checks** despite `isBusinessOwner` middleware (IDOR by discount id).
+2. **P1 — Service deletion has two incompatible DELETE semantics** (`delete-service/:id` = whole parent; `/:parentId/child-services/:childId` = embedded child). Frontend sending child ids to the parent route returns 404.
+3. **P1 — Stripe legacy checkout session** may start checkout for any `draftId` without verifying draft ownership.
+4. **P2 — Public onboarding status** exposes application metadata and PII by `applicationId` without auth.
+5. **P2 — Response envelope inconsistency** across delete mutations (`{ message }` vs `{ success, data }`).
+
+**Doc drift:** [`docs/API_SURFACE.md`](../API_SURFACE.md) is stale on payment-intent auth and omits the new child-service DELETE route. [`docs/MVP_BACKEND_API_AUDIT.md`](../MVP_BACKEND_API_AUDIT.md) and [`docs/launch-readiness-report.md`](../launch-readiness-report.md) contain outdated claims that `/stripe/*` and payment-intent are unauthenticated.
+
+---
+
+## Registered route count
+
+| Metric | Value |
+| --- | --- |
+| Total manifest rows | **309** |
+| Unique mount registrations | **52** |
+| Router files on disk | **51** |
+| Unmounted router files | **1** (`routes/cms/cmsRoutes.js`) |
+| Inline `app.js` handlers | **3** (`GET /`, vendor onboarding payment webhook, subscription webhook) |
+
+---
+
+## Mount prefixes (registration order)
+
+See full table in [`BACKEND_ROUTE_MANIFEST.md`](./BACKEND_ROUTE_MANIFEST.md#mount-prefix-registry-registration-order).
+
+Notable dual mounts:
+
+| Router file | Mount prefixes |
+| --- | --- |
+| `vendorOnboarding.routes.js` | `/api/vendor-onboarding`, `/admin/vendor-onboard-verify-stage1` |
+| `admin/cmsRoutes.js` | `/api/cms`, `/cms` |
+| `admin/businessRoutes.js` | `/admin/api/business`, `/api/admin/business` |
+| Shared `/api` prefix | `healthRoutes`, `publicListing`, `uploadImage`, `categoryRoutes`, `subcategoryRoutes`, `api.routes`, `featuredProductRoutes` |
+
+---
+
+## Duplicate routes
+
+| ID | Description | Evidence |
+| --- | --- | --- |
+| DUP-01 | CMS admin/public routes registered at both `/api/cms/*` and `/cms/*` | `app.js:174,179` |
+| DUP-02 | Admin business routes at `/admin/api/business` and `/api/admin/business` | `app.js:187-188` |
+| DUP-03 | Vendor onboarding router mounted twice with different prefixes | `app.js:163-164` |
+| DUP-04 | Legacy alias `GET /api/getProductCategories` duplicates `GET /api/categories/products` | `categoryRoutes.js:21,26` |
+| DUP-05 | Featured products canonical: `GET /api/featured-products` only — `/api/products/featured` **not registered** (correct) | `featuredProductRoutes.js`, contract tests |
+
+---
+
+## Unmounted routers
+
+| File | Status |
+| --- | --- |
+| `routes/cms/cmsRoutes.js` | Not referenced in `app.js`. Active CMS is `routes/admin/cmsRoutes.js`. Dead file references `getHowItWorks` without import — do not mount without repair. |
+
+---
+
+## Dynamic route-order risks
+
+| ID | Router | Risk | Current status |
+| --- | --- | --- | --- |
+| RO-01 | `serviceRoutes.js` | `/:id` could shadow named routes | **Safe** — static paths (`/delete-service/:id`, `/child-services/...`, `/my-services`) registered before `/:id` |
+| RO-02 | `vendorOnboarding.routes.js` | Admin `GET /:applicationId` vs public `GET /status/:applicationId` | **Safe on vendor mount** — `/status/...` is static. On `/admin/vendor-onboard-verify-stage1`, admin routes use `authenticate,isAdmin` |
+| RO-03 | `orderRoutes.js` | `GET /vendor` vs `GET /:id/invoice.pdf` | **Safe** — `/vendor` registered before param route |
+| RO-04 | `productRoutes.js` | Variant routes vs `/:id` | **Verify** — delete-variant uses explicit prefix `/delete-variant/:productId/:variantId` |
+
+---
+
+## Routes missing authentication (route level)
+
+| Route | Method | Notes |
+| --- | --- | --- |
+| `GET /api/admin/categories` | GET | No `authenticate`/`isAdmin` at route — public taxonomy dump |
+| `GET /api/vendor-onboarding/status/:applicationId` | GET | Intentionally public polling |
+| `POST /api/discounts/validate` | POST | Public coupon validation |
+| `POST /api/discounts/apply` | POST | Public apply |
+| Most public marketplace GETs | GET | By design |
+| Stripe webhooks | POST | Signature-only (no JWT) |
+
+**Corrected finding:** `POST /api/payments/create-payment-intent` **has** `authenticate` + `isCustomer` in [`paymentRoutes.js`](../routes/paymentRoutes.js). [`docs/API_SURFACE.md`](../API_SURFACE.md) line ~348 still marks it ⚪ No auth — **documentation drift**.
+
+**Corrected finding:** `/stripe/*` dashboard routes in [`stripe.routes.js`](../routes/stripe.routes.js) **require** `authenticate` + `isBusinessOwner`. Older audits claiming unauthenticated `/stripe/*` are stale.
+
+---
+
+## Routes missing role checks
+
+| Route | Gap |
+| --- | --- |
+| `GET /api/discounts/:id` | `authenticate` only — any logged-in role can read any discount by id |
+| `GET /api/service/business-service/:id` | Public — verify publication filter in controller |
+| `GET /api/food/business-food/:id` | Public — same |
+
+---
+
+## Routes missing ownership checks (controller level)
+
+| Area | Middleware | Controller gap |
+| --- | --- | --- |
+| Discounts CRUD | `isBusinessOwner` on mutating routes | No verify that `businessId` or discount belongs to `req.user` |
+| Stripe checkout session | `isBusinessOwner` | `createCheckoutSession` loads draft by id without owner match |
+| `addChildServices` | `isBusinessOwner` | Allows business-owner fallback via populated `businessId.owner` (403 not 404) — differs from strict `deleteChildService` |
+
+---
+
+## Identifier ambiguities
+
+| Domain | Parent ID | Child/nested ID | Routes |
+| --- | --- | --- | --- |
+| **Service** | `Service._id` | `services[]._id` (embedded) | `DELETE /api/service/delete-service/:id` deletes **parent**; `DELETE /api/service/:parentServiceId/child-services/:childServiceId` deletes **child** |
+| **Product** | `Product._id` | `ProductVariant._id` (collection) | `DELETE /api/product/delete-product/:productId` vs `DELETE /api/product/delete-variant/:productId/:variantId` |
+| **Food** | `Food._id` | menu items embedded | Single `DELETE /api/food/delete-food/:id` on listing |
+| **Order** | `Order._id` | line items embedded | Vendor actions use `vendorId: req.user._id` |
+| **Onboarding** | Mongo `_id` | `applicationId` string (`MBH-*`) | Public status uses **applicationId**, not Mongo id |
+| **Reviews** | listing id | `reviewId` | Nested under `/:serviceId/reviews/:reviewId` etc. |
+
+---
+
+## Nested-resource gaps
+
+| Gap | Status |
+| --- | --- |
+| Child service delete without deleting parent | **Addressed** on audit baseline — `DELETE /api/service/:parentServiceId/child-services/:childServiceId` |
+| Parent service delete still removes entire document | **By design** — `DELETE /api/service/delete-service/:id` |
+| Product variant vs product delete | Separate explicit routes — frontend must not swap ids |
+| Food menu item delete | No dedicated nested delete route found — updates likely via PUT replacing menu array |
+
+---
+
+## Method and payload inconsistencies
+
+| Issue | Detail |
+| --- | --- |
+| Order vendor actions | `PUT /api/orders/accept/:orderId` pattern (action in path) vs REST noun-only |
+| Service routes | Mix of `/delete-service/:id` prefix vs REST nested child path |
+| Product routes | `/delete-product/:productId` vs `/delete-variant/:productId/:variantId` |
+| Featured products | Canonical `GET /api/featured-products` — not `/api/products/featured` |
+
+---
+
+## Response-envelope inconsistencies
+
+| Pattern | Example endpoints |
+| --- | --- |
+| `{ success, data, publication? }` | Service create/update, child delete |
+| `{ message }` only | `deleteService`, `deleteFood`, delete product |
+| `{ success: true, message }` | delete variant, child delete (also includes `data`) |
+| `{ clientSecret, amount, currency }` | payment intent — no `success` flag |
+| `{ error }` / `{ message }` | 404/500 legacy errors |
+| Order vendor fulfillment | `{ success, message, order }` |
+
+Frontend code treating `{ message }` as success without checking HTTP status or `success` flag risks false-positive UX.
+
+---
+
+## Destructive-route risks
+
+All DELETE routes are listed in the manifest with `Destructive=yes`. Highest-impact:
+
+- Service parent delete vs child delete (see BE-CR-002)
+- Product soft-delete vs food hard-delete asymmetry
+- Admin user soft-delete, CMS slug delete
+- Cart line removal (non-destructive to listing but mutates checkout state)
+
+---
+
+## Payment and webhook risks
+
+| Surface | Auth | Notes |
+| --- | --- | --- |
+| Raw webhooks before `express.json` | Stripe signature | Preserved in `app.js:124-133`, `stripeRoutes.js:8-9` |
+| `POST /api/orders/initiate` | customer | Canonical marketplace checkout |
+| `POST /api/payments/create-payment-intent` | customer + order ownership | Legacy; guarded in code |
+| `POST /api/stripe/create-checkout-session` | business_owner | Draft ownership gap (BE-CR-005) |
+| `/stripe/account-session` etc. | business_owner | Connect ownership asserted in controller |
+
+Environment variable names involved (values not listed): `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `JWT_SECRET`, `MONGODB_URI`, `CORS_ORIGINS`, `FRONTEND_URL`, `AWS_*`, `SENTRY_DSN`.
+
+---
+
+## Documentation drift
+
+| Document | Drift |
+| --- | --- |
+| [`API_SURFACE.md`](../API_SURFACE.md) | Payment-intent marked unauthenticated; child-service DELETE not listed |
+| [`MVP_BACKEND_API_AUDIT.md`](../MVP_BACKEND_API_AUDIT.md) | Claims unauthenticated payment-intent and `/stripe/*` |
+| [`launch-readiness-report.md`](../launch-readiness-report.md) | Same stale payment claims |
+| [`PRODUCTION_RUNBOOK.md`](../PRODUCTION_RUNBOOK.md) | P0-7 references unauthenticated payment-intent |
+| [`BACKEND_ROUTE_REGISTRATION.md`](../backend/BACKEND_ROUTE_REGISTRATION.md) | Archived 2026-06-19; payment-intent correctly shows JWT+customer |
+| [`BACKEND_FRONTEND_ROUTE_CONTRACT.md`](../BACKEND_FRONTEND_ROUTE_CONTRACT.md) | Mostly aligned; predates child delete route |
+| [`API_CONTRACT_AS_BUILT.md`](../backend/API_CONTRACT_AS_BUILT.md) | Partial; cross-check per route in manifest |
+
+---
+
+## Missing contract and integration tests
+
+| Gap | Recommendation |
+| --- | --- |
+| Child service delete | Covered by `tests/integration/service-child-delete.integration.test.js` (on audit baseline) |
+| Discount ownership IDOR | No integration test proving cross-vendor discount mutation fails |
+| Public `GET /api/admin/categories` | `tests/admin/admin-categories-guard.test.js` documents public exposure |
+| Stripe checkout draft ownership | No test for cross-user draft checkout |
+| Route registration completeness | `tests/launch/backend-launch-contract.test.js` covers mounts, not every route |
+| Full route manifest sync | No CI check that `API_SURFACE.md` row count matches code |
+
+---
+
+## Runtime evidence required
+
+Cannot be proven from static analysis alone:
+
+- Live responses at `https://api.mosaicbizhub.com` for each workflow
+- Frontend caller inventory (`Digital-Builders-757/mosaic-biz-frontend-launch`)
+- Real Stripe webhook signature validation under load
+- CORS + cookie behavior across production origins
+- S3 presigned upload/delete side effects
+- EB environment variable values (names only listed above)
+
+---
+
+## Classified findings
+
+### BE-CR-001 — Discount IDOR on mutate/read
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P0** |
+| **Classification** | Authorization / data integrity |
+| **Full route** | `PUT /api/discounts/:id`, `DELETE /api/discounts/:id`, `GET /api/discounts/:id`, `POST /api/discounts/` |
+| **Method** | PUT, DELETE, GET, POST |
+| **Router / controller** | `routes/discounts.js` → `discountController` |
+| **Middleware** | `isBusinessOwner` on mutators; GET `/:id` authenticate only |
+| **Expected role** | business_owner scoped to own business |
+| **Identifier semantics** | `:id` = discount Mongo id; body/query `businessId` not verified against owner |
+| **Request contract** | POST body includes `businessId`; PUT accepts fields without ownership |
+| **Response contract** | `{ success, data/message }` |
+| **Evidence** | `routes/discounts.js:74-101`; `controllers/discountController.js` — no `ownerId`/`business.owner` check on update/delete/get |
+| **Likely frontend impact** | Vendor dashboard may appear to work while allowing cross-tenant discount edits if ids are guessed |
+| **Owner** | **backend** |
+| **Smoke test** | Vendor A creates discount; Vendor B PUT/DELETE same id → expect 404/403; currently may succeed |
+| **Next action** | Add business ownership checks in controller; add integration test — **do not implement in this audit branch** |
+
+---
+
+### BE-CR-002 — Service parent delete vs child delete semantics
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P1** |
+| **Classification** | Identifier mismatch / destructive behavior |
+| **Full route** | `DELETE /api/service/delete-service/:id` vs `DELETE /api/service/:parentServiceId/child-services/:childServiceId` |
+| **Method** | DELETE |
+| **Router / controller** | `serviceRoutes.js` → `deleteService` / `deleteChildService` |
+| **Middleware** | authenticate, isBusinessOwner |
+| **Expected role** | business_owner |
+| **Identifier semantics** | `:id` = parent Service `_id`; child route requires parent + embedded child `_id` |
+| **Request contract** | Path params only |
+| **Response contract** | Parent delete: `{ message }`; child delete: `{ success, deletedChildServiceId, data: { service, publication } }` |
+| **Evidence** | `serviceController.js:657-673`; `serviceChildController.js:14-77` |
+| **Likely frontend impact** | Vendor services UI sending child id to `delete-service/:id` → 404; wrong id could delete entire listing |
+| **Owner** | **both** (frontend route switch + backend docs) |
+| **Smoke test** | Create parent with 2 children; DELETE child via nested route → parent remains; DELETE via delete-service with child id → 404 |
+| **Next action** | Frontend must call nested route; keep both endpoints documented — **do not remove parent delete** |
+
+---
+
+### BE-CR-003 — Public onboarding status exposes PII
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P1** |
+| **Classification** | Data exposure |
+| **Full route** | `GET /api/vendor-onboarding/status/:applicationId` |
+| **Method** | GET |
+| **Router / controller** | `vendorOnboarding.routes.js:46` → `getStatusByApplicationId` |
+| **Middleware** | None (public) |
+| **Expected role** | Public poll by applicationId |
+| **Identifier semantics** | `applicationId` string, not Mongo `_id` |
+| **Request contract** | Path param `applicationId` |
+| **Response contract** | `{ success, data: { businessName, status, details with email/phone/bio/logo } }` |
+| **Evidence** | `vendorOnboarding.controller.js:1268-1391` |
+| **Likely frontend impact** | Onboarding UI depends on public poll; risk if applicationId enumerable |
+| **Owner** | **backend** (+ product decision) |
+| **Smoke test** | GET status with valid applicationId unauthenticated → confirm fields exposed; assess redaction |
+| **Next action** | Redact PII from public status or require session ownership — **do not implement in audit branch** |
+
+---
+
+### BE-CR-004 — Public admin categories endpoint
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P2** |
+| **Classification** | Missing route-level auth |
+| **Full route** | `GET /api/admin/categories` |
+| **Method** | GET |
+| **Router / controller** | `categoryRoutes.js:30` → `getAllCategoriesAdmin` |
+| **Middleware** | None |
+| **Expected role** | Docs imply admin; code is public |
+| **Identifier semantics** | N/A |
+| **Request contract** | None |
+| **Response contract** | `{ success, data: { foodCategories, serviceCategories, productCategories } }` |
+| **Evidence** | `categoryController.js:64-130` |
+| **Likely frontend impact** | Admin UI may assume auth gate; endpoint works without session |
+| **Owner** | **backend** |
+| **Smoke test** | Unauthenticated GET → 200 with full taxonomy |
+| **Next action** | Add authenticate+isAdmin or rename path to public `/api/categories/admin` — **do not implement in audit branch** |
+
+---
+
+### BE-CR-005 — Stripe checkout session draft ownership
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P1** |
+| **Classification** | Authorization |
+| **Full route** | `POST /api/stripe/create-checkout-session` |
+| **Method** | POST |
+| **Router / controller** | `stripeRoutes.js:12` → `stripeController.createCheckoutSession` |
+| **Middleware** | authenticate, isBusinessOwner |
+| **Expected role** | business_owner |
+| **Identifier semantics** | Body `draftId` — ownership not verified against `req.user` |
+| **Request contract** | draft/checkout payload |
+| **Response contract** | Stripe session url/id |
+| **Evidence** | `stripeController.js:11-19` — loads draft without owner comparison |
+| **Likely frontend impact** | Low if draft ids not exposed; high if predictable |
+| **Owner** | **backend** |
+| **Smoke test** | User A creates draft; User B POST checkout with A's draftId |
+| **Next action** | Assert draft.owner === req.user._id — **do not implement in audit branch** |
+
+---
+
+### BE-CR-006 — API_SURFACE stale on payment-intent auth
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P2** |
+| **Classification** | Documentation drift |
+| **Full route** | `POST /api/payments/create-payment-intent` |
+| **Method** | POST |
+| **Router / controller** | `paymentRoutes.js` → `createPaymentIntent` |
+| **Middleware** | authenticate, isCustomer, rateLimit |
+| **Evidence** | Code: `paymentRoutes.js:18-28`; Doc: `API_SURFACE.md` ~348 marks ⚪ No auth |
+| **Likely frontend impact** | QA may skip auth tests; frontend may duplicate unnecessary guards or miss required credentials |
+| **Owner** | **both** (docs + frontend test plans) |
+| **Smoke test** | Unauthenticated POST → 401 (per `BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md`) |
+| **Next action** | Update API_SURFACE and stale launch docs — **do not implement in audit branch** |
+
+---
+
+### BE-CR-007 — Delete mutation response envelope mismatch
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P2** |
+| **Classification** | Response contract |
+| **Full route** | Service/product/food delete family |
+| **Evidence** | `deleteService` → `{ message }`; `deleteVariant` → `{ success, message }`; `deleteChildService` → full owner DTO |
+| **Likely frontend impact** | Shared delete handler may miss `success` on some listings |
+| **Owner** | **both** |
+| **Smoke test** | Compare DELETE responses across product/service/food |
+| **Next action** | Document per-route envelopes in frontend API client — normalize in future API version |
+
+---
+
+### BE-CR-008 — Dual Stripe mount confusion
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P2** |
+| **Classification** | Route prefix irregularity |
+| **Full route** | `/api/stripe/*` vs `/stripe/*` |
+| **Evidence** | `app.js:124,228`; different controllers |
+| **Likely frontend impact** | Wrong base path → 404 (checkout vs Connect dashboard) |
+| **Owner** | **both** |
+| **Smoke test** | Verify frontend uses `/stripe/account-session` for Connect and `/api/stripe/create-checkout-session` for subscription checkout |
+| **Next action** | Maintain BACKEND_FRONTEND_ROUTE_CONTRACT quick reference |
+
+---
+
+### BE-CR-009 — Child delete route undocumented in API_SURFACE
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P2** |
+| **Classification** | Documentation drift |
+| **Full route** | `DELETE /api/service/:parentServiceId/child-services/:childServiceId` |
+| **Evidence** | Registered in `serviceRoutes.js:30-35`; absent from `API_SURFACE.md` |
+| **Likely frontend impact** | Frontend/backend teams may miss canonical child delete path |
+| **Owner** | **both** |
+| **Smoke test** | Integration test in `service-child-delete.integration.test.js` |
+| **Next action** | Add row to API_SURFACE after merge |
+
+---
+
+### BE-CR-010 — Duplicate CMS mount
+
+| Field | Value |
+| --- | --- |
+| **Severity** | **P3** |
+| **Classification** | Maintainability |
+| **Full route** | `/api/cms/*` and `/cms/*` |
+| **Evidence** | `app.js:174,179` |
+| **Likely frontend impact** | Either prefix works if CORS/cookies identical |
+| **Owner** | **backend** |
+| **Next action** | Deprecate one prefix in docs |
+
+---
+
+## Verification appendix
+
+Commands run on audit branch `audit/backend-frontend-contract-integrity`:
+
+| Command | Result |
+| --- | --- |
+| `npm test` | **345 passed**, 0 failed |
+| `npm run test:contract` | **20 passed**, 0 failed |
+| `npm run test:integration` | **44 passed**, 0 failed |
+| `GET /api/health` (harness) | **200** — `status: ok` |
+| `GET /api/ready` (harness) | **200** — `status: ready` |
+
+---
+
+## What was not tested in this audit
+
+- Production/staging live HTTP probes (except planned smoke above)
+- Frontend repository call sites
+- MongoDB RLS-equivalent data isolation beyond controller reads
+- Rate limit thresholds under abuse
+- Webhook replay/idempotency at scale
+- Admin category public exposure business impact assessment with security team
+
+---
+
+## Recommended next actions (audit-only — do not implement here)
+
+1. Merge PR #124 (child delete) before frontend switches delete calls.
+2. Fix discount ownership (P0) in a dedicated security PR.
+3. Refresh `API_SURFACE.md` payment-intent and child-delete rows.
+4. Frontend audit (`Digital-Builders-757/mosaic-biz-frontend-launch`) to map callers to manifest rows.
+5. Add integration tests for discount IDOR and checkout draft ownership.

--- a/docs/contracts/BACKEND_ROUTE_MANIFEST.md
+++ b/docs/contracts/BACKEND_ROUTE_MANIFEST.md
@@ -1,0 +1,529 @@
+# Backend Route Manifest
+
+**Type:** Launch readiness audit evidence  
+**Generated:** 2026-06-24  
+**Branch baseline:** `audit/backend-frontend-contract-integrity` (includes child-service delete from PR #124)  
+**Source of truth:** [`app.js`](../app.js) mount order → router files → controllers  
+**Registered route count:** 309 (includes duplicate mounts of shared routers)  
+**Unique mount registrations:** 52  
+**Unmounted router files:** `routes/cms/cmsRoutes.js` (only file not registered in `app.js`)
+
+---
+
+## Mount prefix registry (registration order)
+
+| Order | Mount prefix | Router variable | Router file |
+| --- | --- | --- | --- |
+| 1 | `/api/stripe` | `stripeRoutes` | `routes/stripeRoutes.js` |
+| 2 | `/api/webhooks` | `webhookRoutes` | `routes/webhookRoutes.js` |
+| 3 | `/api` | `healthRoutes` | `routes/healthRoutes.js` |
+| 4 | `/api/product` | `productRoutes` | `routes/productRoutes.js` |
+| 5 | `/api` | `publicListingRoutes` | `routes/publicListing.js` |
+| 6 | `/api/private` | `privateListingRoutes` | `routes/privateListing.js` |
+| 7 | `/api/users` | `userRoutes` | `routes/userRoutes.js` |
+| 8 | `/api/business` | `businessRoutes` | `routes/businessRoutes.js` |
+| 9 | `/api/vendor-onboarding` | `vendorOnboardRoutes` | `routes/vendorOnboarding.routes.js` |
+| 10 | `/admin/vendor-onboard-verify-stage1` | `vendorOnboardVerifyStage1Routes` | `routes/vendorOnboarding.routes.js` |
+| 11 | `/api/subscription-plans` | `subscriptionPlanRoutes` | `routes/subscriptionPlanRoutes.js` |
+| 12 | `/api/service` | `serviceRoutes` | `routes/serviceRoutes.js` |
+| 13 | `/api/food` | `foodRoutes` | `routes/foodRoutes.js` |
+| 14 | `/api/minority-types` | `minorityTypeRoutes` | `routes/minorityTypeRoutes.js` |
+| 15 | `/api` | `uploadImageRoute` | `routes/uploadImage.js` |
+| 16 | `/api/subscriptions` | `subscriptionRoutes` | `routes/subscriptionRoutes.js` |
+| 17 | `/api` | `categoryRoutes` | `routes/categoryRoutes.js` |
+| 18 | `/api` | `subcategoryRoutes` | `routes/subcategoryRoutes.js` |
+| 19 | `/api/cms` | `cmsRoutes` | `routes/admin/cmsRoutes.js` |
+| 20 | `/cms` | `cmsRoutes` | `routes/admin/cmsRoutes.js` |
+| 21 | `/admin/users` | `adminUserRoutes` | `routes/admin/userRoutes.js` |
+| 22 | `/admin/faqs` | `adminFaqRoutes` | `routes/admin/faqRoutes.js` |
+| 23 | `/api/admin/testimonials` | `testimonialRoutes` | `routes/admin/testimonialRoutes.js` |
+| 24 | `/admin/api/blogs` | `blogRoutes` | `routes/admin/Blog/blogRoutes.js` |
+| 25 | `/admin/api/business` | `adminBusinessRoutes` | `routes/admin/businessRoutes.js` |
+| 26 | `/api/admin/business` | `adminBusinessRoutes` | `routes/admin/businessRoutes.js` |
+| 27 | `/admin/api/products` | `adminProductRoutes` | `routes/admin/adminProductRoutes.js` |
+| 28 | `/admin/api/orders` | `adminOrderRoutes` | `routes/admin/adminOrderRoutes.js` |
+| 29 | `/admin/api/audit-events` | `adminAuditRoutes` | `routes/admin/adminAuditRoutes.js` |
+| 30 | `/api/business-profile` | `businessProfileRoutes` | `routes/businessProfileRoutes.js` |
+| 31 | `/api/admin/category/product` | `productCategoryRoutes` | `routes/admin/productCategoryRoutes.js` |
+| 32 | `/api/admin/category/product-subcategory` | `productSubcategoryRoutes` | `routes/admin/productSubcategoryRoutes.js` |
+| 33 | `/api/admin/category/service` | `ServiceCategoryRoutes` | `routes/admin/categoryRoutes.js` |
+| 34 | `/api/admin/category-requests` | `categoryRequestRoutes` | `routes/admin/categoryRequestRoutes.js` |
+| 35 | `/api/admin/category/service-subcategory` | `serviceSubcategoryRoutes` | `routes/admin/serviceSubcategoryRoutes.js` |
+| 36 | `/api/admin/category/food` | `foodCategoryRoutes` | `routes/admin/foodCategoryRoutes.js` |
+| 37 | `/api/admin/category/food-subcategory` | `foodSubcategoryRoutes` | `routes/admin/foodSubcategoryRoutes.js` |
+| 38 | `/admin/business-profile-verify` | `businessProfileVerifyRoutes` | `routes/admin/businessProfileVerifyRoutes.js` |
+| 39 | `/api/discounts` | `discountRoutes` | `routes/discounts.js` |
+| 40 | `/api/wishlist` | `wishlistRoutes` | `routes/customer/wishlistRoutes.js` |
+| 41 | `/api/cart` | `cartRoutes` | `routes/customer/cartRoutes.js` |
+| 42 | `/api/payments` | `paymentRoutes` | `routes/paymentRoutes.js` |
+| 43 | `/api/orders` | `orderRoutes` | `routes/orderRoutes.js` |
+| 44 | `/api/bookings` | `bookingRoutes` | `routes/bookingRoutes.js` |
+| 45 | `/api/connect` | `connectRoutes` | `routes/connectRoutes.js` |
+| 46 | `/stripe` | `stripeNewRoutes` | `routes/stripe.routes.js` |
+| 47 | `/api` | `apiRoutes` | `routes/api.routes.js` |
+| 48 | `/api/google-places` | `googlePlace` | `routes/googlePlace.js` |
+| 49 | `/api` | `featuredProductRoutes` | `routes/featuredProductRoutes.js` |
+| 50 | `/api/contact-inquiry` | `contactInquiryRoutes` | `routes/contactInquiryRoutes.js` |
+| 51 | `/api/auth` | `authRoutes` | `routes/authRoutes.js` |
+| 52 | `/api/enquiries` | `enquiryRoutes` | `routes/enquiryRoutes.js` |
+
+---
+
+## Legend
+
+| Column | Meaning |
+| --- | --- |
+| FullRoute | Effective URL path relative to API host |
+| Auth | Public / JWT / Stripe signature |
+| Role | Route-level role gate (controller may add ownership) |
+| Destructive | DELETE or state-changing mutation |
+| PaySens | Payment, order, webhook, or checkout adjacent |
+| ID semantics | Parent vs child / slug vs Mongo _id notes |
+| Doc | listed in API_SURFACE / new-unlisted / unlisted |
+
+---
+
+## Global / health (3 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/build-info` | GET | `routes/healthRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/health` | GET | `routes/healthRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/ready` | GET | `routes/healthRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+
+## Auth and users (17 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/admin/users/` | GET | `routes/admin/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/users/:id` | GET | `routes/admin/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/users/:id` | PUT | `routes/admin/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/users/:id` | DELETE | `routes/admin/userRoutes` | `inline` | — | Public | — | yes | no | — | listed |
+| `/admin/users/:id/block` | PUT | `routes/admin/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/users/admins` | POST | `routes/admin/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/auth/google` | GET | `routes/authRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/auth/google/callback` | GET | `routes/authRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/auth/google/complete` | POST | `routes/authRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/auth/check` | GET | `routes/userRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/users/forgot-password` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/login` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/logout` | POST | `routes/userRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/users/register` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/resend-otp` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/reset-password` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | no | no | — | listed |
+| `/api/users/verify-otp` | POST | `routes/userRoutes` | `inline` | rateLimit | Public | — | maybe | no | — | listed |
+
+## Vendor onboarding (31 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/admin/vendor-onboard-verify-stage1/:applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/admin/vendor-onboard-verify-stage1/:applicationId/finalize` | POST | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/admin/vendor-onboard-verify-stage1/:applicationId/verify` | POST | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/admin/vendor-onboard-verify-stage1/applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/admin/vendor-onboard-verify-stage1/business-profile` | PUT | `routes/vendorOnboarding.routes` | `inline` | requireStage1VerifiedVendor, authenticate | JWT cookie/Bearer | any authenticated | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/business-profile` | PATCH | `routes/vendorOnboarding.routes` | `inline` | requireStage1VerifiedVendor, authenticate | JWT cookie/Bearer | any authenticated | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/draft` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/draft` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/onboarding-data` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/pending` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/stage1/create-payment` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | maybe | yes | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/stage1/payment-status` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | yes | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/stage1/upload-url` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/admin/vendor-onboard-verify-stage1/status/:applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | — | Public | — | no | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/admin/vendor-onboard-verify-stage1/submit` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | maybe | no | — | unlisted |
+| `/api/vendor-onboarding/:applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/api/vendor-onboarding/:applicationId/finalize` | POST | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/api/vendor-onboarding/:applicationId/verify` | POST | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/api/vendor-onboarding/applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | applicationId string (MBH-*), not Mongo _id | unlisted |
+| `/api/vendor-onboarding/business-profile` | PUT | `routes/vendorOnboarding.routes` | `inline` | requireStage1VerifiedVendor, authenticate | JWT cookie/Bearer | any authenticated | no | no | — | unlisted |
+| `/api/vendor-onboarding/business-profile` | PATCH | `routes/vendorOnboarding.routes` | `inline` | requireStage1VerifiedVendor, authenticate | JWT cookie/Bearer | any authenticated | no | no | — | unlisted |
+| `/api/vendor-onboarding/draft` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/api/vendor-onboarding/draft` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/api/vendor-onboarding/onboarding-data` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/api/vendor-onboarding/pending` | GET | `routes/vendorOnboarding.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/vendor-onboarding/stage1/create-payment` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | maybe | yes | — | unlisted |
+| `/api/vendor-onboarding/stage1/payment-status` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | yes | — | unlisted |
+| `/api/vendor-onboarding/stage1/upload-url` | GET | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | no | no | — | unlisted |
+| `/api/vendor-onboarding/status/:applicationId` | GET | `routes/vendorOnboarding.routes` | `inline` | — | Public | — | no | no | applicationId string (MBH-*), not Mongo _id | listed |
+| `/api/vendor-onboarding/submit` | POST | `routes/vendorOnboarding.routes` | `inline` | requireVerifiedVendor, authenticate | JWT cookie/Bearer | business_owner (verified vendor) | maybe | no | — | unlisted |
+| `/api/vendor-onboarding/webhook/payment` | POST | `app.js` | `router.handleVendorPaymentWebhook` | express.raw | Stripe signature | — | maybe | yes | — | listed |
+
+## Business profile (21 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/admin/business-profile-verify/:profileId` | GET | `routes/admin/businessProfileVerifyRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/admin/business-profile-verify/:profileId/finalize` | POST | `routes/admin/businessProfileVerifyRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | — | unlisted |
+| `/admin/business-profile-verify/:profileId/verify/:questionNumber` | POST | `routes/admin/businessProfileVerifyRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | no | — | unlisted |
+| `/admin/business-profile-verify/pending` | GET | `routes/admin/businessProfileVerifyRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/business-profile/` | GET | `routes/businessProfileRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/business-profile/save` | POST | `routes/businessProfileRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/business-profile/step4-survey` | POST | `routes/businessProfileRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/business-profile/submit` | POST | `routes/businessProfileRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | maybe | no | — | listed |
+| `/api/business/` | POST | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/` | GET | `routes/businessRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/business/:id` | PUT | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/:id` | DELETE | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | — | listed |
+| `/api/business/:id/shipping-settings` | GET | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/:id/shipping-settings` | PUT | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | no | — | listed |
+| `/api/business/:id/tax-settings` | GET | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/:id/tax-settings` | PUT | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/:slug` | GET | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | slug string | listed |
+| `/api/business/draft` | POST | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/my` | GET | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/business/public/:slug` | GET | `routes/businessRoutes` | `inline` | — | Public | — | no | no | slug string | listed |
+| `/api/business/retry-create` | POST | `routes/businessRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+
+## Vendor products (15 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/product/` | POST | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/:productId` | GET | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/:productId` | PUT | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/:productId/reviews` | GET | `routes/productRoutes` | `inline` | — | Public | — | no | no | listingId + reviewId | listed |
+| `/api/product/:productId/reviews` | POST | `routes/productRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | no | listingId + reviewId | listed |
+| `/api/product/:productId/reviews/:reviewId` | DELETE | `routes/productRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | yes | no | listingId + reviewId | listed |
+| `/api/product/add-variants/:productId` | POST | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/business/:businessId` | GET | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/delete-product/:productId` | DELETE | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | productId=Product._id | listed |
+| `/api/product/delete-variant/:productId/:variantId` | DELETE | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | productId=Product._id; variantId=ProductVariant._id | listed |
+| `/api/product/get-variant/:productId/:variantId` | GET | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/update-variant/:productId/:variantId` | PUT | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/update-variantstock/:variantId` | PATCH | `routes/productRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/product/upload-url` | GET | `routes/productRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/product/variant-upload-url` | GET | `routes/productRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+
+## Vendor services (24 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/admin/category/service-subcategory/` | GET | `routes/admin/serviceSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/service-subcategory/` | POST | `routes/admin/serviceSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/service-subcategory/:id` | PUT | `routes/admin/serviceSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/service-subcategory/:id` | DELETE | `routes/admin/serviceSubcategoryRoutes` | `inline` | — | Public | — | yes | no | — | unlisted |
+| `/api/admin/category/service/` | GET | `routes/admin/categoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/service/` | POST | `routes/admin/categoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/service/:id` | PUT | `routes/admin/categoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/service/:id` | DELETE | `routes/admin/categoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | yes | no | — | unlisted |
+| `/api/service/` | POST | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/` | GET | `routes/serviceRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/service/:id` | GET | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/:id` | PUT | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/:parentServiceId/child-services/:childServiceId` | DELETE | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | parentServiceId=Service._id; childServiceId=embedded subdoc _id | unlisted |
+| `/api/service/:serviceId/reviews` | GET | `routes/serviceRoutes` | `inline` | — | Public | — | no | no | listingId + reviewId | listed |
+| `/api/service/:serviceId/reviews` | POST | `routes/serviceRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | no | listingId + reviewId | listed |
+| `/api/service/:serviceId/reviews/:reviewId` | DELETE | `routes/serviceRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | yes | no | listingId + reviewId | listed |
+| `/api/service/add-child-services` | POST | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | parentServiceId=Service._id; childServiceId=embedded subdoc _id | listed |
+| `/api/service/business-service/:id` | GET | `routes/serviceRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/service/child-services/:parentServiceId` | GET | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | parentServiceId=Service._id; childServiceId=embedded subdoc _id | listed |
+| `/api/service/delete-service/:id` | DELETE | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | :id=parent Service._id (whole document) | listed |
+| `/api/service/my-services` | GET | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/parent` | POST | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/parent-services` | GET | `routes/serviceRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/service/upload-url` | GET | `routes/serviceRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+
+## Vendor food (11 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/food/` | GET | `routes/foodRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/food/:foodId/reviews` | GET | `routes/foodRoutes` | `inline` | — | Public | — | no | no | listingId + reviewId | listed |
+| `/api/food/:foodId/reviews` | POST | `routes/foodRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | no | listingId + reviewId | listed |
+| `/api/food/:foodId/reviews/:reviewId` | DELETE | `routes/foodRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | yes | no | listingId + reviewId | listed |
+| `/api/food/add-food` | POST | `routes/foodRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/food/business-food/:id` | GET | `routes/foodRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/food/delete-food/:id` | DELETE | `routes/foodRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | no | :id=Food listing _id | listed |
+| `/api/food/food-by-id/:id` | GET | `routes/foodRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/food/my-foods` | GET | `routes/foodRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/food/update-food/:id` | PUT | `routes/foodRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/food/upload-url` | GET | `routes/foodRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+
+## Vendor private listings (4 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/private/food/list` | GET | `routes/privateListing` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/private/products/list` | GET | `routes/privateListing` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/private/services/:slug` | GET | `routes/privateListing` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | slug string | listed |
+| `/api/private/services/list` | GET | `routes/privateListing` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+
+## Public marketplace (22 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/:id/similar` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/categories/foods` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/categories/products` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/categories/services` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/featured-products` | GET | `routes/featuredProductRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/food/:slug` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/food/list` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/foods/subcategories/:categoryIdOrSlug` | GET | `routes/subcategoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/products/:slug` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/products/filters` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/products/list` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/products/subcategories/:categoryIdOrSlug` | GET | `routes/subcategoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/foods/:id` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/product/:productId` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/product/vendor-profile/:businessId` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/products/business/:businessId` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/search` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/public/services/:id` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/ranked` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/services/:slug` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | slug string | listed |
+| `/api/services/list` | GET | `routes/publicListing` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/services/subcategories/:categoryIdOrSlug` | GET | `routes/subcategoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+
+## Cart, checkout, orders (31 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/admin/api/orders/` | GET | `routes/admin/adminOrderRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | unlisted |
+| `/admin/api/orders/summary` | GET | `routes/admin/adminOrderRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | unlisted |
+| `/api/cart/` | GET | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/add` | POST | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/count` | GET | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/merge` | POST | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/products/mini` | GET | `routes/customer/cartRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/cart/products/mini` | POST | `routes/customer/cartRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/cart/remove` | DELETE | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | yes | yes | — | listed |
+| `/api/cart/remove/:cartItemId` | DELETE | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | yes | yes | — | listed |
+| `/api/cart/update-quantity` | PUT | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/update/:cartItemId` | PUT | `routes/customer/cartRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/cart/variants/mini` | GET | `routes/customer/cartRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/cart/variants/mini` | POST | `routes/customer/cartRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/orders/:id/invoice.pdf` | GET | `routes/orderRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/orders/:orderId/cancel` | POST | `routes/orderRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | maybe | yes | — | listed |
+| `/api/orders/accept/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/orders/admin` | GET | `routes/orderRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | listed |
+| `/api/orders/deliver/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/orders/initiate` | POST | `routes/orderRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | maybe | yes | — | listed |
+| `/api/orders/initiateReturn/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | maybe | yes | — | listed |
+| `/api/orders/reject/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/orders/retrieve-intent/:id` | GET | `routes/orderRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/orders/return/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/orders/ship/:orderId` | PUT | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/orders/user` | GET | `routes/orderRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/orders/vendor` | GET | `routes/orderRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/payments/create-payment-intent` | POST | `routes/paymentRoutes` | `inline` | authenticate, isCustomer, rateLimit | JWT cookie/Bearer | customer | maybe | yes | — | listed |
+| `/api/wishlist/` | GET | `routes/customer/wishlistRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/wishlist/:productVariantId` | POST | `routes/customer/wishlistRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/wishlist/:productVariantId` | DELETE | `routes/customer/wishlistRoutes` | `inline` | — | Public | — | yes | no | — | listed |
+
+## Bookings (17 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/bookings/:id` | DELETE | `routes/bookingRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | yes | yes | — | listed |
+| `/api/bookings/cancel/:id` | PUT | `routes/bookingRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/bookings/complete/:id` | PUT | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/confirm/:id` | PUT | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/customer` | GET | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/customer/food` | GET | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/customer/service` | GET | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/food` | POST | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/food/:foodId` | POST | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/service` | POST | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/service/:id/approve` | PUT | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/service/:id/reject` | PUT | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/bookings/service/:id/request-payment` | PUT | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/service/:serviceId` | POST | `routes/bookingRoutes` | `inline` | authenticate, isCustomer | JWT cookie/Bearer | customer | no | yes | — | listed |
+| `/api/bookings/vendor` | GET | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/vendor/food` | GET | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/bookings/vendor/service` | GET | `routes/bookingRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+
+## Discounts (7 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/discounts/` | POST | `routes/discounts` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/discounts/:id` | GET | `routes/discounts` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/discounts/:id` | PUT | `routes/discounts` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/discounts/:id` | DELETE | `routes/discounts` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | yes | yes | — | listed |
+| `/api/discounts/apply` | POST | `routes/discounts` | `inline` | — | Public | — | maybe | yes | — | listed |
+| `/api/discounts/business/:businessId` | GET | `routes/discounts` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/discounts/validate` | POST | `routes/discounts` | `inline` | — | Public | — | no | yes | — | listed |
+
+## Stripe Connect and billing (12 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/connect/:businessId/account-link` | POST | `routes/connectRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/connect/:businessId/status` | GET | `routes/connectRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/connect/refresh` | GET | `routes/connectRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/connect/return` | GET | `routes/connectRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/stripe/create-checkout-session` | POST | `routes/stripeRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/stripe/payment/webhook` | POST | `routes/stripeRoutes` | `inline` | express.raw | Stripe signature | — | maybe | yes | — | listed |
+| `/api/stripe/webhook` | POST | `routes/stripeRoutes` | `inline` | express.raw | Stripe signature | — | maybe | yes | — | listed |
+| `/stripe/account-balance` | GET | `routes/stripe.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/stripe/account-session` | POST | `routes/stripe.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/stripe/backfill-customers` | POST | `routes/stripe.routes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | maybe | yes | — | listed |
+| `/stripe/express-login-link` | POST | `routes/stripe.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/stripe/last-payout` | GET | `routes/stripe.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+
+## Subscriptions (7 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/subscription-plans/` | POST | `routes/subscriptionPlanRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | listed |
+| `/api/subscription-plans/` | GET | `routes/subscriptionPlanRoutes` | `inline` | — | Public | — | no | yes | — | listed |
+| `/api/subscription-plans/:id` | PUT | `routes/subscriptionPlanRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | listed |
+| `/api/subscription-plans/:id` | GET | `routes/subscriptionPlanRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | yes | — | listed |
+| `/api/subscription/webhook` | POST | `app.js` | `router.handleSubscriptionWebhook` | express.raw | Stripe signature | — | maybe | yes | — | listed |
+| `/api/subscriptions/create` | POST | `routes/subscriptionRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | yes | — | listed |
+| `/api/subscriptions/user/subscriptions` | GET | `routes/subscriptionRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+
+## Taxonomy and uploads (5 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/minority-types/` | GET | `routes/minorityTypeRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/minority-types/` | POST | `routes/minorityTypeRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/api/minority-types/:id` | PUT | `routes/minorityTypeRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/api/minority-types/:id` | DELETE | `routes/minorityTypeRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | yes | no | — | listed |
+| `/api/minority-types/admin/all` | GET | `routes/minorityTypeRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+
+## CMS (18 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/cms/admin` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/cms/admin/:slug` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/cms/admin/:slug` | POST | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/cms/admin/:slug` | PUT | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/cms/admin/:slug` | DELETE | `routes/admin/cmsRoutes` | `inline` | — | Public | — | yes | no | slug string | unlisted |
+| `/api/cms/admin/:slug/toggle` | PATCH | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/cms/admin/how_it_works/:section` | PUT | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/cms/public/:slug` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/api/cms/public/how_it_works` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/cms/admin` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/cms/admin/:slug` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/cms/admin/:slug` | POST | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/cms/admin/:slug` | PUT | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/cms/admin/:slug` | DELETE | `routes/admin/cmsRoutes` | `inline` | — | Public | — | yes | no | slug string | unlisted |
+| `/cms/admin/:slug/toggle` | PATCH | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/cms/admin/how_it_works/:section` | PUT | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/cms/public/:slug` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/cms/public/how_it_works` | GET | `routes/admin/cmsRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+
+## Admin (45 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/admin/api/audit-events/` | GET | `routes/admin/adminAuditRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/admin/api/audit-events/:eventId` | GET | `routes/admin/adminAuditRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/admin/api/blogs/` | POST | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/api/blogs/` | GET | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/api/blogs/:slug` | GET | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/admin/api/blogs/:slug` | PUT | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/admin/api/blogs/:slug` | DELETE | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | yes | no | slug string | unlisted |
+| `/admin/api/blogs/:slug/feature` | PUT | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | no | no | slug string | unlisted |
+| `/admin/api/blogs/:slug/publish` | PUT | `routes/admin/Blog/blogRoutes` | `inline` | — | Public | — | maybe | no | slug string | unlisted |
+| `/admin/api/business/` | GET | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/admin/api/business/approve/:id` | POST | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/admin/api/business/status/:id` | PATCH | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/admin/api/products/` | GET | `routes/admin/adminProductRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/admin/api/products/:productId/featured` | PATCH | `routes/admin/adminProductRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
+| `/admin/faqs/` | GET | `routes/admin/faqRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/faqs/` | POST | `routes/admin/faqRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/admin/faqs/:id` | PUT | `routes/admin/faqRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/admin/faqs/:id` | DELETE | `routes/admin/faqRoutes` | `inline` | — | Public | — | yes | no | — | unlisted |
+| `/api/admin/business/` | GET | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/business/approve/:id` | POST | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/business/status/:id` | PATCH | `routes/admin/businessRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category-requests/` | GET | `routes/admin/categoryRequestRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category-requests/:id/approve` | PUT | `routes/admin/categoryRequestRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category-requests/:id/reject` | PUT | `routes/admin/categoryRequestRoutes` | `inline` | — | Public | — | maybe | no | — | unlisted |
+| `/api/admin/category/food-subcategory/` | GET | `routes/admin/foodSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/food-subcategory/` | POST | `routes/admin/foodSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/food-subcategory/:id` | PUT | `routes/admin/foodSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/food-subcategory/:id` | DELETE | `routes/admin/foodSubcategoryRoutes` | `inline` | — | Public | — | yes | no | — | unlisted |
+| `/api/admin/category/food/` | GET | `routes/admin/foodCategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/food/` | POST | `routes/admin/foodCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/food/:id` | PUT | `routes/admin/foodCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/food/:id` | DELETE | `routes/admin/foodCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | yes | no | — | unlisted |
+| `/api/admin/category/product-subcategory/` | GET | `routes/admin/productSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/product-subcategory/` | POST | `routes/admin/productSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/product-subcategory/:id` | PUT | `routes/admin/productSubcategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/product-subcategory/:id` | DELETE | `routes/admin/productSubcategoryRoutes` | `inline` | — | Public | — | yes | no | — | unlisted |
+| `/api/admin/category/product/` | POST | `routes/admin/productCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/product/` | GET | `routes/admin/productCategoryRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/category/product/:id` | GET | `routes/admin/productCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/product/:id` | PUT | `routes/admin/productCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | unlisted |
+| `/api/admin/category/product/:id` | DELETE | `routes/admin/productCategoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | yes | no | — | unlisted |
+| `/api/admin/testimonials/` | GET | `routes/admin/testimonialRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/admin/testimonials/` | POST | `routes/admin/testimonialRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/admin/testimonials/:id` | PUT | `routes/admin/testimonialRoutes` | `inline` | — | Public | — | no | no | — | unlisted |
+| `/api/admin/testimonials/:id` | DELETE | `routes/admin/testimonialRoutes` | `inline` | — | Public | — | yes | no | — | unlisted |
+
+## Contact and enquiries (3 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/contact-inquiry/` | POST | `routes/contactInquiryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/enquiries/reveal` | POST | `routes/enquiryRoutes` | `inline` | authenticate | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/enquiries/vendor` | GET | `routes/enquiryRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+
+## Google Places (1 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/google-places/` | POST | `routes/googlePlace` | `inline` | — | Public | — | no | no | — | listed |
+
+## Webhooks (1 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/api/webhooks/stripe` | POST | `routes/webhookRoutes` | `inline` | express.raw | Stripe signature | — | no | yes | — | listed |
+
+## Other (14 endpoints)
+
+| FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/` | GET | `app.js` | `router.inline` | — | Public | — | no | no | — | listed |
+| `/api/admin/categories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/billing-portal/session` | POST | `routes/api.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/categories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/category-requests` | POST | `routes/categoryRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/category-requests/my` | GET | `routes/categoryRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+| `/api/getProductCategories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/s3-presigned-url` | GET | `routes/categoryRoutes` | `inline` | authenticate, isBusinessOwnerOrAdmin | JWT cookie/Bearer | any authenticated | no | no | — | listed |
+| `/api/sub-categories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/subcategories/:categoryId` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/subscriptions/:id/cancel` | POST | `routes/api.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | maybe | yes | — | listed |
+| `/api/subscriptions/:id/resume` | POST | `routes/api.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/subscriptions/current` | GET | `routes/api.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
+| `/api/upload-image` | POST | `routes/uploadImage` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |
+
+---
+
+## Duplicate mount note
+
+The following routers are mounted more than once (each combination produces distinct full paths):
+
+- `vendorOnboarding.routes.js` → `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1`
+- `admin/cmsRoutes.js` → `/api/cms` and `/cms`
+- `admin/businessRoutes.js` → `/admin/api/business` and `/api/admin/business`
+- `publicListing.js`, `categoryRoutes.js`, `featuredProductRoutes.js`, `uploadImage.js`, `api.routes.js`, `healthRoutes.js` share `/api` prefix with other routers
+
+---
+
+## Response envelope patterns (controller-level — see risk report)
+
+| Pattern | Example routes |
+| --- | --- |
+| `{ success, data, publication? }` | Service owner mutations via `formatOwnerServiceResponse` |
+| `{ success, message, data? }` | Discounts, CMS, many admin routes |
+| `{ message }` only | `deleteService`, `deleteFood`, parent product delete |
+| `{ success: true, message }` | Variant delete, child service delete |
+| `{ clientSecret, amount, currency }` | Payment intent (no `success` wrapper) |
+| `{ error }` / `{ message }` | Legacy error responses |
+| Pagination `{ data, total, page, totalPages }` | List endpoints |
+
+---
+
+## Verification limits
+
+This manifest is derived from static route registration and middleware strings. Request body fields, exact success status codes, and controller ownership checks are summarized in [`BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md`](./BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md). Runtime behavior requires staging smoke tests against `https://api.mosaicbizhub.com`.

--- a/routes/serviceRoutes.js
+++ b/routes/serviceRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { createService, getMyServices, deleteService, updateService, getServiceById, getBusinessServiceById, getServiceUploadUrl, createParentService, addChildServices, getParentServices, getChildServices } = require('../controllers/serviceController');
+const { deleteChildService } = require('../controllers/serviceChildController');
 const authenticate = require('../middlewares/authenticate');
 const isBusinessOwner = require('../middlewares/isBusinessOwner');
 const isCustomer = require('../middlewares/isCustomer');
@@ -24,6 +25,13 @@ router.get(
   authenticate,
   isBusinessOwner,
   getChildServices
+);
+
+router.delete(
+  '/:parentServiceId/child-services/:childServiceId',
+  authenticate,
+  isBusinessOwner,
+  deleteChildService
 );
 
 router.post(

--- a/tests/integration/service-child-delete.integration.test.js
+++ b/tests/integration/service-child-delete.integration.test.js
@@ -1,0 +1,250 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedServiceBusiness,
+  seedServiceCategories,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Service = require('../../models/Service');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+const twoChildPayload = {
+  title: 'Integration Hair Styling',
+  description: 'Full salon menu for child delete proof',
+  services: [
+    { name: 'Basic Cut', price: 30, duration: '30' },
+    { name: 'Premium Cut', price: 50, duration: '60' },
+  ],
+};
+
+async function setupVendorWithTwoChildren(agent, { isPublished = false, businessOverrides = {} } = {}) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user, businessOverrides);
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const createRes = await agent.post('/api/service/').send({
+    ...twoChildPayload,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished,
+  });
+
+  const service = createRes.body?.data?.service;
+  const parentServiceId = service?._id ? String(service._id) : null;
+  const childAId = service?.services?.[0]?._id ? String(service.services[0]._id) : null;
+  const childBId = service?.services?.[1]?._id ? String(service.services[1]._id) : null;
+
+  return {
+    vendor,
+    user,
+    business,
+    category,
+    subcategory,
+    createRes,
+    parentServiceId,
+    childAId,
+    childBId,
+    slug: service?.slug || null,
+  };
+}
+
+function assertPublicSurfacesIncludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 200);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 200);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 200);
+  })();
+}
+
+function assertPublicSurfacesExcludeService(agent, serviceId, slug) {
+  return (async () => {
+    const publicList = await agent.get('/api/services/list');
+    assert.equal(publicList.status, 200);
+    assert.ok(!publicList.body.data.some((entry) => String(entry.id || entry._id) === serviceId));
+
+    const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+    assert.equal(publicDetail.status, 404);
+
+    if (slug) {
+      const slugDetail = await agent.get(`/api/services/${slug}`);
+      assert.equal(slugDetail.status, 404);
+    }
+
+    const businessServiceDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+    assert.equal(businessServiceDetail.status, 404);
+  })();
+}
+
+test('owner deletes one of two child services without deleting parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: true });
+
+  assert.equal(setup.createRes.status, 201);
+  assert.equal(setup.createRes.body.data.service.services.length, 2);
+
+  const deleteRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childBId}`
+  );
+
+  assert.equal(deleteRes.status, 200);
+  assert.equal(deleteRes.body.success, true);
+  assert.equal(deleteRes.body.deletedChildServiceId, setup.childBId);
+  assert.equal(deleteRes.body.data.service.services.length, 1);
+  assert.equal(String(deleteRes.body.data.service.services[0]._id), setup.childAId);
+  assert.equal(deleteRes.body.data.service.price, 30);
+  assert.equal(deleteRes.body.data.service.isPublished, true);
+  assert.equal(deleteRes.body.data.publication.isPublished, true);
+  assert.equal(deleteRes.body.data.publication.isPubliclyVisible, true);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.ok(parentInDb, 'parent service must remain in database');
+  assert.equal(parentInDb.services.length, 1);
+  assert.equal(String(parentInDb.services[0]._id), setup.childAId);
+  assert.equal(parentInDb.price, 30);
+  assert.equal(parentInDb.isPublished, true);
+
+  await assertPublicSurfacesIncludeService(agent, setup.parentServiceId, setup.slug);
+});
+
+test('owner deleting final child unpublishes parent and hides public listing', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: true });
+
+  assert.equal(setup.createRes.status, 201);
+
+  const deleteFirst = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childBId}`
+  );
+  assert.equal(deleteFirst.status, 200);
+
+  const deleteFinal = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${setup.childAId}`
+  );
+
+  assert.equal(deleteFinal.status, 200);
+  assert.equal(deleteFinal.body.success, true);
+  assert.equal(deleteFinal.body.deletedChildServiceId, setup.childAId);
+  assert.deepEqual(deleteFinal.body.data.service.services, []);
+  assert.equal(deleteFinal.body.data.service.price, 0);
+  assert.equal(deleteFinal.body.data.service.duration, '');
+  assert.equal(deleteFinal.body.data.service.isPublished, false);
+  assert.equal(deleteFinal.body.data.publication.isPublished, false);
+  assert.equal(deleteFinal.body.data.publication.isPubliclyVisible, false);
+
+  const parentCount = await Service.countDocuments({ _id: setup.parentServiceId });
+  assert.equal(parentCount, 1);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.ok(parentInDb);
+  assert.equal(parentInDb.services.length, 0);
+  assert.equal(parentInDb.price, 0);
+  assert.equal(parentInDb.isPublished, false);
+
+  await assertPublicSurfacesExcludeService(agent, setup.parentServiceId, setup.slug);
+});
+
+test('another business_owner cannot delete child service', async () => {
+  const agentA = createAgent(getApp());
+  const agentB = createAgent(getApp());
+
+  const setupA = await setupVendorWithTwoChildren(agentA, { isPublished: true });
+  assert.equal(setupA.createRes.status, 201);
+
+  const vendorB = await registerAndVerify(agentB, { role: 'business_owner' });
+  await login(agentB, vendorB.email, vendorB.password);
+
+  const deleteRes = await agentB.delete(
+    `/api/service/${setupA.parentServiceId}/child-services/${setupA.childBId}`
+  );
+  assert.equal(deleteRes.status, 404);
+
+  const parentInDb = await Service.findById(setupA.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+  assert.ok(parentInDb.services.some((child) => String(child._id) === setupA.childAId));
+  assert.ok(parentInDb.services.some((child) => String(child._id) === setupA.childBId));
+});
+
+test('invalid parent or child id returns safe 404 without modifying parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const invalidParentRes = await agent.delete(
+    `/api/service/not-a-valid-id/child-services/${setup.childAId}`
+  );
+  assert.equal(invalidParentRes.status, 404);
+
+  const invalidChildRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/not-a-valid-id`
+  );
+  assert.equal(invalidChildRes.status, 404);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+});
+
+test('missing child id returns 404 and does not modify parent', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const missingChildId = new mongoose.Types.ObjectId();
+  const deleteRes = await agent.delete(
+    `/api/service/${setup.parentServiceId}/child-services/${missingChildId}`
+  );
+
+  assert.equal(deleteRes.status, 404);
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb.services.length, 2);
+});
+
+test('existing parent deletion route still deletes entire parent service', async () => {
+  const agent = createAgent(getApp());
+  const setup = await setupVendorWithTwoChildren(agent, { isPublished: false });
+  assert.equal(setup.createRes.status, 201);
+
+  const deleteRes = await agent.delete(`/api/service/delete-service/${setup.parentServiceId}`);
+  assert.equal(deleteRes.status, 200);
+  assert.equal(deleteRes.body.message, 'Service deleted successfully.');
+
+  const parentInDb = await Service.findById(setup.parentServiceId);
+  assert.equal(parentInDb, null);
+});


### PR DESCRIPTION
## Summary

- Adds evidence-based backend route inventory (`docs/contracts/BACKEND_ROUTE_MANIFEST.md`) — **309 registered route rows** from `app.js` mount order through router/controller registration.
- Adds classified frontend contract risk report (`docs/contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md`) with **10 findings** (P0–P3), documentation drift matrix, and verification results.
- **Audit-only** — no route, middleware, Stripe, or controller behavior changes.

## Baseline

Branch includes merged `fix/backend-vendor-child-service-delete` so manifest reflects `DELETE /api/service/:parentServiceId/child-services/:childServiceId`.

## Top findings

- **P0:** Discount mutations lack business ownership checks (IDOR)
- **P1:** Service parent vs child DELETE semantics differ; frontend must use nested child route
- **P1:** Public onboarding status exposes PII by applicationId
- **P2:** `API_SURFACE.md` stale on payment-intent auth (code requires customer auth)

## Test plan

- [x] `npm test` — 345 passed
- [x] `npm run test:contract` — 20 passed
- [x] `npm run test:integration` — 44 passed
- [x] `GET /api/health` → 200 ok
- [x] `GET /api/ready` → 200 ready
