### PR TITLE
Harden canonical frontend link generation

### DIFF
--- a/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
+++ b/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
@@ -18,7 +18,7 @@ The prior `app.mosaicbizhub.com` canonical-domain plan is superseded. Do not pro
 
 | Area | File | Behavior |
 | --- | --- | --- |
-| Frontend URL generation | `utils/frontendUrl.js` | Defaults to `https://mosaicbizhub.com`; approves apex, temporary app, Vercel QA, and dev localhost outside production; rejects `www`, API, and arbitrary origins |
+| Frontend URL generation | `utils/frontendUrl.js` | Defaults generated links to `https://mosaicbizhub.com`; ignores stale `app.mosaicbizhub.com` env defaults; approves temporary app only for transition redirects/CORS preservation; approves Vercel QA and dev localhost outside production; rejects `www`, API, and arbitrary origins |
 | Stripe Connect return and refresh URLs | `lib/connect/connectUrls.js` | Uses the shared frontend URL allowlist and preserves approved full URL overrides |
 | Google OAuth redirect state | `controllers/authController.js` | Sanitizes supplied redirects before state creation and again before callback redirect |
 | Billing portal return URL | `controllers/billing.controller.js` | Sanitizes user-supplied or configured return URLs to an approved frontend origin or fallback account path |
@@ -57,7 +57,7 @@ Names only; do not commit values.
 | `CORS_ORIGINS` | Explicit comma-separated origins: apex plus approved transition/QA origins; no wildcard |
 | `API_BASE_URL` | API subdomain |
 | `COOKIE_DOMAIN` | Audit before changing; production default remains `.mosaicbizhub.com` when unset |
-| `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL` | Optional full overrides; must resolve to an approved frontend origin |
+| `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL` | Optional full overrides; must resolve to an approved frontend origin; leave unset for canonical apex generated defaults |
 | `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH` | Optional Connect path overrides on approved frontend origin |
 | `BILLING_PORTAL_RETURN_URL` | Optional billing return override; sanitized before use |
 | `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` | Release reporting; unchanged by hostname swap |

--- a/docs/TECHWARE_REGRESSION_RECONCILIATION.md
+++ b/docs/TECHWARE_REGRESSION_RECONCILIATION.md
@@ -63,7 +63,7 @@ History checks run before code edits:
 | 24 | Rejected applications cannot be resubmitted. | STALE_ALREADY_FIXED | `submitForReview` permits `rejected`. | `POST /api/vendor-onboarding/submit`. | Rejected resubmit tests. | No change. |
 | 25 | Admin approval sync failure. | PARTIALLY_CONFIRMED | `isApproved` sync exists; `isActive` remains separate. | Admin finalization and public marketplace eligibility. | Finalization and eligibility tests. | No change until lifecycle rule approved. |
 | 26 | Missing user metadata in login response. | STALE_ALREADY_FIXED | Shared serializer returns `mobile` and `isOtpVerified`. | `POST /api/user/login`, `GET /api/user/auth/check`. | Auth payload tests. | No change. |
-| 27 | Backend canonical frontend domain still points to `app.mosaicbizhub.com` after apex decision. | CONFIRMED_CURRENT_DEFECT | Current staging still has `utils/frontendUrl.js:1-4`, `utils/corsOrigins.js:1-4`, `tests/url/frontend-url.test.js:21-35`, and `docs/DOMAIN_MIGRATION_URL_INVENTORY.md:9-21` treating app as canonical and apex as disallowed/community. | Generated frontend URLs and default credentialed CORS origins. | Open PR `#130 fix/backend-root-domain-canonicalization -> staging` isolates this fix. Not bundled here to keep badge/listing recovery focused. | Separate P7 domain PR required before staging promotion. |
+| 27 | Backend canonical frontend domain still points to `app.mosaicbizhub.com` after apex decision. | RESOLVED_AFTER_REPORT | Current staging defaults generated frontend links to `https://mosaicbizhub.com`, keeps `app.mosaicbizhub.com` transition-only, keeps Vercel launch QA approved, and rejects `www`/API as frontend redirect targets. Stale app-domain env values no longer become the generated default. | Generated frontend URLs and default credentialed CORS origins. | `tests/url/frontend-url.test.js`, `tests/connect/connect-urls.test.js`, `tests/cors/cors-origins.test.js`. | Resolved by the root-domain correction and follow-up generated-link hardening. |
 
 ## Contradictions In The Report
 
