### PR TITLE
Fix marketplace badge filter intersections

### DIFF
--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -26,6 +26,7 @@ const {
   loadTagsByBusinessIds,
   narrowVisibleBusinessIds,
   mergeBusinessIdFilter,
+  applyBadgeBusinessIdFilter,
   buildKeywordRegex,
 } = require('../lib/listing/publicSearchFilters');
 const {
@@ -142,12 +143,6 @@ exports.getAllServices = async (req, res) => {
     } = req.query;
 
     const filters = { isPublished: true };
-    const badgeValueMap = {
-      silver: 'Silver',
-      gold: 'Gold',
-      platinum: 'Platinum',
-      diamond: 'Diamond',
-    };
 
     // Search
     if (search) {
@@ -222,43 +217,9 @@ exports.getAllServices = async (req, res) => {
       }
     }
 
-    // Badge filtering via Business badge
-    if (badge) {
-      const requestedBadges = (Array.isArray(badge) ? badge : [badge])
-        .flatMap((value) => String(value || '').split(','))
-        .map((value) => value.trim().toLowerCase())
-        .filter(Boolean)
-        .map((value) => badgeValueMap[value] || value);
-
-      const badgeBusinesses = await Business.find(
-        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
-      ).select('_id').lean();
-
-      const badgeBusinessIds = badgeBusinesses.map((b) => b._id.toString());
-
-      if (!badgeBusinessIds.length) {
-        return res.json({
-          success: true,
-          total: 0,
-          page: parseInt(page),
-          totalPages: 0,
-          data: [],
-        });
-      }
-
-      if (filters.businessId) {
-        if (!badgeBusinessIds.includes(String(filters.businessId))) {
-          return res.json({
-            success: true,
-            total: 0,
-            page: parseInt(page),
-            totalPages: 0,
-            data: [],
-          });
-        }
-      } else {
-        filters.businessId = { $in: badgeBusinessIds };
-      }
+    const badgeScoped = await applyBadgeBusinessIdFilter(filters, badge);
+    if (badgeScoped.empty) {
+      return res.json(emptyListResponse(page));
     }
 
     // Sorting
@@ -560,12 +521,6 @@ exports.getAllFood = async (req, res) => {
     } = req.query;
 
     const filters = { isPublished: true };
-    const badgeValueMap = {
-      silver: 'Silver',
-      gold: 'Gold',
-      platinum: 'Platinum',
-      diamond: 'Diamond',
-    };
 
     // Search filter
     if (search) {
@@ -649,31 +604,9 @@ exports.getAllFood = async (req, res) => {
       filters.price = { $gte: 0, $lte: 200 };
     }
 
-    // Badge filtering
-    if (badge) {
-      const requestedBadges = (Array.isArray(badge) ? badge : [badge])
-        .flatMap((value) => String(value || '').split(','))
-        .map((value) => value.trim().toLowerCase())
-        .filter(Boolean)
-        .map((value) => badgeValueMap[value] || value);
-
-      const badgeBusinesses = await Business.find(
-        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
-      ).select('_id').lean();
-
-      const badgeBusinessIds = badgeBusinesses.map((b) => b._id);
-
-      if (!badgeBusinessIds.length) {
-        return res.json({
-          success: true,
-          total: 0,
-          page: parseInt(page),
-          totalPages: 0,
-          data: [],
-        });
-      }
-
-      filters.businessId = { $in: badgeBusinessIds };
+    const badgeScoped = await applyBadgeBusinessIdFilter(filters, badge);
+    if (badgeScoped.empty) {
+      return res.json(emptyListResponse(page));
     }
 
     // Sorting
@@ -1037,12 +970,6 @@ exports.getAllProducts = async (req, res) => {
     } = req.query;
 
     const filters = { isDeleted: false, isPublished: true };
-    const badgeValueMap = {
-      silver: 'Silver',
-      gold: 'Gold',
-      platinum: 'Platinum',
-      diamond: 'Diamond',
-    };
 
     if (search) {
       filters.$or = [
@@ -1115,43 +1042,9 @@ if (price) {
   }
 }
 
-    // Badge filtering via Business badge
-    if (badge) {
-      const requestedBadges = (Array.isArray(badge) ? badge : [badge])
-        .flatMap((value) => String(value || '').split(','))
-        .map((value) => value.trim().toLowerCase())
-        .filter(Boolean)
-        .map((value) => badgeValueMap[value] || value);
-
-      const badgeBusinesses = await Business.find(
-        publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
-      ).select('_id').lean();
-
-      const badgeBusinessIds = badgeBusinesses.map((b) => b._id.toString());
-
-      if (!badgeBusinessIds.length) {
-        return res.json({
-          success: true,
-          total: 0,
-          page: parseInt(page),
-          totalPages: 0,
-          data: [],
-        });
-      }
-
-      if (filters.businessId) {
-        if (!badgeBusinessIds.includes(String(filters.businessId))) {
-          return res.json({
-            success: true,
-            total: 0,
-            page: parseInt(page),
-            totalPages: 0,
-            data: [],
-          });
-        }
-      } else {
-        filters.businessId = { $in: badgeBusinessIds };
-      }
+    const badgeScoped = await applyBadgeBusinessIdFilter(filters, badge);
+    if (badgeScoped.empty) {
+      return res.json(emptyListResponse(page));
     }
 
     let sortOption = { createdAt: -1 };

--- a/docs/TECHWARE_REGRESSION_RECONCILIATION.md
+++ b/docs/TECHWARE_REGRESSION_RECONCILIATION.md
@@ -1,0 +1,109 @@
+# Techware Regression Reconciliation
+
+Date: 2026-06-24
+
+Repository: `Techware-Hut/mosaic-backend`
+
+Input report: `MBH Technical Regression Analysis.docx`
+
+This document reconciles the report as a set of claims against the current backend code. The report is not treated as source of truth. Only currently proven, low-risk marketplace badge filter defects are in scope for the paired code change.
+
+## Repository Truth
+
+| Item | Evidence |
+| --- | --- |
+| Working branch | `fix/backend-marketplace-badge-filter-regressions` |
+| Branch base | `origin/staging` |
+| Current branch SHA before edits | `c00b9fc8697c104851c4027d92540aa7a5c92e0f` |
+| `origin/main` SHA | `779b6945737b55d24f2e548300818d713570480a` |
+| `origin/staging` SHA | `c00b9fc8697c104851c4027d92540aa7a5c92e0f` |
+| Working tree before edits | Clean |
+| Open PRs affecting staging/main | `#130 fix/backend-root-domain-canonicalization -> staging`; `#129 staging -> main` |
+| Production health build identity | `release.commit=cf454ed`, `deploymentVersion=mosaic-cf454edb28905a1b54963ee71da819f40a6ade68` from `GET /api/health`, `GET /api/ready`, `GET /api/build-info` |
+| Production matches main? | Not confirmed. Production commit `cf454ed` differs from `origin/main` `779b6945737b55d24f2e548300818d713570480a`. |
+
+History checks run before code edits:
+
+- `git fetch --all --prune`
+- `git status`
+- `git branch --show-current`
+- `git log --oneline --decorate --graph --all -n 100`
+- `git diff --stat origin/main...origin/staging`
+- `git log --oneline origin/main..origin/staging`
+
+`origin/main..origin/staging` currently contains the domain/connect release work from PRs `#124`, `#128`, and staging sync commit `c00b9fc`. This branch is based on `origin/staging` and does not target `main`.
+
+## Claim Classification Table
+
+| Report issue | Normalized claim | Classification | Current evidence | Route/contract | Tests/evidence | Final disposition |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Vendor registration OTP copy says mobile and failed email delivery returns false success. | STALE_ALREADY_FIXED | `controllers/userController.js:79-94`, `96-145` return `502 OTP_DELIVERY_FAILED` on send failure and success copy says email. | `POST /api/user/register` returns `201` only after OTP email send succeeds. | `tests/auth/otp-email-delivery.test.js` asserts email copy and delivery failure behavior. | No auth change. |
+| 2 | Public DTO contracts leak inconsistent BSON Decimal128 or omit safe fields. | STALE_ALREADY_FIXED | `lib/listing/publicListingDto.js:42-50`, `245-305`; public listing controllers use shared DTO/card serializers. | Public product/service/food cards return finite numeric price or safe `null`. | `tests/marketplace/public-listing-dto.test.js`; this PR adds exact `{ "$numberDecimal": "15.00" }` coverage. | No DTO rewrite. |
+| 3 | Customer registration OTP flow is broken. | DUPLICATE_FINDING | Same auth code path as issue 1. | Same as issue 1. | Same as issue 1. | Counted as duplicate OTP claim. |
+| 4 | Rejected vendor save flow moves applications incorrectly or blocks resubmit. | STALE_ALREADY_FIXED | `controllers/vendorOnboarding.controller.js:58-170`, `1006-1080`. Save draft moves rejected to `draft`; explicit submit allows `rejected -> submitted`. | `POST /api/vendor-onboarding/draft`; `POST /api/vendor-onboarding/submit`. | `tests/vendor/rejected-application-resubmit.test.js`; `docs/VENDOR_LIFECYCLE.md`. | No onboarding change. |
+| 5 | Admin approval does not sync marketplace visibility. | PARTIALLY_CONFIRMED | `controllers/admin/vendorOnboardVerifyStage1.js:27-45`, `585-599` sync `Business.isApproved`. `lib/marketplace/businessEligibility.js:1-21` also requires `isActive`. | Public marketplace filters require approved and active businesses. | `tests/admin/vendor-onboarding-finalize.test.js:113-149`. | `isApproved` stale; automatic `isActive` reactivation is product/lifecycle decision. |
+| 6 | Location search ignores state/country. | NOT_REPRODUCED | `lib/listing/publicSearchFilters.js:51-73`, `216-250`, `298-350`, `419-465`; services include business/vendor location scope. Food/product apply listing `address.city/state/country` and business scope separately. | `GET /api/services/list`, `/api/food/list`, `/api/products/list`, `/api/public/search`. | `tests/marketplace/public-search-filters.test.js` covers city/state; this PR adds country and explicit businessId intersection checks. | No location code change. Clarify intended location source when frontend QA tests filters. |
+| 7 | Service badge filter fails due casing/object filter and missing Bronze. | CONFIRMED_CURRENT_DEFECT | Branch-base service badge code had no `Bronze` normalization and compared object `businessId` filters as strings. `Business.badge` enum includes `Bronze` at `models/Business.js:170-173`. This PR fixes with `lib/listing/publicSearchFilters.js:14-20`, `503-525` and `controllers/publicListing.js:220-222`. | `GET /api/services/list?badge=...` must preserve approved/active business scope and explicit `businessId`. | `tests/marketplace/public-listing-badge-filters.test.js`. | Fixed by shared badge normalization/intersection helper. |
+| 8 | Food listing has default price cap and badge overwrites vendor context. | PARTIALLY_CONFIRMED | `controllers/publicListing.js:593-604` default `$0-$200`, `price=all` opt-out. Branch-base food badge code overwrote existing `filters.businessId`; this PR fixes with `controllers/publicListing.js:607-609`. | `GET /api/food/list`. | `tests/marketplace/public-listing-badge-filters.test.js`. | Badge overwrite fixed. Price cap classified product decision, unchanged. |
+| 9 | Product count/listing count mismatch due soft deletes or stale counters. | RUNTIME_EVIDENCE_REQUIRED | Public/admin/category counts use `Product.countDocuments` or aggregation with `isDeleted:false`. `Business.usage.totalProducts` exists in `models/Business.js:94-105`, `274-303`, but no current mutation path was proven in this pass. | Product browse/category/admin count routes. | Static evidence only. | No counter mutation. Requires separate consumer/source-of-truth decision and reconciliation tests if needed. |
+| 10 | Product delete route is misspelled as `/api/product` vs expected `/api/products`. | STALE_ALREADY_FIXED | `app.js:158` mounts `routes/productRoutes.js` at `/api/product`; `routes/productRoutes.js:127-135` registers `DELETE /delete-product/:productId`. | Canonical vendor CRUD route is `DELETE /api/product/delete-product/:productId`. | Frontend callers inspected in `mosaic-biz-frontend-launch` call `/api/product/delete-product/:id`. Docs list singular product CRUD. | No alias added. |
+| 11 | Stripe Connect should restrict vendor types. | PRODUCT_DECISION_REQUIRED | `controllers/connectController.js:25-70` owner check and account-link creation; no listing-type eligibility rule in approved backend contract found during this pass. | `POST /api/connect/:businessId/account-link`. | Existing connect contract/integration tests only verify account-link/status behavior. | Out of scope by instruction. No Stripe changes. |
+| 12 | Login and auth-check response shapes differ and omit `mobile`/`isOtpVerified`. | STALE_ALREADY_FIXED | `utils/toPublicAuthUser.js:5-14`; `routes/userRoutes.js:55-57`, `121-122`; `controllers/userController.js:434-439`. | Login and auth-check use same safe serializer. | `tests/auth/auth-check-payload.test.js`; `tests/auth/vendor-login-session.test.js`. | No auth change. |
+| 13 | Vendor journey testing limitations prove production breakage. | NOT_REPRODUCED | Testing limitations are not defects without failing current route evidence. | N/A. | Test matrix documents remaining live/E2E gaps. | Track as QA coverage, not backend fix. |
+| 14 | Marketplace discovery umbrella regression. | DUPLICATE_FINDING | Decomposes into location, badge, DTO, count, booking/checkout claims. | Multiple public routes. | See rows 6-9 and Stripe/payment rows. | Duplicates handled by underlying claims. |
+| 15 | Decimal128 pricing serialization failure. | STALE_ALREADY_FIXED | Shared `normalizePrice` handles `$numberDecimal`. | Public listing cards/details. | `tests/marketplace/public-listing-dto.test.js`. | Add exact 15.00 regression assertion only. |
+| 16 | Service location filtering failure. | DUPLICATE_FINDING | Same as issue 6. | `GET /api/services/list`. | Public search filter tests. | No separate defect. |
+| 17 | Badge casing mismatch. | CONFIRMED_CURRENT_DEFECT | Branch-base maps normalized Silver/Gold/Platinum/Diamond but omitted Bronze; service/product compared object filters as strings; food overwrote filters. Fixed in `lib/listing/publicSearchFilters.js:14-20`, `503-525`. | Public service/food/product list badge filters. | `tests/marketplace/public-listing-badge-filters.test.js`; `tests/marketplace/public-search-filters.test.js`. | Fixed in shared helper. |
+| 18 | Food absent price filter should not cap at `$0-$200`. | PRODUCT_DECISION_REQUIRED | Current code intentionally keeps default MVP window and `price=all` opt-out at `controllers/publicListing.js:638-650`. | `GET /api/food/list`. | Static code evidence. | No change until product decides default behavior. |
+| 19 | Food badge filter overwrites vendor context. | CONFIRMED_CURRENT_DEFECT | Branch-base food badge code replaced `filters.businessId` with badge IDs. Current code calls `applyBadgeBusinessIdFilter` at `controllers/publicListing.js:607-609`. | `GET /api/food/list?businessId=...&badge=...`. | New badge test proves explicit matching vendor is preserved and nonmatching vendor is empty. | Fixed. |
+| 20 | OTP delivery failure. | DUPLICATE_FINDING | Same as issue 1. | Auth registration/resend/login. | OTP tests. | No separate defect. |
+| 21 | Delete product route mismatch. | DUPLICATE_FINDING | Same as issue 10. | `DELETE /api/product/delete-product/:productId`. | Frontend caller inspected. | No separate defect. |
+| 22 | Product counter synchronization failure. | RUNTIME_EVIDENCE_REQUIRED | `Business.usage.totalProducts` exists, but current public/admin/category counts do not appear to rely on it. | Subscription quota methods may read counters. | Static evidence only. | Separate focused audit if quota behavior fails. |
+| 23 | Draft save auto-submits rejected applications. | STALE_ALREADY_FIXED | Current `saveDraft` explicitly sets rejected to `draft` only. | `POST /api/vendor-onboarding/draft`. | Rejected resubmit tests. | No change. |
+| 24 | Rejected applications cannot be resubmitted. | STALE_ALREADY_FIXED | `submitForReview` permits `rejected`. | `POST /api/vendor-onboarding/submit`. | Rejected resubmit tests. | No change. |
+| 25 | Admin approval sync failure. | PARTIALLY_CONFIRMED | `isApproved` sync exists; `isActive` remains separate. | Admin finalization and public marketplace eligibility. | Finalization and eligibility tests. | No change until lifecycle rule approved. |
+| 26 | Missing user metadata in login response. | STALE_ALREADY_FIXED | Shared serializer returns `mobile` and `isOtpVerified`. | `POST /api/user/login`, `GET /api/user/auth/check`. | Auth payload tests. | No change. |
+
+## Contradictions In The Report
+
+- The report claims rejected draft edits move applications to `draft`, while another root-cause claim says draft save auto-submits rejected applications to `submitted`. Current code and tests prove the two-step flow: save/edit -> `draft`; explicit submit -> `submitted`.
+- The report claims rejected applications cannot be resubmitted, while also describing a flow where rejected applications re-enter review. Current code allows explicit resubmission from `rejected`.
+- The report claims OTP registration returns a false `201` success on email failure and says mobile; current code returns `502 OTP_DELIVERY_FAILED` and success copy says email.
+- The report claims login omits `mobile` and `isOtpVerified`; current login and auth-check both use `toPublicAuthUser`.
+- The report claims Decimal128 leaks through public DTOs; current public listing DTO normalizes `$numberDecimal`.
+
+## Confirmed Fix Scope
+
+Only these current defects are included in this PR:
+
+- Add `Bronze` to public badge normalization where `Business.badge` already supports it.
+- Intersect badge-matching business IDs with the existing `businessId` filter.
+- Preserve explicit vendor/business filters, including vendor-menu context.
+- Preserve approved/active marketplace eligibility through `publicMarketplaceBusinessFilter`.
+- Apply the same shared helper to public service, food, and product list badge filters because all three had the same badge normalization/intersection family.
+
+Out of scope:
+
+- Auth/OTP changes.
+- Rejected onboarding state changes.
+- Product counter mutations.
+- Product route aliases.
+- Food default price behavior.
+- Stripe Connect/payment/subscription/webhook changes.
+- Main branch merge or production deploy.
+
+## Runtime Smoke Evidence
+
+Read-only production checks were run against `https://api.mosaicbizhub.com` after local tests:
+
+| Probe | Result |
+| --- | --- |
+| `GET /api/health` | `200` |
+| `GET /api/ready` | `200` |
+| `GET /api/featured-products?page=1&limit=1` | `200`, count `0` |
+| `GET /api/services/list?badge=bronze&page=1&limit=1` | `200`, count `0` |
+| `GET /api/services/list?badge=silver&page=1&limit=1` | `200`, count `0` |
+| `GET /api/food/list?badge=bronze&page=1&limit=1&price=all` | `200`, count `0` |
+| `GET /api/food/list?badge=silver&page=1&limit=1&price=all` | `200`, count `0` |
+| `GET /api/services/list?businessId=6a3918d47788a4bcead90dc3&badge=silver&page=1&limit=1` | `200`, count `1` |
+| Food explicit `businessId+badge` | Skipped: no public food listing with both businessId and badge found on first page. |

--- a/lib/listing/publicSearchFilters.js
+++ b/lib/listing/publicSearchFilters.js
@@ -11,6 +11,13 @@ const {
 } = require('../marketplace/businessEligibility');
 
 const GEO_UNSUPPORTED_KEYS = ['radius', 'lat', 'lng', 'nearMe', 'nearme', 'longitude', 'latitude'];
+const BADGE_VALUE_MAP = Object.freeze({
+  bronze: 'Bronze',
+  silver: 'Silver',
+  gold: 'Gold',
+  platinum: 'Platinum',
+  diamond: 'Diamond',
+});
 
 function escapeRegex(value = '') {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -466,9 +473,10 @@ async function narrowVisibleBusinessIds(visibleBusinessIds, query = {}, options 
 }
 
 function mergeBusinessIdFilter(existingFilter, allowedBusinessIds) {
-  const allowedSet = new Set(allowedBusinessIds.map(String));
+  const allowedIds = (allowedBusinessIds || []).filter(Boolean);
+  const allowedSet = new Set(allowedIds.map(String));
 
-  if (!allowedBusinessIds.length) {
+  if (!allowedIds.length) {
     return { empty: true };
   }
 
@@ -487,9 +495,38 @@ function mergeBusinessIdFilter(existingFilter, allowedBusinessIds) {
   }
 
   return {
-    filter: { $in: allowedBusinessIds.map((id) => new mongoose.Types.ObjectId(id)) },
+    filter: { $in: allowedIds.map((id) => new mongoose.Types.ObjectId(id)) },
     empty: false,
   };
+}
+
+function normalizeBadgeValues(badge) {
+  const values = (Array.isArray(badge) ? badge : [badge])
+    .flatMap((value) => String(value || '').split(','))
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => BADGE_VALUE_MAP[value.toLowerCase()] || value);
+
+  return [...new Set(values)];
+}
+
+async function applyBadgeBusinessIdFilter(filters, badge) {
+  const requestedBadges = normalizeBadgeValues(badge);
+  if (!requestedBadges.length) return { empty: false };
+
+  const badgeBusinesses = await Business.find(
+    publicMarketplaceBusinessFilter({ badge: { $in: requestedBadges } })
+  ).select('_id').lean();
+
+  const merged = mergeBusinessIdFilter(
+    filters.businessId,
+    badgeBusinesses.map((business) => business._id)
+  );
+
+  if (merged.empty) return { empty: true };
+
+  filters.businessId = merged.filter;
+  return { empty: false };
 }
 
 function attachBusinessMetadataToListings(items, { verifiedMap, tagsMap }) {
@@ -531,5 +568,7 @@ module.exports = {
   loadTagsByBusinessIds,
   narrowVisibleBusinessIds,
   mergeBusinessIdFilter,
+  normalizeBadgeValues,
+  applyBadgeBusinessIdFilter,
   attachBusinessMetadataToListings,
 };

--- a/tests/marketplace/business-eligibility.test.js
+++ b/tests/marketplace/business-eligibility.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isPublicMarketplaceBusiness,
+  publicMarketplaceBusinessFilter,
+  getPublicMarketplaceBusinessBlock,
+} = require('../../lib/marketplace/businessEligibility');
+
+test('public marketplace eligibility requires approved and active business', () => {
+  assert.equal(isPublicMarketplaceBusiness({ isApproved: true, isActive: true }), true);
+  assert.equal(isPublicMarketplaceBusiness({ isApproved: false, isActive: true }), false);
+  assert.equal(isPublicMarketplaceBusiness({ isApproved: true, isActive: false }), false);
+});
+
+test('public marketplace filter adds approved active scope to extra criteria', () => {
+  assert.deepEqual(
+    publicMarketplaceBusinessFilter({ badge: { $in: ['Bronze'] } }),
+    { badge: { $in: ['Bronze'] }, isApproved: true, isActive: true }
+  );
+});
+
+test('public marketplace block reports ineligible businesses', () => {
+  const block = getPublicMarketplaceBusinessBlock({ isApproved: true, isActive: false });
+
+  assert.equal(block.status, 403);
+  assert.match(block.message, /approved and active/);
+  assert.equal(getPublicMarketplaceBusinessBlock({ isApproved: true, isActive: true }), null);
+});
+

--- a/tests/marketplace/public-listing-badge-filters.test.js
+++ b/tests/marketplace/public-listing-badge-filters.test.js
@@ -1,0 +1,288 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(__dirname, '../../controllers/publicListing.js');
+const filtersPath = path.resolve(__dirname, '../../lib/listing/publicSearchFilters.js');
+
+const ids = {
+  bronze: '507f1f77bcf86cd799439011',
+  silver: '507f1f77bcf86cd799439012',
+  gold: '507f1f77bcf86cd799439013',
+  otherSilver: '507f1f77bcf86cd799439014',
+  inactiveSilver: '507f1f77bcf86cd799439015',
+  unapprovedSilver: '507f1f77bcf86cd799439016',
+};
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildBusiness(overrides = {}) {
+  return {
+    _id: ids.bronze,
+    businessName: 'Marketplace Vendor',
+    badge: 'Bronze',
+    isApproved: true,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function buildListing(type, businessId) {
+  return {
+    _id: `${type}-${businessId}`,
+    title: `${type} listing`,
+    description: 'Listing',
+    businessId,
+    isPublished: true,
+    price: 25,
+    toObject() {
+      return { ...this };
+    },
+  };
+}
+
+function buildServiceFindChain(rows) {
+  const chain = {
+    select() { return chain; },
+    populate() { return chain; },
+    sort() { return chain; },
+    skip() { return chain; },
+    limit() { return chain; },
+    lean() { return Promise.resolve(rows); },
+  };
+  return chain;
+}
+
+function buildLeanFindChain(rows) {
+  const chain = {
+    select() { return chain; },
+    populate() { return chain; },
+    sort() { return chain; },
+    skip() { return chain; },
+    limit() { return chain; },
+    lean() { return Promise.resolve(rows); },
+  };
+  return chain;
+}
+
+function buildSelectLeanChain(rows) {
+  return {
+    select() {
+      return {
+        lean: async () => rows,
+      };
+    },
+  };
+}
+
+function normalizeIdSet(value) {
+  if (!value) return [];
+  if (value.$in) return value.$in.map(String);
+  return [String(value)];
+}
+
+function loadController(options = {}) {
+  const businesses = options.businesses || [
+    buildBusiness({ _id: ids.bronze, badge: 'Bronze' }),
+    buildBusiness({ _id: ids.silver, badge: 'Silver' }),
+    buildBusiness({ _id: ids.gold, badge: 'Gold' }),
+    buildBusiness({ _id: ids.otherSilver, badge: 'Silver' }),
+    buildBusiness({ _id: ids.inactiveSilver, badge: 'Silver', isActive: false }),
+    buildBusiness({ _id: ids.unapprovedSilver, badge: 'Silver', isApproved: false }),
+  ];
+  const captured = {
+    businessFinds: [],
+    serviceFind: null,
+    foodFind: null,
+    productFind: null,
+  };
+
+  const activeApprovedBusinesses = () => (
+    businesses.filter((business) => business.isApproved === true && business.isActive === true)
+  );
+
+  const findBusinesses = (filter = {}) => {
+    captured.businessFinds.push(filter);
+    let rows = activeApprovedBusinesses();
+
+    if (filter.badge?.$in) {
+      const requested = new Set(filter.badge.$in.map(String));
+      rows = rows.filter((business) => requested.has(String(business.badge)));
+    }
+
+    if (filter._id?.$in) {
+      const requested = new Set(filter._id.$in.map(String));
+      rows = rows.filter((business) => requested.has(String(business._id)));
+    }
+
+    return buildSelectLeanChain(rows);
+  };
+
+  const Service = {
+    find: (filter) => {
+      captured.serviceFind = filter;
+      return buildServiceFindChain(options.serviceRows || [buildListing('service', ids.bronze)]);
+    },
+    countDocuments: async () => 1,
+    findOne: async () => null,
+    findById: () => ({ populate: () => ({ populate: () => ({ populate: async () => null }) }) }),
+  };
+
+  const Food = {
+    find: (filter) => {
+      captured.foodFind = filter;
+      return buildLeanFindChain(options.foodRows || [buildListing('food', ids.silver)]);
+    },
+    countDocuments: async () => 1,
+    findById: () => ({ populate: () => ({ populate: async () => null }) }),
+  };
+
+  const Product = {
+    find: (filter) => {
+      captured.productFind = filter;
+      return buildLeanFindChain(options.productRows || [buildListing('product', ids.bronze)]);
+    },
+    countDocuments: async () => 1,
+    findById: () => ({ populate: () => ({ populate: async () => null }) }),
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).endsWith('models/Service')) return Service;
+    if (String(request).endsWith('models/Food')) return Food;
+    if (String(request).endsWith('models/Product')) return Product;
+    if (String(request).endsWith('models/ProductVariant')) return {};
+    if (String(request).endsWith('models/Business')) {
+      return {
+        find: findBusinesses,
+        findOne: () => ({ select: () => ({ lean: async () => activeApprovedBusinesses()[0] || null }) }),
+      };
+    }
+    if (String(request).endsWith('models/VendorOnboardingStage1')) {
+      return { find: () => buildSelectLeanChain([]), findOne: () => ({ select: () => ({ lean: async () => null }) }) };
+    }
+    if (String(request).endsWith('models/Review')) return { find: () => ({ populate: async () => [] }) };
+    if (String(request).endsWith('models/MinorityType')) return { find: async () => [] };
+    if (String(request).endsWith('models/ServiceCategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/ServiceSubcategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/FoodCategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/FoodSubcategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/ProductCategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/ProductSubcategory')) return { findOne: async () => null };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  delete require.cache[filtersPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+
+  return { controller, captured };
+}
+
+test('service badge filter normalizes Bronze and keeps approved active scope', async () => {
+  const { controller, captured } = loadController({
+    serviceRows: [buildListing('service', ids.bronze)],
+  });
+  const res = mockResponse();
+
+  await controller.getAllServices({ query: { badge: 'bronze' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.deepEqual(normalizeIdSet(captured.serviceFind.businessId), [ids.bronze]);
+  const badgeFilter = captured.businessFinds.find((filter) => filter.badge);
+  assert.deepEqual(badgeFilter.badge.$in, ['Bronze']);
+  assert.equal(badgeFilter.isApproved, true);
+  assert.equal(badgeFilter.isActive, true);
+});
+
+test('service badge filter supports Silver and Gold without explicit businessId', async () => {
+  const { controller, captured } = loadController({
+    serviceRows: [buildListing('service', ids.silver), buildListing('service', ids.gold)],
+  });
+  const res = mockResponse();
+
+  await controller.getAllServices({ query: { badge: 'silver,gold' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.deepEqual(
+    normalizeIdSet(captured.serviceFind.businessId).sort(),
+    [ids.gold, ids.silver, ids.otherSilver].sort()
+  );
+  assert.ok(!normalizeIdSet(captured.serviceFind.businessId).includes(ids.inactiveSilver));
+  assert.ok(!normalizeIdSet(captured.serviceFind.businessId).includes(ids.unapprovedSilver));
+});
+
+test('service badge filter preserves explicit matching businessId', async () => {
+  const { controller, captured } = loadController({
+    serviceRows: [buildListing('service', ids.silver)],
+  });
+  const res = mockResponse();
+
+  await controller.getAllServices({ query: { badge: 'silver', businessId: ids.silver } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.equal(captured.serviceFind.businessId, ids.silver);
+});
+
+test('service badge filter returns empty for explicit nonmatching businessId', async () => {
+  const { controller, captured } = loadController();
+  const res = mockResponse();
+
+  await controller.getAllServices({ query: { badge: 'gold', businessId: ids.silver } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.total, 0);
+  assert.equal(captured.serviceFind, null);
+});
+
+test('food badge filter does not leak another vendor into explicit vendor menu context', async () => {
+  const { controller, captured } = loadController({
+    foodRows: [buildListing('food', ids.silver)],
+  });
+  const res = mockResponse();
+
+  await controller.getAllFood({ query: { badge: 'silver', businessId: ids.silver, price: 'all' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.equal(captured.foodFind.businessId, ids.silver);
+});
+
+test('food badge filter returns empty for explicit nonmatching vendor context', async () => {
+  const { controller, captured } = loadController();
+  const res = mockResponse();
+
+  await controller.getAllFood({ query: { badge: 'gold', businessId: ids.silver, price: 'all' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.total, 0);
+  assert.equal(captured.foodFind, null);
+});
+
+test('product badge filter shares Bronze normalization and business-scope intersection', async () => {
+  const { controller, captured } = loadController({
+    productRows: [buildListing('product', ids.bronze)],
+  });
+  const res = mockResponse();
+
+  await controller.getAllProducts({ query: { badge: 'BRONZE' } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.deepEqual(normalizeIdSet(captured.productFind.businessId), [ids.bronze]);
+  const badgeFilter = captured.businessFinds.find((filter) => filter.badge);
+  assert.deepEqual(badgeFilter.badge.$in, ['Bronze']);
+});

--- a/tests/marketplace/public-listing-dto.test.js
+++ b/tests/marketplace/public-listing-dto.test.js
@@ -48,6 +48,7 @@ test('normalizePrice returns null for missing values', () => {
 
 test('normalizePrice parses Decimal128 shape and zero', () => {
   assert.equal(normalizePrice({ $numberDecimal: '19.99' }), 19.99);
+  assert.equal(normalizePrice({ $numberDecimal: '15.00' }), 15);
   assert.equal(normalizePrice(0), 0);
 });
 

--- a/tests/marketplace/public-search-filters.test.js
+++ b/tests/marketplace/public-search-filters.test.js
@@ -14,6 +14,8 @@ const {
   intersectBusinessIdSets,
   shouldIncludeListingType,
   buildFlexibleMatchRegex,
+  normalizeBadgeValues,
+  mergeBusinessIdFilter,
 } = require(filtersPath);
 
 test('parsePublicSearchQuery leaves keyword empty when absent', () => {
@@ -32,6 +34,11 @@ test('parsePublicSearchQuery preserves city and state filters', () => {
   const parsed = parsePublicSearchQuery({ city: ' Austin ', state: ' TX ' });
   assert.equal(parsed.city, 'Austin');
   assert.equal(parsed.state, 'TX');
+});
+
+test('parsePublicSearchQuery preserves country filters', () => {
+  const parsed = parsePublicSearchQuery({ country: ' United States ' });
+  assert.equal(parsed.country, 'United States');
 });
 
 test('resolveBusinessIdsForMinorityType returns null for empty input', async () => {
@@ -65,6 +72,28 @@ test('resolveBusinessIdsByLocation applies city and state with approved active b
   assert.equal(capturedFilter.isActive, true);
   assert.equal(capturedFilter.isApproved, true);
   assert.equal(capturedFilter.$and.length, 2);
+});
+
+test('resolveBusinessIdsByLocation applies country with approved active business scope', async () => {
+  const id = '507f1f77bcf86cd799439012';
+  let capturedFilter = null;
+  const filters = loadFiltersWithMocks({
+    Business: {
+      find: async (filter) => {
+        capturedFilter = filter;
+        return [{ _id: id }];
+      },
+    },
+    VendorOnboardingStage1: { find: async () => [] },
+    MinorityType: { find: async () => [] },
+  });
+
+  const result = await filters.resolveBusinessIdsByLocation({ country: 'United States' });
+  assert.equal(result.length, 1);
+  assert.equal(String(result[0]), id);
+  assert.equal(capturedFilter.isActive, true);
+  assert.equal(capturedFilter.isApproved, true);
+  assert.equal(capturedFilter.$and.length, 1);
 });
 
 test('searchPublicListings returns empty data for unknown categorySlug', async () => {
@@ -111,6 +140,19 @@ test('intersectBusinessIdSets returns shared business ids', () => {
   const result = intersectBusinessIdSets(a, b);
   assert.equal(result.length, 1);
   assert.equal(String(result[0]), String(a[0]));
+});
+
+test('mergeBusinessIdFilter intersects explicit businessId lists', () => {
+  const keep = '507f1f77bcf86cd799439011';
+  const drop = '507f1f77bcf86cd799439012';
+  const result = mergeBusinessIdFilter({ $in: [keep, drop] }, [keep]);
+
+  assert.equal(result.empty, false);
+  assert.deepEqual(result.filter.$in.map(String), [keep]);
+});
+
+test('normalizeBadgeValues supports Bronze and comma-separated case normalization', () => {
+  assert.deepEqual(normalizeBadgeValues('bronze, GOLD'), ['Bronze', 'Gold']);
 });
 
 test('shouldIncludeListingType respects listingType filter', () => {


### PR DESCRIPTION
## Summary

This PR reconciles the MBH Technical Regression Analysis claims against current backend code and fixes only the confirmed marketplace badge filtering defects.

Confirmed and fixed:
- Public service badge filtering omitted `Bronze` and compared existing object `businessId` filters as strings.
- Public food badge filtering omitted `Bronze` and overwrote explicit/vendor `businessId` context with badge-matched IDs.
- Public product badge filtering had the same badge normalization/intersection family, so it now uses the shared helper too.

Disproven/stale or deferred in the reconciliation doc:
- OTP delivery/login/auth-check serializer claims are stale.
- Rejected vendor application resubmission claims are stale.
- Admin `Business.isApproved` sync exists; `isActive` reactivation remains a product decision.
- Product delete route singular `/api/product/delete-product/:productId` matches local frontend callers.
- Food default `$0-$200` price window remains unchanged pending product decision.
- Product counters need a separate source-of-truth/runtime audit before mutation.
- Stripe Connect behavior is intentionally untouched.

## Files Changed

- `docs/TECHWARE_REGRESSION_RECONCILIATION.md`
- `lib/listing/publicSearchFilters.js`
- `controllers/publicListing.js`
- `tests/marketplace/public-listing-badge-filters.test.js`
- `tests/marketplace/public-search-filters.test.js`
- `tests/marketplace/public-listing-dto.test.js`
- `tests/marketplace/business-eligibility.test.js`

## Routes Affected

- `GET /api/services/list?badge=...`
- `GET /api/food/list?badge=...`
- `GET /api/products/list?badge=...`

## Behavior Preserved

- Public marketplace filters still require approved and active businesses.
- Explicit `businessId` filters remain scoped to that vendor.
- Empty intersections still return the existing empty list response shape.
- Food default price behavior and `price=all` opt-out are unchanged.
- Auth, onboarding, payments, Stripe Connect, webhooks, subscriptions, and route aliases are unchanged.

## Tests Run

- `node --test tests/marketplace/public-listing-badge-filters.test.js tests/marketplace/public-search-filters.test.js tests/marketplace/public-listing-dto.test.js` -> 54 passed
- `node --test tests/marketplace/public-listing-badge-filters.test.js tests/marketplace/public-listing-dto.test.js tests/marketplace/public-search-filters.test.js tests/marketplace/business-eligibility.test.js tests/vendor/rejected-application-resubmit.test.js tests/admin/vendor-onboarding-finalize.test.js tests/auth/auth-check-payload.test.js tests/auth/otp-email-delivery.test.js tests/launch/backend-launch-contract.test.js tests/admin/admin-product-routes-guard.test.js tests/marketplace/featured-products-response.test.js` -> 104 passed
- `npm test` -> 386 passed
- `npm run test:contract` -> 20 passed
- `git diff --check` -> passed, CRLF warnings only

## Read-Only Runtime Smoke

Against `https://api.mosaicbizhub.com`:
- `GET /api/health` -> 200
- `GET /api/ready` -> 200
- `GET /api/featured-products?page=1&limit=1` -> 200, count 0
- `GET /api/services/list?badge=bronze&page=1&limit=1` -> 200, count 0
- `GET /api/services/list?badge=silver&page=1&limit=1` -> 200, count 0
- `GET /api/food/list?badge=bronze&page=1&limit=1&price=all` -> 200, count 0
- `GET /api/food/list?badge=silver&page=1&limit=1&price=all` -> 200, count 0
- `GET /api/services/list?businessId=6a3918d47788a4bcead90dc3&badge=silver&page=1&limit=1` -> 200, count 1
- Food explicit `businessId+badge` probe skipped because no public food listing with both fields was found on the first page.

## Known Risks

- Production currently reports build commit `cf454ed`, which is not confirmed to match `origin/main` `779b6945737b55d24f2e548300818d713570480a`.
- Badge smoke counts depend on current production data and the currently deployed build, not this branch.
- Product counter behavior is documented as requiring a separate source-of-truth audit.

## Rollback

Revert commit `51ace5c` from this branch/PR. This returns public badge filtering to the previous per-route implementation.

## Reconciliation Doc

See `docs/TECHWARE_REGRESSION_RECONCILIATION.md`.
