### PR TITLE
Release: protect admin categories endpoint

### DIFF
--- a/docs/ADMIN_AUTHORIZATION_MATRIX.md
+++ b/docs/ADMIN_AUTHORIZATION_MATRIX.md
@@ -56,7 +56,7 @@ Mount prefixes from [`app.js`](../app.js). All mutation routes require `authenti
 
 ## Public taxonomy reads (intentional)
 
-These admin-mounted **GET list** endpoints expose category metadata without auth — used by marketplace UI for taxonomy dropdowns:
+These admin-mounted **GET list** endpoints expose category metadata without auth for legacy taxonomy dropdowns. Aggregated admin category management uses `GET /api/admin/categories` and now requires `authenticate` + `isAdmin`.
 
 | Endpoint | File |
 |----------|------|
@@ -64,9 +64,8 @@ These admin-mounted **GET list** endpoints expose category metadata without auth
 | `GET /api/admin/category/service` | `categoryRoutes.js` |
 | `GET /api/admin/category/food` | `foodCategoryRoutes.js` |
 | `GET /api/admin/category/*-subcategory` (list) | `*SubcategoryRoutes.js` |
-| `GET /api/admin/categories` | `routes/categoryRoutes.js` (aggregated) |
 
-**Mutations** (POST/PUT/DELETE) on these mounts require admin. Documented in [`tests/admin/admin-categories-guard.test.js`](../tests/admin/admin-categories-guard.test.js).
+**Mutations** (POST/PUT/DELETE) on these mounts require admin. `GET /api/admin/categories` also requires admin and is documented in [`tests/admin/admin-categories-guard.test.js`](../tests/admin/admin-categories-guard.test.js).
 
 ---
 

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -257,7 +257,7 @@ Mounts: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (same
 | GET | `/api/subcategories/:categoryId` | — | `getProductSubcategories` | ⚪ Public | Subcategories | 🟢 |
 | GET | `/api/sub-categories` | — | `listSubcategories` | ⚪ Public | List subcategories | 🟢 |
 | GET | `/api/s3-presigned-url` | `authenticate`, `isBusinessOwnerOrAdmin` | `s3Controller.getPresignedUrl` | owner or admin | Generic S3 URL | 🟡 |
-| GET | `/api/admin/categories` | — | `getAllCategoriesAdmin` | ⚪ Public | Admin category list (no router guard on this route) | 🟡 audit |
+| GET | `/api/admin/categories` | `authenticate`, `isAdmin` | `getAllCategoriesAdmin` | admin | Admin category list | 🟢 guarded |
 
 ### Subcategories — [`routes/subcategoryRoutes.js`](../routes/subcategoryRoutes.js) → `/api`
 

--- a/docs/contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md
+++ b/docs/contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md
@@ -87,7 +87,6 @@ Notable dual mounts:
 
 | Route | Method | Notes |
 | --- | --- | --- |
-| `GET /api/admin/categories` | GET | No `authenticate`/`isAdmin` at route — public taxonomy dump |
 | `GET /api/vendor-onboarding/status/:applicationId` | GET | Intentionally public polling |
 | `POST /api/discounts/validate` | POST | Public coupon validation |
 | `POST /api/discounts/apply` | POST | Public apply |
@@ -215,7 +214,7 @@ Environment variable names involved (values not listed): `STRIPE_SECRET_KEY`, `S
 | --- | --- |
 | Child service delete | Covered by `tests/integration/service-child-delete.integration.test.js` (on audit baseline) |
 | Discount ownership IDOR | No integration test proving cross-vendor discount mutation fails |
-| Public `GET /api/admin/categories` | `tests/admin/admin-categories-guard.test.js` documents public exposure |
+| Admin `GET /api/admin/categories` | `tests/admin/admin-categories-guard.test.js` verifies `authenticate` + `isAdmin` |
 | Stripe checkout draft ownership | No test for cross-user draft checkout |
 | Route registration completeness | `tests/launch/backend-launch-contract.test.js` covers mounts, not every route |
 | Full route manifest sync | No CI check that `API_SURFACE.md` row count matches code |
@@ -312,16 +311,16 @@ Cannot be proven from static analysis alone:
 | **Full route** | `GET /api/admin/categories` |
 | **Method** | GET |
 | **Router / controller** | `categoryRoutes.js:30` → `getAllCategoriesAdmin` |
-| **Middleware** | None |
-| **Expected role** | Docs imply admin; code is public |
+| **Middleware** | `authenticate`, `isAdmin` |
+| **Expected role** | admin |
 | **Identifier semantics** | N/A |
 | **Request contract** | None |
 | **Response contract** | `{ success, data: { foodCategories, serviceCategories, productCategories } }` |
-| **Evidence** | `categoryController.js:64-130` |
-| **Likely frontend impact** | Admin UI may assume auth gate; endpoint works without session |
+| **Evidence** | `routes/categoryRoutes.js`, `tests/admin/admin-categories-guard.test.js` |
+| **Likely frontend impact** | Admin UI must call with an authenticated admin session; public browse uses `/api/categories/*` |
 | **Owner** | **backend** |
-| **Smoke test** | Unauthenticated GET → 200 with full taxonomy |
-| **Next action** | Add authenticate+isAdmin or rename path to public `/api/categories/admin` — **do not implement in audit branch** |
+| **Smoke test** | Unauthenticated GET returns `401`; non-admin sessions return `403` |
+| **Next action** | Resolved in launch hardening pass |
 
 ---
 

--- a/docs/contracts/BACKEND_ROUTE_MANIFEST.md
+++ b/docs/contracts/BACKEND_ROUTE_MANIFEST.md
@@ -483,7 +483,7 @@
 | FullRoute | Method | Router | Controller | Middleware | Auth | Role | Destructive | PaySens | ID semantics | Doc |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `/` | GET | `app.js` | `router.inline` | — | Public | — | no | no | — | listed |
-| `/api/admin/categories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
+| `/api/admin/categories` | GET | `routes/categoryRoutes` | `inline` | authenticate, isAdmin | JWT cookie/Bearer | admin | no | no | — | listed |
 | `/api/billing-portal/session` | POST | `routes/api.routes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | yes | — | listed |
 | `/api/categories` | GET | `routes/categoryRoutes` | `inline` | — | Public | — | no | no | — | listed |
 | `/api/category-requests` | POST | `routes/categoryRoutes` | `inline` | authenticate, isBusinessOwner | JWT cookie/Bearer | business_owner | no | no | — | listed |

--- a/routes/categoryRoutes.js
+++ b/routes/categoryRoutes.js
@@ -12,6 +12,7 @@ const {
 } = require('../controllers/categoryController');
 const s3Controller = require('../controllers/s3Controller');
 const authenticate = require('../middlewares/authenticate');
+const isAdmin = require('../middlewares/isAdmin');
 const isBusinessOwner = require('../middlewares/isBusinessOwner');
 const isBusinessOwnerOrAdmin = require('../middlewares/isBusinessOwnerOrAdmin');
 const router = express.Router();
@@ -27,7 +28,7 @@ router.get('/getProductCategories', getProductCategories);
 router.get('/subcategories/:categoryId', getProductSubcategories);
 router.get('/sub-categories', listSubcategories);
 router.get("/s3-presigned-url", authenticate,isBusinessOwnerOrAdmin, s3Controller.getPresignedUrl);
-router.get('/admin/categories', getAllCategoriesAdmin);
+router.get('/admin/categories', authenticate, isAdmin, getAllCategoriesAdmin);
 
 
 module.exports = router;

--- a/tests/admin/admin-categories-guard.test.js
+++ b/tests/admin/admin-categories-guard.test.js
@@ -5,11 +5,11 @@ const path = require('node:path');
 
 const categoryRoutesPath = path.resolve(__dirname, '../../routes/categoryRoutes.js');
 
-test('GET /api/admin/categories is registered without auth middleware (documented public exposure)', () => {
+test('GET /api/admin/categories requires authenticate and isAdmin middleware', () => {
   const source = fs.readFileSync(categoryRoutesPath, 'utf8');
 
-  assert.match(source, /router\.get\('\/admin\/categories', getAllCategoriesAdmin\)/);
-  const adminBlock = source.slice(source.indexOf("router.get('/admin/categories'"));
-  assert.ok(!adminBlock.includes('authenticate'), 'no authenticate on admin categories route');
-  assert.ok(!adminBlock.includes('isAdmin'), 'no isAdmin on admin categories route');
+  assert.match(
+    source,
+    /router\.get\('\/admin\/categories', authenticate, isAdmin, getAllCategoriesAdmin\)/
+  );
 });


### PR DESCRIPTION
## Summary
- Promotes the admin category aggregate endpoint guard from staging.
- `GET /api/admin/categories` now requires `authenticate` + `isAdmin`.
- Public marketplace taxonomy endpoints remain unchanged.

## Verification
- PR #139 passed GitHub CI: Test and build.
- Local focused tests passed 25/25.
- Local backend full test suite passed 391/391.

## Runtime expectation
After deployment, unauthenticated `GET https://api.mosaicbizhub.com/api/admin/categories` should return 401. Public endpoints such as `/api/categories/products`, `/api/categories/services`, and `/api/categories/foods` should continue returning 200.