@@ -92,7 +92,7 @@ Out of scope:
 - Product route aliases.
 - Food default price behavior.
 - Stripe Connect/payment/subscription/webhook changes.
-- Apex/root domain code changes already isolated in PR `#130`.
+- Apex/root domain code changes, now handled by the root-domain correction and generated-link hardening.
 - Main branch merge or production deploy.
 
 ## Ordered Queue Evidence
@@ -105,7 +105,7 @@ Out of scope:
 | Product counts and deletion | RUNTIME_EVIDENCE_REQUIRED | Product delete route is registered at `routes/productRoutes.js:127-135` and soft-deletes product plus variants in `controllers/productController.js:926-955`. Public/admin/category counts use `Product.countDocuments` or aggregation with `isDeleted:false`; quota usage is documented and tested in `utils/listingTierLimits.js:6-17`, `tests/vendor/listing-tier-limits.test.js:10-24`. No wrong consumer result was reproduced. |
 | Stale auth/onboarding claims | STALE_ALREADY_FIXED | OTP delivery tests, auth-check payload tests, rejected-resubmit tests, vendor finalize tests, and marketplace eligibility tests cover these without backend behavior changes. |
 | Food price ceiling | PRODUCT_DECISION_REQUIRED | `controllers/publicListing.js:593-604` keeps default `$0-$200`; `price=all` explicitly opts out. No approved source found proving no maximum is intended. |
-| Canonical domain audit | CONFIRMED_CURRENT_DEFECT, SEPARATE_PR | Apex is now contractually canonical, but staging still defaults to app. PR `#130` contains the isolated root-domain correction; this branch does not change CORS/cookie/domain behavior. |
+| Canonical domain audit | RESOLVED_AFTER_REPORT | Apex is now contractually canonical for generated backend links. `app.mosaicbizhub.com` remains only as a temporary transition origin for CORS/redirect preservation until apex auth/payment smoke passes. |
 
 ## Runtime Smoke Evidence
 

--- a/problem.txt
+++ b/problem.txt
@@ -49,5 +49,5 @@ app.use("trust proxy", 1);
 app.js
 
 stripeController.js
-    success_url: 'https://app.mosaicbizhub.com/partners',
-    cancel_url: 'https://app.mosaicbizhub.com/partners',
+    success_url: buildFrontendUrl("/partners"),
+    cancel_url: buildFrontendUrl("/partners"),

--- a/tests/connect/connect-urls.test.js
+++ b/tests/connect/connect-urls.test.js
@@ -20,6 +20,22 @@ test('getReturnAndRefreshUrls uses the apex frontend host and default Connect pa
   );
 });
 
