### PR TITLE
Release: backend deploy gate and release identity hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
 
       - name: Run integration tests
         run: npm run test:integration
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Confirm required build gate
+        run: echo "Backend validation completed; required build status is satisfied."

--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -52,6 +52,13 @@ jobs:
 
       - name: Create deployment package
         run: |
+          cat > release-manifest.json <<EOF
+          {
+            "commit": "${{ github.sha }}",
+            "environment": "production",
+            "deploymentVersion": "mosaic-${{ github.sha }}"
+          }
+          EOF
           shopt -s dotglob
           zip -r deploy.zip . \
             -x "*.git*" \
@@ -133,7 +140,12 @@ jobs:
               console.error('Missing release identity on /api/health');
               process.exit(1);
             }
-            console.log('Release identity present on /api/health');
+            const expected = '${{ github.sha }}'.slice(0, 7);
+            if (payload.release.commit !== expected) {
+              console.error(\`Release identity mismatch: expected \${expected}, got \${payload.release.commit}\`);
+              process.exit(1);
+            }
+            console.log(\`Release identity matches deployed commit: \${expected}\`);
           "
 
       - name: Post-deploy CORS probe

--- a/tests/release/releaseIdentity.test.js
+++ b/tests/release/releaseIdentity.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const releaseIdentityPath = path.resolve(__dirname, '../../utils/releaseIdentity.js');
@@ -12,6 +14,7 @@ function withReleaseIdentity(envOverrides, run) {
     'DEPLOYMENT_VERSION_LABEL',
     'SENTRY_RELEASE',
     'SENTRY_ENVIRONMENT',
+    'RELEASE_MANIFEST_PATH',
     'NODE_ENV',
   ]) {
     saved[key] = process.env[key];
@@ -72,6 +75,45 @@ test('getSentryRelease falls back to deployment label when SENTRY_RELEASE unset'
       });
     }
   );
+});
+
+test('getPublicReleaseInfo prefers packaged manifest over stale Sentry release env', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mosaic-release-'));
+  const manifestPath = path.join(tempDir, 'release-manifest.json');
+
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      commit: 'feedbee1234567890abcdef1234567890abcdef1',
+      environment: 'production',
+      deploymentVersion: 'mosaic-feedbee1234567890abcdef1234567890abcdef1',
+    })
+  );
+
+  try {
+    withReleaseIdentity(
+      {
+        RELEASE_MANIFEST_PATH: manifestPath,
+        SENTRY_RELEASE: 'mosaic-deadbee1234567890abcdef1234567890abcdef1',
+        SENTRY_ENVIRONMENT: 'staging',
+      },
+      ({ getPublicReleaseInfo, getSentryTags }) => {
+        const info = getPublicReleaseInfo();
+        assert.deepEqual(info, {
+          commit: 'feedbee',
+          environment: 'production',
+          deploymentVersion: 'mosaic-feedbee1234567890abcdef1234567890abcdef1',
+        });
+        assert.deepEqual(getSentryTags(), {
+          deployment_version: 'mosaic-feedbee1234567890abcdef1234567890abcdef1',
+          commit_sha: 'feedbee',
+          environment: 'production',
+        });
+      }
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test('getReleaseCommitSha derives commit from SENTRY_RELEASE mosaic label', () => {

--- a/utils/releaseIdentity.js
+++ b/utils/releaseIdentity.js
@@ -1,6 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
 const SAFE_LABEL_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
 const SAFE_SHA_PATTERN = /^[a-f0-9]{7,40}$/i;
 const VERSION_LABEL_PATTERN = /^mosaic-[a-f0-9]{7,40}$/i;
+const DEFAULT_RELEASE_MANIFEST_PATH = path.resolve(__dirname, '..', 'release-manifest.json');
 
 function normalizeOptionalString(value) {
   if (value == null) return undefined;
@@ -28,9 +32,27 @@ function extractCommitFromVersionLabel(label) {
   return sanitizeCommitSha(normalized);
 }
 
+function getReleaseManifestPath() {
+  return normalizeOptionalString(process.env.RELEASE_MANIFEST_PATH) || DEFAULT_RELEASE_MANIFEST_PATH;
+}
+
+function readReleaseManifest() {
+  try {
+    const raw = fs.readFileSync(getReleaseManifestPath(), 'utf8');
+    const manifest = JSON.parse(raw);
+    return manifest && typeof manifest === 'object' ? manifest : {};
+  } catch (_err) {
+    return {};
+  }
+}
+
 function getReleaseCommitSha() {
+  const manifest = readReleaseManifest();
+
   return (
     sanitizeCommitSha(process.env.RELEASE_COMMIT_SHA)
+    || sanitizeCommitSha(manifest.commit)
+    || extractCommitFromVersionLabel(manifest.deploymentVersion)
     || extractCommitFromVersionLabel(process.env.DEPLOYMENT_VERSION_LABEL)
     || extractCommitFromVersionLabel(process.env.SENTRY_RELEASE)
     || 'unknown'
@@ -43,8 +65,11 @@ function getShortReleaseCommitSha() {
 }
 
 function getReleaseEnvironment() {
+  const manifest = readReleaseManifest();
+
   return (
     normalizeOptionalString(process.env.RELEASE_ENVIRONMENT)
+    || normalizeOptionalString(manifest.environment)
     || normalizeOptionalString(process.env.SENTRY_ENVIRONMENT)
     || normalizeOptionalString(process.env.NODE_ENV)
     || 'development'
@@ -52,6 +77,12 @@ function getReleaseEnvironment() {
 }
 
 function getDeploymentVersionLabel() {
+  const manifest = readReleaseManifest();
+  const manifestVersion = normalizeOptionalString(manifest.deploymentVersion);
+  if (manifestVersion && SAFE_LABEL_PATTERN.test(manifestVersion)) {
+    return manifestVersion;
+  }
+
   const explicit = normalizeOptionalString(process.env.DEPLOYMENT_VERSION_LABEL);
   if (explicit && SAFE_LABEL_PATTERN.test(explicit)) {
     return explicit;


### PR DESCRIPTION
## Summary
- Promotes the backend CI required \uild\ status gate from staging.
- Promotes release-manifest based runtime identity so deployed packages report their actual SHA.
- Promotes deploy workflow enforcement that fails if /api/health reports the wrong deployed SHA.

## Verification
- PR #137 passed GitHub CI: Test and build.
- Local backend contract tests passed 20/20.
- Local backend full test suite passed 391/391.

## Operator note
After this merges to main and deploys, verify \https://api.mosaicbizhub.com/api/health\ and \/api/build-info\ report the new main SHA. Do not treat the release as verified until that runtime identity matches.