### PR TITLE
Enforce staging-only promotions to main

### DIFF
--- a/.github/workflows/enforce-staging-to-main.yml
+++ b/.github/workflows/enforce-staging-to-main.yml
@@ -1,0 +1,22 @@
+name: Enforce staging to main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-staging-source:
+    name: Enforce staging promotion
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify source branch is staging
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "::error::Pull requests to main must originate from the staging branch. Source branch: ${GITHUB_HEAD_REF:-unknown}"
+            exit 1
+          fi
+          echo "Source branch is staging — promotion to main is allowed."


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs on pull requests targeting `main`.
- Fails the check when the source branch (`github.head_ref`) is not exactly `staging`.
- Allows promotion PRs that originate from `staging` only.

## Test plan
- [ ] Merge to staging, then open a PR from a feature branch to `main` and confirm the check fails
- [ ] Open a PR from `staging` to `main` and confirm the check passes
- [ ] Confirm existing CI and EB deploy workflows are unchanged