+test('getReturnAndRefreshUrls ignores legacy app FRONTEND_URL for generated defaults', () => {
+  const urls = getReturnAndRefreshUrls(businessId, {
+    NODE_ENV: 'production',
+    FRONTEND_URL: 'https://app.mosaicbizhub.com',
+  });
+
+  assert.equal(
+    urls.returnUrl,
+    'https://mosaicbizhub.com/partners/connect/return?businessId=507f1f77bcf86cd799439011'
+  );
+  assert.equal(
+    urls.refreshUrl,
+    'https://mosaicbizhub.com/partners/connect/refresh?businessId=507f1f77bcf86cd799439011'
+  );
+});
+
 test('getReturnAndRefreshUrls honors full URL overrides', () => {
   const urls = getReturnAndRefreshUrls(businessId, {
     NODE_ENV: 'production',

--- a/tests/url/frontend-url.test.js
+++ b/tests/url/frontend-url.test.js
@@ -25,6 +25,17 @@ test('getFrontendBaseUrl uses the first approved configured frontend origin', ()
   );
 });
 
+test('getFrontendBaseUrl ignores the legacy app subdomain as a configured default', () => {
+  assert.equal(
+    getFrontendBaseUrl({
+      NODE_ENV: 'production',
+      FRONTEND_URL: 'https://app.mosaicbizhub.com',
+      APP_URL: 'https://app.mosaicbizhub.com',
+    }),
+    'https://mosaicbizhub.com'
+  );
+});
+
 test('getFrontendBaseUrl ignores www because it should redirect to apex', () => {
   assert.equal(
     getFrontendBaseUrl({
@@ -33,6 +44,16 @@ test('getFrontendBaseUrl ignores www because it should redirect to apex', () => 
       APP_URL: 'https://www.mosaicbizhub.com',
     }),
     'https://mosaicbizhub.com'
+  );
+});
+
+test('buildFrontendUrl falls back to apex when production env still points at legacy app', () => {
+  assert.equal(
+    buildFrontendUrl('/partners/connect/return?businessId=abc', {
+      NODE_ENV: 'production',
+      FRONTEND_URL: 'https://app.mosaicbizhub.com',
+    }),
+    'https://mosaicbizhub.com/partners/connect/return?businessId=abc'
   );
 });
 

--- a/utils/frontendUrl.js
+++ b/utils/frontendUrl.js
@@ -1,8 +1,14 @@
 const DEFAULT_FRONTEND_URL = 'https://mosaicbizhub.com';
+const LEGACY_FRONTEND_URL = 'https://app.mosaicbizhub.com';
+const LAUNCH_QA_FRONTEND_URL = 'https://mosaic-biz-frontend-launch.vercel.app';
 const APPROVED_FRONTEND_ORIGINS = [
-  'https://mosaicbizhub.com',
-  'https://app.mosaicbizhub.com',
-  'https://mosaic-biz-frontend-launch.vercel.app',
+  DEFAULT_FRONTEND_URL,
+  LEGACY_FRONTEND_URL,
+  LAUNCH_QA_FRONTEND_URL,
+];
+const GENERATED_FRONTEND_ORIGINS = [
+  DEFAULT_FRONTEND_URL,
+  LAUNCH_QA_FRONTEND_URL,
 ];
 const DEV_FRONTEND_ORIGINS = [
   'http://localhost:3000',
@@ -46,6 +52,16 @@ function getAllowedFrontendOrigins(env = process.env) {
   return [...new Set(origins)];
 }
 
+function getGeneratedFrontendOrigins(env = process.env) {
+  const origins = [...GENERATED_FRONTEND_ORIGINS];
+
+  if (!isProductionEnv(env)) {
+    origins.push(...DEV_FRONTEND_ORIGINS);
+  }
+
+  return [...new Set(origins)];
+}
+
 function getOrigin(value) {
   if (!value) return null;
 
@@ -57,6 +73,12 @@ function isAllowedFrontendOrigin(value, env = process.env) {
   const origin = getOrigin(value);
   if (!origin || DISALLOWED_FRONTEND_ORIGINS.has(origin)) return false;
   return getAllowedFrontendOrigins(env).includes(origin);
+}
+
+function isAllowedGeneratedFrontendOrigin(value, env = process.env) {
+  const origin = getOrigin(value);
+  if (!origin || DISALLOWED_FRONTEND_ORIGINS.has(origin)) return false;
+  return getGeneratedFrontendOrigins(env).includes(origin);
 }
 
 function toBaseUrlString(url) {
@@ -74,7 +96,7 @@ function toBaseUrlString(url) {
 function getFrontendBaseUrl(env = process.env) {
   for (const key of ENV_PRIORITY) {
     const parsed = parseAbsoluteUrl(env[key]);
-    if (parsed && isAllowedFrontendOrigin(parsed, env)) {
+    if (parsed && isAllowedGeneratedFrontendOrigin(parsed, env)) {
       return toBaseUrlString(parsed);
     }
   }
@@ -121,10 +143,15 @@ module.exports = {
   APPROVED_FRONTEND_ORIGINS,
   DEFAULT_FRONTEND_URL,
   DEV_FRONTEND_ORIGINS,
+  GENERATED_FRONTEND_ORIGINS,
+  LAUNCH_QA_FRONTEND_URL,
+  LEGACY_FRONTEND_URL,
   buildFrontendUrl,
   getAllowedFrontendOrigins,
   getFrontendBaseUrl,
+  getGeneratedFrontendOrigins,
   getFrontendLogoUrl,
+  isAllowedGeneratedFrontendOrigin,
   isAllowedFrontendOrigin,
   normalizeFrontendUrl,
   sanitizeFrontendRedirectUrl,


### PR DESCRIPTION
Summary: keep app.mosaicbizhub.com as a temporary transition origin, but prevent stale FRONTEND_URL or APP_URL values from making it the generated backend default. Generated Stripe/OAuth/email/frontend links now fall back to mosaicbizhub.com unless an approved QA origin is configured. Tests passed: focused URL/CORS/OAuth/cookie suite, backend contract suite, full backend test suite.