### PR TITLE
Fix discount IDOR by enforcing business ownership (BE-CR-001)

### DIFF
--- a/controllers/discountController.js
+++ b/controllers/discountController.js
@@ -1,5 +1,37 @@
 const Discount = require('../models/Discounts');
+const Business = require('../models/Business');
 const mongoose = require('mongoose');
+
+const UPDATABLE_DISCOUNT_FIELDS = [
+  'name',
+  'couponCode',
+  'type',
+  'value',
+  'minOrderAmount',
+  'maxDiscountAmount',
+  'usageLimit',
+  'validFrom',
+  'validTill',
+  'isActive',
+];
+
+async function findDiscountOwnedByUser(discountId, userId) {
+  if (!mongoose.Types.ObjectId.isValid(discountId)) {
+    return null;
+  }
+
+  const discount = await Discount.findById(discountId);
+  if (!discount) {
+    return null;
+  }
+
+  const business = await Business.findOne({
+    _id: discount.businessId,
+    owner: userId,
+  });
+
+  return business ? discount : null;
+}
 
 // ============================================
 // CREATE DISCOUNT
@@ -87,7 +119,7 @@ exports.getBusinessDiscounts = async (req, res) => {
 // ============================================
 exports.getDiscountById = async (req, res) => {
   try {
-    const discount = await Discount.findById(req.params.id);
+    const discount = await findDiscountOwnedByUser(req.params.id, req.user._id);
 
     if (!discount) {
       return res.status(404).json({
@@ -116,11 +148,7 @@ exports.getDiscountById = async (req, res) => {
 // ============================================
 exports.updateDiscount = async (req, res) => {
   try {
-    const discount = await Discount.findByIdAndUpdate(
-      req.params.id,
-      req.body,
-      { new: true, runValidators: true }
-    );
+    const discount = await findDiscountOwnedByUser(req.params.id, req.user._id);
 
     if (!discount) {
       return res.status(404).json({
@@ -128,6 +156,16 @@ exports.updateDiscount = async (req, res) => {
         message: "Discount not found"
       });
     }
+
+    for (const field of UPDATABLE_DISCOUNT_FIELDS) {
+      if (req.body[field] !== undefined) {
+        discount[field] = field === 'couponCode'
+          ? String(req.body[field]).toUpperCase()
+          : req.body[field];
+      }
+    }
+
+    await discount.save();
 
     res.json({
       success: true,
@@ -149,7 +187,7 @@ exports.updateDiscount = async (req, res) => {
 // ============================================
 exports.deleteDiscount = async (req, res) => {
   try {
-    const discount = await Discount.findByIdAndDelete(req.params.id);
+    const discount = await findDiscountOwnedByUser(req.params.id, req.user._id);
 
     if (!discount) {
       return res.status(404).json({
@@ -157,6 +195,8 @@ exports.deleteDiscount = async (req, res) => {
         message: "Discount not found"
       });
     }
+
+    await discount.deleteOne();
 
     res.json({
       success: true,

--- a/routes/discounts.js
+++ b/routes/discounts.js
@@ -74,6 +74,7 @@ router.post(
 router.get(
   '/:id',
   authenticate,
+  isBusinessOwner,
   getDiscountById
 );
 

--- a/tests/discount/discount-ownership.test.js
+++ b/tests/discount/discount-ownership.test.js
@@ -1,0 +1,228 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+const mongoose = require('mongoose');
+
+const discountControllerPath = path.resolve(__dirname, '../../controllers/discountController.js');
+const ownerId = '507f1f77bcf86cd799439011';
+const otherOwnerId = '507f1f77bcf86cd799439012';
+const businessId = '507f1f77bcf86cd799439013';
+const discountId = '507f1f77bcf86cd799439014';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildDiscount(overrides = {}) {
+  return {
+    _id: discountId,
+    businessId,
+    name: 'Summer Sale',
+    couponCode: 'SUMMER10',
+    type: 'percentage',
+    value: 10,
+    minOrderAmount: 0,
+    save: async function save() {
+      return this;
+    },
+    deleteOne: async function deleteOne() {
+      return { deletedCount: 1 };
+    },
+    ...overrides,
+  };
+}
+
+function loadDiscountController({
+  discountExists = true,
+  businessOwnedByUser = true,
+} = {}) {
+  const originalLoad = Module._load;
+  const discount = discountExists ? buildDiscount() : null;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Discounts')) {
+      return {
+        findById: async (id) => {
+          if (!mongoose.Types.ObjectId.isValid(id)) {
+            return null;
+          }
+          return discountExists ? buildDiscount({ _id: id }) : null;
+        },
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findOne: async (query) => {
+          if (!discountExists) {
+            return null;
+          }
+          if (String(query.owner) !== String(ownerId)) {
+            return null;
+          }
+          return businessOwnedByUser ? { _id: query._id, owner: ownerId } : null;
+        },
+      };
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[discountControllerPath];
+  const controller = require(discountControllerPath);
+  Module._load = originalLoad;
+  return controller;
+}
+
+test('getDiscountById returns owned discount for business owner', async () => {
+  const { getDiscountById } = loadDiscountController();
+  const res = mockResponse();
+
+  await getDiscountById(
+    { params: { id: discountId }, user: { _id: ownerId } },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data._id, discountId);
+});
+
+test('getDiscountById returns 404 when discount is not owned', async () => {
+  const { getDiscountById } = loadDiscountController({ businessOwnedByUser: false });
+  const res = mockResponse();
+
+  await getDiscountById(
+    { params: { id: discountId }, user: { _id: otherOwnerId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, 'Discount not found');
+});
+
+test('getDiscountById returns 404 when discount does not exist', async () => {
+  const { getDiscountById } = loadDiscountController({ discountExists: false });
+  const res = mockResponse();
+
+  await getDiscountById(
+    { params: { id: discountId }, user: { _id: ownerId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Discount not found');
+});
+
+test('getDiscountById returns 404 for malformed discount id', async () => {
+  const { getDiscountById } = loadDiscountController();
+  const res = mockResponse();
+
+  await getDiscountById(
+    { params: { id: 'not-a-valid-id' }, user: { _id: ownerId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Discount not found');
+});
+
+test('updateDiscount updates owned discount and ignores businessId reassignment', async () => {
+  const { updateDiscount } = loadDiscountController();
+  const res = mockResponse();
+  let savedBusinessId = businessId;
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Discounts')) {
+      return {
+        findById: async () => buildDiscount({
+          save: async function save() {
+            savedBusinessId = this.businessId;
+            return this;
+          },
+        }),
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findOne: async () => ({ _id: businessId, owner: ownerId }),
+      };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+  delete require.cache[discountControllerPath];
+  const { updateDiscount: updateDiscountPatched } = require(discountControllerPath);
+  Module._load = originalLoad;
+
+  await updateDiscountPatched(
+    {
+      params: { id: discountId },
+      user: { _id: ownerId },
+      body: {
+        name: 'Updated Sale',
+        businessId: '507f1f77bcf86cd799439099',
+      },
+    },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.name, 'Updated Sale');
+  assert.equal(String(savedBusinessId), businessId);
+});
+
+test('updateDiscount returns 404 when discount is not owned', async () => {
+  const { updateDiscount } = loadDiscountController({ businessOwnedByUser: false });
+  const res = mockResponse();
+
+  await updateDiscount(
+    {
+      params: { id: discountId },
+      user: { _id: otherOwnerId },
+      body: { name: 'Blocked Update' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Discount not found');
+});
+
+test('deleteDiscount deletes owned discount', async () => {
+  const { deleteDiscount } = loadDiscountController();
+  const res = mockResponse();
+
+  await deleteDiscount(
+    { params: { id: discountId }, user: { _id: ownerId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.message, 'Discount deleted successfully');
+});
+
+test('deleteDiscount returns 404 when discount is not owned', async () => {
+  const { deleteDiscount } = loadDiscountController({ businessOwnedByUser: false });
+  const res = mockResponse();
+
+  await deleteDiscount(
+    { params: { id: discountId }, user: { _id: otherOwnerId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Discount not found');
+});

--- a/tests/integration/discount-ownership.integration.test.js
+++ b/tests/integration/discount-ownership.integration.test.js
@@ -1,0 +1,147 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+  seedDiscount,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Discount = require('../../models/Discounts');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+async function setupTwoVendors() {
+  const ownerAgent = createAgent(getApp());
+  const otherAgent = createAgent(getApp());
+
+  const ownerRegistration = await registerAndVerify(ownerAgent, { role: 'business_owner' });
+  const otherRegistration = await registerAndVerify(otherAgent, { role: 'business_owner' });
+
+  const ownerUser = await User.findOne({ email: ownerRegistration.email });
+  const otherUser = await User.findOne({ email: otherRegistration.email });
+
+  const ownerBusiness = await seedApprovedBusiness(ownerUser);
+  const otherBusiness = await seedApprovedBusiness(otherUser);
+
+  const ownerLogin = await login(ownerAgent, ownerRegistration.email, ownerRegistration.password);
+  const otherLogin = await login(otherAgent, otherRegistration.email, otherRegistration.password);
+
+  assert.equal(ownerLogin.status, 200);
+  assert.equal(otherLogin.status, 200);
+
+  const discount = await seedDiscount(ownerBusiness, {
+    name: 'Owner Only Discount',
+    couponCode: `OWN${Date.now()}`.slice(0, 20),
+  });
+
+  return {
+    ownerAgent,
+    otherAgent,
+    ownerBusiness,
+    otherBusiness,
+    discount,
+  };
+}
+
+test('owner can read, update, and delete their own discount', async () => {
+  const { ownerAgent, discount } = await setupTwoVendors();
+
+  const getRes = await ownerAgent.get(`/api/discounts/${discount._id}`);
+  assert.equal(getRes.status, 200);
+  assert.equal(getRes.body.success, true);
+  assert.equal(String(getRes.body.data._id), String(discount._id));
+
+  const updateRes = await ownerAgent.put(`/api/discounts/${discount._id}`).send({
+    name: 'Updated Owner Discount',
+  });
+  assert.equal(updateRes.status, 200);
+  assert.equal(updateRes.body.success, true);
+  assert.equal(updateRes.body.data.name, 'Updated Owner Discount');
+
+  const deleteRes = await ownerAgent.delete(`/api/discounts/${discount._id}`);
+  assert.equal(deleteRes.status, 200);
+  assert.equal(deleteRes.body.success, true);
+  assert.equal(deleteRes.body.message, 'Discount deleted successfully');
+
+  const missing = await Discount.findById(discount._id);
+  assert.equal(missing, null);
+});
+
+test('different business_owner cannot read, update, or delete another discount', async () => {
+  const { ownerAgent, otherAgent, discount } = await setupTwoVendors();
+
+  const otherGet = await otherAgent.get(`/api/discounts/${discount._id}`);
+  assert.equal(otherGet.status, 404);
+  assert.equal(otherGet.body.success, false);
+  assert.equal(otherGet.body.message, 'Discount not found');
+
+  const otherUpdate = await otherAgent.put(`/api/discounts/${discount._id}`).send({
+    name: 'Cross Tenant Update',
+  });
+  assert.equal(otherUpdate.status, 404);
+  assert.equal(otherUpdate.body.message, 'Discount not found');
+
+  const otherDelete = await otherAgent.delete(`/api/discounts/${discount._id}`);
+  assert.equal(otherDelete.status, 404);
+  assert.equal(otherDelete.body.message, 'Discount not found');
+
+  const ownerGet = await ownerAgent.get(`/api/discounts/${discount._id}`);
+  assert.equal(ownerGet.status, 200);
+  assert.equal(ownerGet.body.data.name, discount.name);
+});
+
+test('unauthenticated access to discount routes is rejected', async () => {
+  const { discount } = await setupTwoVendors();
+  const agent = createAgent(getApp());
+
+  const getRes = await agent.get(`/api/discounts/${discount._id}`);
+  assert.equal(getRes.status, 401);
+
+  const updateRes = await agent.put(`/api/discounts/${discount._id}`).send({ name: 'No Auth' });
+  assert.equal(updateRes.status, 401);
+
+  const deleteRes = await agent.delete(`/api/discounts/${discount._id}`);
+  assert.equal(deleteRes.status, 401);
+});
+
+test('nonexistent discount id returns 404 for owner', async () => {
+  const { ownerAgent } = await setupTwoVendors();
+  const missingId = new mongoose.Types.ObjectId();
+
+  const getRes = await ownerAgent.get(`/api/discounts/${missingId}`);
+  assert.equal(getRes.status, 404);
+  assert.equal(getRes.body.message, 'Discount not found');
+
+  const updateRes = await ownerAgent.put(`/api/discounts/${missingId}`).send({ name: 'Missing' });
+  assert.equal(updateRes.status, 404);
+
+  const deleteRes = await ownerAgent.delete(`/api/discounts/${missingId}`);
+  assert.equal(deleteRes.status, 404);
+});
+
+test('malformed discount id returns 404 for owner', async () => {
+  const { ownerAgent } = await setupTwoVendors();
+
+  const getRes = await ownerAgent.get('/api/discounts/not-a-valid-id');
+  assert.equal(getRes.status, 404);
+  assert.equal(getRes.body.message, 'Discount not found');
+});

--- a/tests/integration/helpers/factories.js
+++ b/tests/integration/helpers/factories.js
@@ -9,6 +9,7 @@ const ServiceSubcategory = require('../../../models/ServiceSubcategory');
 const Subscription = require('../../../models/Subscription');
 const SubscriptionPlan = require('../../../models/SubscriptionPlan');
 const VendorOnboarding = require('../../../models/VendorOnboardingStage1');
+const Discount = require('../../../models/Discounts');
 const { getCapturedOtp } = require('./otpCapture');
 
 function uniqueEmail(prefix) {
@@ -194,6 +195,21 @@ async function seedVendorOnboarding(user, overrides = {}) {
   });
 }
 
+async function seedDiscount(business, overrides = {}) {
+  const suffix = `${Date.now()}_${Math.random().toString(16).slice(2, 8)}`.toUpperCase();
+
+  return Discount.create({
+    businessId: business._id,
+    name: overrides.name || 'Integration Discount',
+    couponCode: overrides.couponCode || `INT${suffix}`.slice(0, 20),
+    type: overrides.type || 'percentage',
+    value: overrides.value ?? 10,
+    minOrderAmount: overrides.minOrderAmount ?? 0,
+    isActive: overrides.isActive ?? true,
+    ...overrides,
+  });
+}
+
 module.exports = {
   validStage1Draft,
   registerUser,
@@ -205,6 +221,7 @@ module.exports = {
   seedServiceBusiness,
   seedServiceCategories,
   seedPublishedProduct,
+  seedDiscount,
   seedVendorOnboarding,
   uniqueEmail,
 };


### PR DESCRIPTION
## Summary
- Close BE-CR-001 by resolving discount ownership from persisted `Discount.businessId -> Business.owner` instead of trusting client-supplied identifiers.
- Guard `GET/PUT/DELETE /api/discounts/:id` with `isBusinessOwner` plus controller ownership checks; cross-tenant access returns non-enumerating 404.
- Add unit and integration authorization tests for owner, cross-owner, unauthenticated, missing, and malformed id cases.

## Test plan
- [x] `npm test`
- [x] `npm run test:contract`
- [x] `npm run test:integration`
- [x] `node --test tests/discount/discount-ownership.test.js`
- [x] `node --test tests/integration/discount-ownership.integration.test.js`
- [x] Health/readiness covered by existing unit tests (`GET /api/health`, `GET /api/ready`)

## Security
**Before:** Any authenticated user could GET any discount; any business_owner could PUT/DELETE any discount by id.
**After:** Only the business owner of the discount's business can read/update/delete; others receive 404.

## Known risks
- `POST /api/discounts/` and `GET /api/discounts/business/:businessId` remain out of scope for this PR.
- No admin discount bypass (none documented).

## Rollback
Revert this PR; no migrations or env changes.

Made with [Cursor](https://cursor.com)