### PR TITLE
[codex] Remove backend launch debug logging

### DIFF
--- a/controllers/contactInquiry.controller.js
+++ b/controllers/contactInquiry.controller.js
@@ -44,7 +44,7 @@ exports.createContactInquiry = async (req, res) => {
 
       await transporter.sendMail(mailOptions);
     } catch (emailError) {
-      console.log('Email sending failed:', emailError.message);
+      console.warn('Contact inquiry email sending failed:', emailError.message);
     }
 
     res.status(201).json({ 

--- a/controllers/customer/wishlist.controller.js
+++ b/controllers/customer/wishlist.controller.js
@@ -5,8 +5,6 @@ const ProductVariant = require('../../models/ProductVariant');
 // GET /api/wishlist
 exports.getWishlist = async (req, res) => {
     try {
-        console.log("hre");
-
         const wishlist = await Wishlist.find({ customerId: req.user._id })
             .populate({
                 path: 'productVariantId',

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -142,7 +142,6 @@ exports.createProductWithVariants = async (req, res) => {
     }
 
     const userId = req.user._id;
-    console.log('Creating product for user:', userId);
 
     const {
       title,
@@ -399,7 +398,6 @@ const maxPrice = Math.max(...prices);
 //     }
 
 //     const userId = req.user._id;
-//     console.log('Creating product for user:', userId);
 
 //     const {
 //       title,

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -1217,7 +1217,7 @@ exports.getProductsByFilters = async (req, res) => {
               product.variants = [];
             }
           } catch (variantError) {
-            console.log('Error fetching variants for product:', product._id, variantError.message);
+            console.warn('Error fetching variants for product:', product._id, variantError.message);
             product.variants = [];
           }
         }

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -72,9 +72,6 @@ exports.stripePaymentWebhook = async (req, res) => {
         // store IDs on each item (matches your current schema)
 
         order.items.forEach((it) => {
-          console.log(chargeId || it.chargeId)
-          console.log(transferId || it.transferId)
-          console.log(applicationFeeId || it.applicationFeeId)
           it.chargeId = chargeId || it.chargeId;
           it.transferId = transferId || it.transferId;
           it.applicationFeeId = applicationFeeId || it.applicationFeeId;

--- a/utils/invoiceHtml.js
+++ b/utils/invoiceHtml.js
@@ -62,7 +62,6 @@ async function invoiceHtmlForOrder({ order }) {
         const unitMajor = Number(it?.price || 0); // unit price captured at purchase (MAJOR)
         const lineMajor = unitMajor * qty;
         subtotalMajor += lineMajor;
-        console.log(subtotalMajor, unitMajor, qty, lineMajor)
         return { name, options, sku, qty, unitMajor, lineMajor };
     });
 

--- a/utils/uploadFile.js
+++ b/utils/uploadFile.js
@@ -11,13 +11,6 @@ const s3 = new S3Client({
 });
 
 exports.uploadFile = async (file, folder = "business") => {
-  console.log("Uploading file to S3", {
-    folder,
-    originalName: file?.originalname || null,
-    mimeType: file?.mimetype || null,
-    size: file?.size || null,
-  });
-  
   if (!file) throw new Error("No file provided");
 
   const fileName = `${folder}/${uuidv4()}-${file.originalname}`;


### PR DESCRIPTION
## Summary
- remove leftover backend runtime debug logging from wishlist, product creation, invoice generation, S3 uploads, and Stripe order payment webhook item updates
- avoid dumping raw Stripe charge/transfer/application fee IDs and upload metadata to production logs
- convert non-fatal contact inquiry email and public listing variant failures from `console.log` to warning-level logging

## Validation
- `npm run test:contract` passed: 20/20
- `npm test` passed: 394/394
- `git diff --check` passed