### PR TITLE
Fix OTP email delivery failure reporting for auth flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,11 +71,11 @@ AWS_S3_BUCKET=replace-me
 
 
 
-# Email and notifications
+# Email and notifications (Gmail SMTP via Nodemailer — use a Google App Password for MAIL_PASSWORD)
 
 MAIL_USER=you@example.com
 
-MAIL_PASSWORD=replace-me
+MAIL_PASSWORD=replace-with-google-app-password
 
 ADMIN_EMAIL=admin@example.com
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 | Variable | Required | Purpose |
 | --- | --- | --- |
 | `MAIL_USER` | Yes for email features | SMTP sender/login identity used by mail utilities |
-| `MAIL_PASSWORD` | Yes for email features | SMTP credential |
+| `MAIL_PASSWORD` | Yes for email features | Gmail **App Password** (not your Google account login password) for SMTP auth |
 | `ADMIN_EMAIL` | Recommended | Admin notification recipient for onboarding, category requests, and contact inquiries |
 | `SUPPORT_EMAIL` | Optional | Support/contact email used in outbound templates |
 | `APP_NAME` | Optional | Branding label used in some email content |

--- a/SETUP.md
+++ b/SETUP.md
@@ -66,10 +66,11 @@ npm run dev
 
 ### Email
 
-- Set `MAIL_USER`.
-- Set `MAIL_PASSWORD`.
+- Set `MAIL_USER` (Gmail address used as SMTP login and From header).
+- Set `MAIL_PASSWORD` to a [Google App Password](https://support.google.com/accounts/answer/185833) — not your normal Google account password. Requires 2-Step Verification on the Google account.
 - Set `ADMIN_EMAIL`.
 - Set `SUPPORT_EMAIL` if you want support links in emails.
+- **Local inbox check:** After starting the server, register a test account with a real inbox you control. Confirm the verification email arrives within a few minutes. Do not log or paste OTP values.
 
 ### Optional integrations
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -76,6 +76,23 @@ function isDuplicateKeyError(err) {
     return err && (err.code === 11000 || err.code === '11000');
 }
 
+const OTP_DELIVERY_FAILED_MESSAGES = {
+    register:
+        'Your account was created, but we could not deliver the verification email. Please try resending the verification code later.',
+    resend:
+        'We could not deliver the verification email. Please try again later.',
+    unverifiedLogin:
+        'Your account still needs verification, but we could not send the verification email. Please try again later.',
+};
+
+function respondOtpDeliveryFailed(res, context) {
+    return res.status(502).json({
+        success: false,
+        code: 'OTP_DELIVERY_FAILED',
+        message: OTP_DELIVERY_FAILED_MESSAGES[context],
+    });
+}
+
 exports.registerUser = async (req, res) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
@@ -116,13 +133,14 @@ exports.registerUser = async (req, res) => {
             await sendOtpEmail(email, otp);
         } catch (emailError) {
             console.error('Failed to send OTP email:', emailError);
+            return respondOtpDeliveryFailed(res, 'register');
         }
 
         res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
 
         return res.status(201).json({
             success: true,
-            message: 'User registered successfully. OTP sent to mobile.',
+            message: 'User registered successfully. OTP sent to email.',
         });
     } catch (err) {
         console.error('Registration error:', err);
@@ -224,7 +242,13 @@ exports.resendOtp = async (req, res) => {
         user.otpExpiry = otpExpiry;
         await user.save();
 
-        await sendOtpEmail(user.email, otp);
+        try {
+            await sendOtpEmail(user.email, otp);
+        } catch (emailError) {
+            console.error('Failed to send OTP email:', emailError);
+            return respondOtpDeliveryFailed(res, 'resend');
+        }
+
         res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
 
         return res.status(200).json({
@@ -383,7 +407,13 @@ exports.loginUser = async (req, res) => {
             user.otpExpiry = otpExpiry;
             await user.save();
 
-            await sendOtpEmail(user.email, otp);
+            try {
+                await sendOtpEmail(user.email, otp);
+            } catch (emailError) {
+                console.error('Failed to send OTP email:', emailError);
+                return respondOtpDeliveryFailed(res, 'unverifiedLogin');
+            }
+
             res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
 
             return res.status(403).json({

--- a/docs/AUTH_FLOW.md
+++ b/docs/AUTH_FLOW.md
@@ -45,9 +45,10 @@ Auth is **stateless JWT** with optional **HTTP-only cookies**. There is no serve
 4. `bcrypt.hash(password, 12)` → `passwordHash`.
 5. 6-digit OTP generated, `bcrypt.hash(otp, 10)` stored in `user.otp` with `otpExpiry` = now + 10 minutes.
 6. User saved with `isOtpVerified: false`, `provider: 'local'` (default).
-7. `sendOtpEmail(email, otp)` — OTP delivered by **email** (response message says "mobile" but mailer sends to email).
-8. `otpPending` cookie set (10 min, via `getCookieOptions`).
-9. Returns `201` — no JWT issued until OTP verified.
+7. `sendOtpEmail(email, otp)` — OTP delivered by **email** (Nodemailer + Gmail SMTP).
+8. On successful send: `otpPending` cookie set (10 min, via `getCookieOptions`).
+9. Returns **201** with message *"OTP sent to email"* — no JWT until OTP verified.
+10. On SMTP failure after user save: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', message: '...' }` — account preserved; no `otpPending` cookie; user may call `POST /api/users/resend-otp` after mail recovery.
 
 ### Diagram
 
@@ -104,11 +105,16 @@ OTP is used for **email verification after registration** and for **re-verificat
 **Rate limit:** 5 / 15 min
 
 - Rejects if user not found, deleted, blocked, or already verified.
-- Generates new OTP, updates hash/expiry, emails OTP, sets `otpPending` cookie.
+- Generates new OTP, updates hash/expiry, emails OTP.
+- On successful send: sets `otpPending` cookie, returns **200**.
+- On SMTP failure after OTP saved: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED' }` — no `otpPending` cookie; OTP hash remains in DB for verify/resend after recovery.
 
 ### Login-triggered OTP
 
-If `loginUser` finds valid credentials but `!user.isOtpVerified`, it generates a **new** OTP, emails it, sets `otpPending`, and returns `403` with `otpPending: true` (no JWT).
+If `loginUser` finds valid credentials but `!user.isOtpVerified`, it generates a **new** OTP, saves hash/expiry, then emails OTP.
+
+- On successful send: sets `otpPending`, returns **403** with `otpPending: true` (no JWT).
+- On SMTP failure: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED' }` — no session, no `otpPending` cookie; account preserved for resend.
 
 ---
 
@@ -124,7 +130,7 @@ If `loginUser` finds valid credentials but `!user.isOtpVerified`, it generates a
 2. Load user; reject with `401 Invalid credentials` if missing or no `passwordHash` (includes Google-only accounts).
 3. Reject `403` if `isDeleted` or `isBlocked`.
 4. `bcrypt.compare(password, passwordHash)` — generic `401` on mismatch.
-5. If `!isOtpVerified` → new OTP emailed, `403 otpPending: true` (see above).
+5. If `!isOtpVerified` → new OTP emailed; on success **403** `otpPending: true`; on SMTP failure **502** `OTP_DELIVERY_FAILED` (see above).
 6. `buildSessionToken(user)` → JWT (`sub`, `role`, `sessionVersion`, 7d).
 7. `setAuthCookies(res, token, user, 7d)`.
 8. Return `200` with `token` and `toPublicAuthUser(user)`.

--- a/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
+++ b/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
@@ -12,7 +12,7 @@
 
 Audit and document launch-safe backend email notification behavior for vendor onboarding, order confirmation, and review follow-up readiness. Add tests proving graceful SMTP failure handling and logging safety without faking delivery.
 
-**Principle:** Do not fake email delivery. When SMTP is missing or send fails, core HTTP flows still succeed unless the existing contract intentionally requires failure (e.g. forgot-password).
+**Principle:** Do not fake email delivery. When SMTP is missing or send fails, auth OTP flows return **502** `OTP_DELIVERY_FAILED` after persisting the unverified account/OTP hash. Vendor onboarding skips sends when env is missing; forgot-password returns **500** on send failure.
 
 ---
 
@@ -51,6 +51,19 @@ Audit and document launch-safe backend email notification behavior for vendor on
 | [`admin/vendorOnboardVerifyStage1.js`](../controllers/admin/vendorOnboardVerifyStage1.js) | `POST /api/vendor-onboarding/:id/finalize` | Approve / reject / badge |
 | [`orderController.js`](../controllers/orderController.js) | `POST /api/orders/initiate`, accept/reject/ship/deliver | Order placed + lifecycle |
 | [`stripePaymentController.js`](../controllers/stripePaymentController.js) | `POST /api/stripe/payment/webhook` | Order paid + invoice |
+| [`userController.js`](../controllers/userController.js) | `POST /api/users/register`, `/resend-otp`, unverified `/login` | Registration / resend / login OTP |
+
+### Auth OTP delivery failure contract
+
+| Endpoint | On SMTP success | On SMTP failure after DB save |
+| --- | --- | --- |
+| `POST /api/users/register` | **201** — OTP sent to email; `otpPending` cookie | **502** `OTP_DELIVERY_FAILED` — account saved; no cookie |
+| `POST /api/users/resend-otp` | **200** — OTP resent; `otpPending` cookie | **502** `OTP_DELIVERY_FAILED` — new OTP hash saved; no cookie |
+| `POST /api/users/login` (unverified) | **403** `otpPending: true` — OTP emailed | **502** `OTP_DELIVERY_FAILED` — no session/cookie |
+
+**Gmail setup:** `MAIL_USER` + `MAIL_PASSWORD` where `MAIL_PASSWORD` is a [Google App Password](https://support.google.com/accounts/answer/185833) (requires 2-Step Verification).
+
+**Production inbox smoke (auth OTP):** Register with a disposable inbox; confirm delivery or **502** + log grep for `Failed to send OTP email:` / `EAUTH` / `535`. Never log OTP values or `MAIL_PASSWORD`.
 
 ### Environment variables (names only — never commit values)
 

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -68,12 +68,36 @@ Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-regist
 
 | Variable | Required for |
 |----------|--------------|
-| `MAIL_USER` | OTP, order, onboarding mail |
-| `MAIL_PASSWORD` | SMTP auth |
+| `MAIL_USER` | OTP, order, onboarding mail (Gmail address; also used as From header) |
+| `MAIL_PASSWORD` | SMTP auth — must be a **Google App Password**, not the account login password |
 | `ADMIN_EMAIL` | Admin notifications |
 | `SUPPORT_EMAIL` | Optional; email templates |
 | `APP_NAME` | Optional branding |
 | `APP_URL` | Optional order email links |
+
+### Auth OTP email (registration / resend / unverified login)
+
+OTP is sent **by email only** via Nodemailer + Gmail (`utils/mailer.js`). There is no SMS/mobile OTP channel.
+
+**Production inbox smoke (disposable test account only):**
+
+1. Set `MAIL_USER` and `MAIL_PASSWORD` (App Password) on Elastic Beanstalk; redeploy.
+2. `POST /api/users/register` with a disposable email you control — expect **201** and inbox delivery within ~2 minutes.
+3. Do **not** paste OTP values or credentials into tickets, Slack, or logs.
+
+**When SMTP delivery fails**, auth endpoints return **502** with `code: OTP_DELIVERY_FAILED` (account may still be saved; user can retry via `POST /api/users/resend-otp` after mail recovery).
+
+**Log signatures for SMTP auth failure (grep EB logs — never log secrets):**
+
+| Signature | Meaning |
+|-----------|---------|
+| `Failed to send OTP email:` | Application caught a registration/resend/login OTP send failure |
+| `Resend OTP error:` | Unexpected error in resend handler (non-delivery paths) |
+| `Login error:` | Unexpected error in login handler (non-delivery paths) |
+| Nodemailer `code: 'EAUTH'` | SMTP authentication rejected |
+| Response contains `535` / `Invalid login` / `Username and Password not accepted` | Gmail rejected credentials — rotate App Password |
+
+Confirm no 6-digit OTP values and no `MAIL_PASSWORD` appear in log lines after auth smoke.
 
 ---
 

--- a/tests/auth/otp-email-delivery.test.js
+++ b/tests/auth/otp-email-delivery.test.js
@@ -1,0 +1,274 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const userControllerPath = path.resolve(__dirname, '../../controllers/userController.js');
+const userRoutesPath = path.resolve(__dirname, '../../routes/userRoutes.js');
+
+function withMocks(modulePath, mocks) {
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[modulePath];
+  const loadedModule = require(modulePath);
+  Module._load = originalLoad;
+
+  return loadedModule;
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    cookies: {},
+    authCookies: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    cookie(name, value) {
+      this.cookies[name] = value;
+    },
+  };
+}
+
+function buildControllerMocks(overrides = {}) {
+  let setAuthCookiesCalled = false;
+
+  const mocks = {
+    '../models/User': {
+      findOne: async () => null,
+      ...(overrides.User || {}),
+    },
+    bcryptjs: {
+      hash: async (value) => `hashed:${value}`,
+      compare: async () => true,
+      ...(overrides.bcryptjs || {}),
+    },
+    'express-validator': {
+      validationResult: () => ({ isEmpty: () => true, array: () => [] }),
+    },
+    '../utils/mailer': {
+      sendOtpEmail: async () => {},
+      sendWelcomeEmail: async () => {},
+      sendPasswordResetOtpEmail: async () => {},
+      ...(overrides.mailer || {}),
+    },
+    '../utils/cookieHelper': {
+      getCookieOptions: () => ({}),
+      clearCookie: () => {},
+      setAuthCookies: (res, token, user, maxAge) => {
+        setAuthCookiesCalled = true;
+        res.authCookies = { token, userId: user._id.toString(), maxAge };
+      },
+      clearAuthCookies: () => {},
+    },
+    jsonwebtoken: {
+      sign: () => 'test-token',
+    },
+    ...overrides.extra,
+  };
+
+  return {
+    mocks,
+    getSetAuthCookiesCalled: () => setAuthCookiesCalled,
+  };
+}
+
+const registerBody = {
+  name: 'OTP Delivery Test',
+  email: 'otp-delivery@example.com',
+  password: 'secret12',
+  mobile: '+15559876543',
+  role: 'customer',
+};
+
+const unverifiedUser = {
+  _id: '507f1f77bcf86cd799439011',
+  email: 'unverified@example.com',
+  name: 'Unverified User',
+  role: 'customer',
+  passwordHash: 'hashed-password',
+  isOtpVerified: false,
+  isDeleted: false,
+  isBlocked: false,
+  sessionVersion: 0,
+};
+
+function assertNoOtpInBody(body) {
+  const serialized = JSON.stringify(body);
+  assert.ok(!/\b\d{6}\b/.test(serialized), 'response must not contain a 6-digit OTP');
+}
+
+class RegisterMockUser {
+  constructor(data) {
+    Object.assign(this, data);
+    this._id = '507f1f77bcf86cd799439011';
+    this.saveCalled = false;
+  }
+
+  async save() {
+    this.saveCalled = true;
+    return this;
+  }
+}
+RegisterMockUser.findOne = async () => null;
+
+test('registerUser returns 201 when OTP email sends successfully', async () => {
+  const userController = withMocks(userControllerPath, {
+    ...buildControllerMocks().mocks,
+    '../models/User': RegisterMockUser,
+  });
+
+  const res = createResponse();
+  await userController.registerUser({ body: registerBody }, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.match(res.body.message, /email/i);
+  assert.doesNotMatch(res.body.message, /mobile/i);
+  assert.equal(res.cookies.otpPending, 'true');
+  assertNoOtpInBody(res.body);
+});
+
+test('registerUser returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () => {
+  let savedUser = null;
+
+  class SavingMockUser extends RegisterMockUser {
+    constructor(data) {
+      super(data);
+      savedUser = this;
+    }
+  }
+  SavingMockUser.findOne = async () => null;
+
+  const userController = withMocks(userControllerPath, {
+    ...buildControllerMocks({
+      mailer: {
+        sendOtpEmail: async () => {
+          throw new Error('SMTP connection failed');
+        },
+      },
+    }).mocks,
+    '../models/User': SavingMockUser,
+  });
+
+  const res = createResponse();
+  await userController.registerUser({ body: registerBody }, res);
+
+  assert.equal(res.statusCode, 502);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'OTP_DELIVERY_FAILED');
+  assert.match(res.body.message, /account was created/i);
+  assert.equal(res.cookies.otpPending, undefined);
+  assert.ok(savedUser && savedUser.saveCalled, 'unverified account should be preserved');
+  assertNoOtpInBody(res.body);
+});
+
+test('resendOtp returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () => {
+  const userController = withMocks(userControllerPath, buildControllerMocks({
+    User: {
+      findOne: async () => ({
+        ...unverifiedUser,
+        async save() {
+          return this;
+        },
+      }),
+    },
+    mailer: {
+      sendOtpEmail: async () => {
+        throw new Error('SMTP auth failed');
+      },
+    },
+  }).mocks);
+
+  const res = createResponse();
+  await userController.resendOtp({ body: { email: unverifiedUser.email } }, res);
+
+  assert.equal(res.statusCode, 502);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'OTP_DELIVERY_FAILED');
+  assert.match(res.body.message, /try again later/i);
+  assert.equal(res.cookies.otpPending, undefined);
+  assertNoOtpInBody(res.body);
+});
+
+test('resendOtp returns 200 when sendOtpEmail succeeds', async () => {
+  const userController = withMocks(userControllerPath, buildControllerMocks({
+    User: {
+      findOne: async () => ({
+        ...unverifiedUser,
+        async save() {
+          return this;
+        },
+      }),
+    },
+  }).mocks);
+
+  const res = createResponse();
+  await userController.resendOtp({ body: { email: unverifiedUser.email } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.cookies.otpPending, 'true');
+  assertNoOtpInBody(res.body);
+});
+
+test('loginUser returns OTP_DELIVERY_FAILED for unverified user when sendOtpEmail throws', async () => {
+  const { mocks, getSetAuthCookiesCalled } = buildControllerMocks({
+    User: {
+      findOne: async () => ({
+        ...unverifiedUser,
+        async save() {
+          return this;
+        },
+      }),
+    },
+    mailer: {
+      sendOtpEmail: async () => {
+        throw new Error('EAUTH invalid credentials');
+      },
+    },
+  });
+
+  const userController = withMocks(userControllerPath, mocks);
+  const res = createResponse();
+
+  await userController.loginUser(
+    { body: { email: unverifiedUser.email, password: 'secret12' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 502);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.code, 'OTP_DELIVERY_FAILED');
+  assert.equal(
+    res.body.message,
+    'Your account still needs verification, but we could not send the verification email. Please try again later.'
+  );
+  assert.equal(res.cookies.otpPending, undefined);
+  assert.equal(res.authCookies, null);
+  assert.equal(getSetAuthCookiesCalled(), false);
+  assertNoOtpInBody(res.body);
+});
+
+test('auth OTP rate limits remain unchanged in userRoutes', () => {
+  const source = fs.readFileSync(userRoutesPath, 'utf8');
+  assert.match(source, /const registerLimiter = buildAuthLimiter\(\s*5,/);
+  assert.match(source, /const otpResendLimiter = buildAuthLimiter\(\s*5,/);
+  assert.match(source, /const loginLimiter = buildAuthLimiter\(\s*15,/);
+  assert.match(source, /skip: \(\) => process\.env\.NODE_ENV === 'test'/);
+});

--- a/tests/auth/register-duplicate-vendor.test.js
+++ b/tests/auth/register-duplicate-vendor.test.js
@@ -214,6 +214,7 @@ test('registerUser succeeds for fresh vendor email', async () => {
 
   assert.equal(res.statusCode, 201);
   assert.equal(res.body.success, true);
+  assert.match(res.body.message, /OTP sent to email/i);
 });
 
 test('register route uses registerLimiter with max 5 per 15 minutes', () => {

--- a/tests/email/email-notification-safety.test.js
+++ b/tests/email/email-notification-safety.test.js
@@ -42,6 +42,14 @@ test('mailer.js does not log OTP values', () => {
   assert.ok(!source.match(/console\.(log|error|warn)\([^)]*\botp\b/i));
 });
 
+test('userController.js does not log OTP values in error handlers', () => {
+  const controllerPath = path.resolve(__dirname, '../../controllers/userController.js');
+  const source = fs.readFileSync(controllerPath, 'utf8');
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*,\s*otp\b/i));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_PASSWORD/));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_USER/));
+});
+
 test('vendorOnboardingEmailDelivery logs error message only', () => {
   const source = fs.readFileSync(deliveryPath, 'utf8');
   assert.ok(source.includes('err.message'));


### PR DESCRIPTION
## Summary

- Registration no longer returns 201 when `sendOtpEmail` fails; returns **502** with `code: OTP_DELIVERY_FAILED` while preserving the unverified account.
- Resend OTP and unverified login use the same structured delivery-failure contract instead of generic 500 or false success.
- Register success message corrected from "sent to mobile" to **"sent to email"**.
- Added focused auth OTP delivery tests and production mail documentation (Gmail App Password, inbox smoke, log signatures).

## Root cause

`registerUser` caught SMTP errors, logged them, and still returned HTTP 201 with `success: true` and misleading mobile wording.

## Test plan

- [x] `npm test` — 352/352 pass
- [x] `node --test tests/auth/otp-email-delivery.test.js` — 6/6 pass
- [ ] `GET /api/health` and `GET /api/ready` locally (server not running in CI agent session)

### Manual production smoke (no OTP/credential exposure)

1. `GET https://api.mosaicbizhub.com/api/health` → 200
2. `GET https://api.mosaicbizhub.com/api/ready` → 200 (DB connected)
3. `POST /api/users/register` with disposable inbox → expect 201 + email within ~2 min
4. On SMTP misconfig, expect 502 + `OTP_DELIVERY_FAILED`; retry via `POST /api/users/resend-otp` after mail recovery
5. EB log grep: `Failed to send OTP email:` / `EAUTH` / `535` — confirm no OTP digits or `MAIL_PASSWORD` in logs
6. Rate limits unchanged: register/resend 5/15min, login 15/15min

## Environment variables (names only)

- `MAIL_USER`
- `MAIL_PASSWORD` (Google App Password)

## Risks

- Frontends must handle 502 + `OTP_DELIVERY_FAILED` on register (account may exist; offer resend).

## Rollback

Revert commit `8a226af` or redeploy previous EB version. No schema migration.

## Not tested

- Live Gmail SMTP / real inbox delivery
- Frontend UI handling of 502
- Production deploy
