### PR TITLE
[codex] Promote backend launch hardening to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@ MONGODB_URI=mongodb://localhost:27017/mbh
 FRONTEND_URL=http://localhost:3000
 
 # Comma-separated browser origins allowed for credentialed CORS (production).
-# The root domain is the community site and is not included by default.
-# CORS_ORIGINS=https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app
+# The apex domain is the canonical marketplace frontend. Keep app.mosaicbizhub.com
+# only as a temporary transition origin until final-domain auth/payment smoke passes.
+# CORS_ORIGINS=https://mosaicbizhub.com,https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app
 
 JWT_SECRET=replace-with-a-long-random-secret
 
@@ -54,8 +55,10 @@ CONNECT_RETURN_PATH=/partners/connect/return
 
 CONNECT_REFRESH_PATH=/partners/connect/refresh
 
+# Prefer FRONTEND_URL + CONNECT_RETURN_PATH in production. Use full URL overrides only for an intentional QA/cutover window.
 CONNECT_RETURN_URL=http://localhost:3000/partners/connect/return
 
+# Prefer FRONTEND_URL + CONNECT_REFRESH_PATH in production. Use full URL overrides only for an intentional QA/cutover window.
 CONNECT_REFRESH_URL=http://localhost:3000/partners/connect/refresh
 
 

--- a/controllers/contactInquiry.controller.js
+++ b/controllers/contactInquiry.controller.js
@@ -44,7 +44,7 @@ exports.createContactInquiry = async (req, res) => {
 
       await transporter.sendMail(mailOptions);
     } catch (emailError) {
-      console.log('Email sending failed:', emailError.message);
+      console.warn('Contact inquiry email sending failed:', emailError.message);
     }
 
     res.status(201).json({ 

--- a/controllers/customer/wishlist.controller.js
+++ b/controllers/customer/wishlist.controller.js
@@ -5,8 +5,6 @@ const ProductVariant = require('../../models/ProductVariant');
 // GET /api/wishlist
 exports.getWishlist = async (req, res) => {
     try {
-        console.log("hre");
-
         const wishlist = await Wishlist.find({ customerId: req.user._id })
             .populate({
                 path: 'productVariantId',

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -142,7 +142,6 @@ exports.createProductWithVariants = async (req, res) => {
     }
 
     const userId = req.user._id;
-    console.log('Creating product for user:', userId);
 
     const {
       title,
@@ -399,7 +398,6 @@ const maxPrice = Math.max(...prices);
 //     }
 
 //     const userId = req.user._id;
-//     console.log('Creating product for user:', userId);
 
 //     const {
 //       title,

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -1217,7 +1217,7 @@ exports.getProductsByFilters = async (req, res) => {
               product.variants = [];
             }
           } catch (variantError) {
-            console.log('Error fetching variants for product:', product._id, variantError.message);
+            console.warn('Error fetching variants for product:', product._id, variantError.message);
             product.variants = [];
           }
         }

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -72,9 +72,6 @@ exports.stripePaymentWebhook = async (req, res) => {
         // store IDs on each item (matches your current schema)
 
         order.items.forEach((it) => {
-          console.log(chargeId || it.chargeId)
-          console.log(transferId || it.transferId)
-          console.log(applicationFeeId || it.applicationFeeId)
           it.chargeId = chargeId || it.chargeId;
           it.transferId = transferId || it.transferId;
           it.applicationFeeId = applicationFeeId || it.applicationFeeId;

--- a/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
+++ b/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
@@ -18,7 +18,7 @@ The prior `app.mosaicbizhub.com` canonical-domain plan is superseded. Do not pro
 
 | Area | File | Behavior |
 | --- | --- | --- |
-| Frontend URL generation | `utils/frontendUrl.js` | Defaults to `https://mosaicbizhub.com`; approves apex, temporary app, Vercel QA, and dev localhost outside production; rejects `www`, API, and arbitrary origins |
+| Frontend URL generation | `utils/frontendUrl.js` | Defaults generated links to `https://mosaicbizhub.com`; ignores stale `app.mosaicbizhub.com` env defaults; approves temporary app only for transition redirects/CORS preservation; approves Vercel QA and dev localhost outside production; rejects `www`, API, and arbitrary origins |
 | Stripe Connect return and refresh URLs | `lib/connect/connectUrls.js` | Uses the shared frontend URL allowlist and preserves approved full URL overrides |
 | Google OAuth redirect state | `controllers/authController.js` | Sanitizes supplied redirects before state creation and again before callback redirect |
 | Billing portal return URL | `controllers/billing.controller.js` | Sanitizes user-supplied or configured return URLs to an approved frontend origin or fallback account path |
@@ -57,7 +57,7 @@ Names only; do not commit values.
 | `CORS_ORIGINS` | Explicit comma-separated origins: apex plus approved transition/QA origins; no wildcard |
 | `API_BASE_URL` | API subdomain |
 | `COOKIE_DOMAIN` | Audit before changing; production default remains `.mosaicbizhub.com` when unset |
-| `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL` | Optional full overrides; must resolve to an approved frontend origin |
+| `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL` | Optional full overrides; must resolve to an approved frontend origin; leave unset for canonical apex generated defaults |
 | `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH` | Optional Connect path overrides on approved frontend origin |
 | `BILLING_PORTAL_RETURN_URL` | Optional billing return override; sanitized before use |
 | `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` | Release reporting; unchanged by hostname swap |

--- a/docs/EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md
+++ b/docs/EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md
@@ -1,0 +1,87 @@
+# EB Env Drift Cutover Audit
+
+**Date:** 2026-06-26
+**Scope:** Names-only launch cutover evidence for backend issues #82 and #83.
+**Rule:** Do not paste secret values from EB, Vercel, Stripe, Sentry, or email providers into this document or issue comments.
+
+This audit documents the intended production environment shape after the canonical frontend correction:
+
+- `https://mosaicbizhub.com` is the canonical marketplace frontend.
+- `https://app.mosaicbizhub.com` is transition-only.
+- `https://www.mosaicbizhub.com` should redirect to apex and should not be a credentialed app origin by default.
+- `https://api.mosaicbizhub.com` remains the backend API host.
+
+## Code Status
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Generated backend frontend links | Ready for cutover | `utils/frontendUrl.js` defaults to apex and ignores stale `FRONTEND_URL=https://app.mosaicbizhub.com` for generated defaults |
+| Stripe Connect return/refresh builder | Ready for cutover | `tests/connect/connect-urls.test.js` covers apex defaults, safe overrides, and legacy app fallback rejection as default |
+| Credentialed CORS defaults | Ready for cutover | `tests/cors/cors-origins.test.js` covers apex, transition app, launch Vercel, and wildcard rejection |
+| Cookie domain guardrails | Ready for cutover | `tests/cookie/cookie-options.test.js` covers `.mosaicbizhub.com` and invalid-domain fallback |
+| Final-domain runtime proof | Not complete | Requires deployed main, DNS/env cutover, and browser smoke |
+
+## EB Variables To Verify
+
+| Variable | Launch expectation | Action if different |
+| --- | --- | --- |
+| `FRONTEND_URL` | `https://mosaicbizhub.com` | Change to apex, then deploy or restart EB |
+| `CORS_ORIGINS` | Explicit comma-separated allowlist including `https://mosaicbizhub.com` and approved temporary origins only | Add apex; remove `https://www.mosaicbizhub.com` unless intentionally tested; deploy or restart EB |
+| `API_BASE_URL` | `https://api.mosaicbizhub.com` | Correct before OAuth smoke |
+| `COOKIE_DOMAIN` | Usually `.mosaicbizhub.com`, unless final smoke chooses host-only cookies | Do not change blindly; verify browser cookie behavior first |
+| `COOKIE_SECURE` | `true` | Correct before final auth smoke |
+| `COOKIE_SAMESITE` | `none` for cross-subdomain browser auth | Correct before final auth smoke |
+| `CONNECT_RETURN_PATH` | `/partners/connect/return` | Correct before Stripe Connect smoke |
+| `CONNECT_REFRESH_PATH` | `/partners/connect/refresh` | Correct before Stripe Connect smoke |
+| `CONNECT_RETURN_URL` | Usually unset in production unless an intentional full override is needed | If set to legacy app, replace with apex or remove and use path-based builder |
+| `CONNECT_REFRESH_URL` | Usually unset in production unless an intentional full override is needed | If set to legacy app, replace with apex or remove and use path-based builder |
+| `BILLING_PORTAL_RETURN_URL` | Apex frontend return URL for billing flows | Replace legacy app values before billing smoke |
+| `SENTRY_DSN` | Set in EB only when backend monitoring is enabled | Do not paste value; verify event after deploy |
+| `SENTRY_ENVIRONMENT` | `production` | Correct before backend Sentry proof |
+| `SENTRY_RELEASE` | Deployed release identifier or commit-based release | Align with deployed artifact |
+
+## Stripe Connect URL Decision
+
+Preferred launch configuration:
+
+```text
+FRONTEND_URL=https://mosaicbizhub.com
+CONNECT_RETURN_PATH=/partners/connect/return
+CONNECT_REFRESH_PATH=/partners/connect/refresh
+```
+
+Use full URL overrides only when QA intentionally targets a non-default frontend origin:
+
+```text
+CONNECT_RETURN_URL=https://mosaicbizhub.com/partners/connect/return
+CONNECT_REFRESH_URL=https://mosaicbizhub.com/partners/connect/refresh
+```
+
+Do not use `https://app.mosaicbizhub.com` as the production Connect return/refresh default after apex cutover.
+
+## Required Human Verification
+
+1. Confirm the EB environment values above in AWS without copying secrets into GitHub.
+2. Apply EB env changes and redeploy or restart the environment.
+3. Confirm the deployed backend release identity matches the intended `main` SHA.
+4. Run backend smoke:
+
+```powershell
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+```
+
+5. Run a credentialed CORS preflight from `https://mosaicbizhub.com`.
+6. Run Stripe Connect onboarding from the final frontend and confirm:
+   - onboarding starts
+   - return route lands on `https://mosaicbizhub.com/partners/connect/return`
+   - refresh route lands on `https://mosaicbizhub.com/partners/connect/refresh`
+   - interrupted onboarding can be resumed
+7. Verify backend Sentry only after `SENTRY_DSN` and release metadata are set, then disable any debug route used for verification.
+
+## Issue Status
+
+| Issue | Current state |
+| --- | --- |
+| #82 Stripe Connect return and refresh URL domain alignment | Code and documentation are ready; final Stripe Connect browser smoke remains open |
+| #83 EB environment variable drift audit | Names-only expected values are documented here; actual EB console comparison remains open |
+| #84 Backend production smoke proof | Still blocked until deployed main, final-domain DNS/env, and runtime smoke are available |

--- a/docs/ROOT_DOMAIN_CUTOVER_CHECKLIST.md
+++ b/docs/ROOT_DOMAIN_CUTOVER_CHECKLIST.md
@@ -29,6 +29,7 @@ This checklist is names-only and value-safe. It records human configuration work
 ## AWS Elastic Beanstalk
 
 - Env var names to reconcile: `FRONTEND_URL`, `CORS_ORIGINS`, `API_BASE_URL`, `COOKIE_DOMAIN`, `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL`, `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH`, `BILLING_PORTAL_RETURN_URL`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`.
+- Names-only EB drift audit: [EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md](EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md).
 - Do not automatically change `COOKIE_DOMAIN`; first confirm whether cookies are host-only or intentionally shared across `mosaicbizhub.com` subdomains.
 - Preserve HttpOnly auth cookies, Secure in production, SameSite behavior, credentialed requests, and explicit CORS origins.
 

--- a/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
+++ b/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
@@ -35,6 +35,16 @@ Unit tests: [`tests/connect/connect-urls.test.js`](../tests/connect/connect-urls
 
 **Note:** Production EB should use the apex marketplace origin. Use `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` only when a full override is intentionally required.
 
+Preferred launch configuration:
+
+```text
+FRONTEND_URL=https://mosaicbizhub.com
+CONNECT_RETURN_PATH=/partners/connect/return
+CONNECT_REFRESH_PATH=/partners/connect/refresh
+```
+
+Full URL overrides are valid for intentional QA or cutover windows, but they should not point at `https://app.mosaicbizhub.com` after apex launch except during a documented temporary rollback window.
+
 ---
 
 ## Runtime verification
@@ -66,6 +76,7 @@ Connect **code** aligns with frontend route expectations. No connect controller 
 2. `POST https://api.mosaicbizhub.com/api/connect/<businessId>/account-link` with Bearer token.
 3. Confirm 200 + Stripe onboarding URL (do not complete onboarding in production without approval).
 4. Verify EB `FRONTEND_URL` matches intended frontend host before relying on default URL builder.
+5. If `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` are set, verify they point to the intended apex or QA host and not an accidental legacy app default.
 
 ---
 

--- a/docs/TECHWARE_REGRESSION_RECONCILIATION.md
+++ b/docs/TECHWARE_REGRESSION_RECONCILIATION.md
@@ -63,7 +63,7 @@ History checks run before code edits:
 | 24 | Rejected applications cannot be resubmitted. | STALE_ALREADY_FIXED | `submitForReview` permits `rejected`. | `POST /api/vendor-onboarding/submit`. | Rejected resubmit tests. | No change. |
 | 25 | Admin approval sync failure. | PARTIALLY_CONFIRMED | `isApproved` sync exists; `isActive` remains separate. | Admin finalization and public marketplace eligibility. | Finalization and eligibility tests. | No change until lifecycle rule approved. |
 | 26 | Missing user metadata in login response. | STALE_ALREADY_FIXED | Shared serializer returns `mobile` and `isOtpVerified`. | `POST /api/user/login`, `GET /api/user/auth/check`. | Auth payload tests. | No change. |
-| 27 | Backend canonical frontend domain still points to `app.mosaicbizhub.com` after apex decision. | CONFIRMED_CURRENT_DEFECT | Current staging still has `utils/frontendUrl.js:1-4`, `utils/corsOrigins.js:1-4`, `tests/url/frontend-url.test.js:21-35`, and `docs/DOMAIN_MIGRATION_URL_INVENTORY.md:9-21` treating app as canonical and apex as disallowed/community. | Generated frontend URLs and default credentialed CORS origins. | Open PR `#130 fix/backend-root-domain-canonicalization -> staging` isolates this fix. Not bundled here to keep badge/listing recovery focused. | Separate P7 domain PR required before staging promotion. |
+| 27 | Backend canonical frontend domain still points to `app.mosaicbizhub.com` after apex decision. | RESOLVED_AFTER_REPORT | Current staging defaults generated frontend links to `https://mosaicbizhub.com`, keeps `app.mosaicbizhub.com` transition-only, keeps Vercel launch QA approved, and rejects `www`/API as frontend redirect targets. Stale app-domain env values no longer become the generated default. | Generated frontend URLs and default credentialed CORS origins. | `tests/url/frontend-url.test.js`, `tests/connect/connect-urls.test.js`, `tests/cors/cors-origins.test.js`. | Resolved by the root-domain correction and follow-up generated-link hardening. |
 
 ## Contradictions In The Report
 
@@ -92,7 +92,7 @@ Out of scope:
 - Product route aliases.
 - Food default price behavior.
 - Stripe Connect/payment/subscription/webhook changes.
-- Apex/root domain code changes already isolated in PR `#130`.
+- Apex/root domain code changes, now handled by the root-domain correction and generated-link hardening.
 - Main branch merge or production deploy.
 
 ## Ordered Queue Evidence
@@ -105,7 +105,7 @@ Out of scope:
 | Product counts and deletion | RUNTIME_EVIDENCE_REQUIRED | Product delete route is registered at `routes/productRoutes.js:127-135` and soft-deletes product plus variants in `controllers/productController.js:926-955`. Public/admin/category counts use `Product.countDocuments` or aggregation with `isDeleted:false`; quota usage is documented and tested in `utils/listingTierLimits.js:6-17`, `tests/vendor/listing-tier-limits.test.js:10-24`. No wrong consumer result was reproduced. |
 | Stale auth/onboarding claims | STALE_ALREADY_FIXED | OTP delivery tests, auth-check payload tests, rejected-resubmit tests, vendor finalize tests, and marketplace eligibility tests cover these without backend behavior changes. |
 | Food price ceiling | PRODUCT_DECISION_REQUIRED | `controllers/publicListing.js:593-604` keeps default `$0-$200`; `price=all` explicitly opts out. No approved source found proving no maximum is intended. |
-| Canonical domain audit | CONFIRMED_CURRENT_DEFECT, SEPARATE_PR | Apex is now contractually canonical, but staging still defaults to app. PR `#130` contains the isolated root-domain correction; this branch does not change CORS/cookie/domain behavior. |
+| Canonical domain audit | RESOLVED_AFTER_REPORT | Apex is now contractually canonical for generated backend links. `app.mosaicbizhub.com` remains only as a temporary transition origin for CORS/redirect preservation until apex auth/payment smoke passes. |
 
 ## Runtime Smoke Evidence
 

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -47,7 +47,7 @@ Set these in the Elastic Beanstalk environment configuration (or secret manager 
 | `PLATFORM_FEE_CENTS` | Order Connect fees |
 | `BILLING_PORTAL_RETURN_URL` | Billing portal return |
 | `CONNECT_RETURN_PATH` / `CONNECT_REFRESH_PATH` | Connect onboarding paths |
-| `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` | Optional full URL overrides |
+| `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` | Optional full URL overrides. Prefer `FRONTEND_URL` + path vars in production; use full overrides only for intentional QA/cutover windows. |
 
 Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-registration.md)
 
@@ -127,7 +127,7 @@ Note: Backend code does **not** read `STRIPE_PUBLIC_KEY` (frontend uses `NEXT_PU
 | `NEXT_PUBLIC_CLIENT_BASE_URL` | `https://mosaicbizhub.com` if still required as fallback |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Live publishable key |
 | `NEXT_PUBLIC_GOOGLE_MAPS_KEY` | Address autocomplete |
-| `JWT_SECRET` | Must match backend `JWT_SECRET` for middleware |
+| `JWT_SECRET` | Must match backend `JWT_SECRET` for the frontend Next proxy |
 
 See `mosaic-biz-frontend/.env.example` when present.
 

--- a/problem.txt
+++ b/problem.txt
@@ -49,5 +49,5 @@ app.use("trust proxy", 1);
 app.js
 
 stripeController.js
-    success_url: 'https://app.mosaicbizhub.com/partners',
-    cancel_url: 'https://app.mosaicbizhub.com/partners',
+    success_url: buildFrontendUrl("/partners"),
+    cancel_url: buildFrontendUrl("/partners"),

--- a/tests/connect/connect-urls.test.js
+++ b/tests/connect/connect-urls.test.js
@@ -20,6 +20,22 @@ test('getReturnAndRefreshUrls uses the apex frontend host and default Connect pa
   );
 });
 
+test('getReturnAndRefreshUrls ignores legacy app FRONTEND_URL for generated defaults', () => {
+  const urls = getReturnAndRefreshUrls(businessId, {
+    NODE_ENV: 'production',
+    FRONTEND_URL: 'https://app.mosaicbizhub.com',
+  });
+
+  assert.equal(
+    urls.returnUrl,
+    'https://mosaicbizhub.com/partners/connect/return?businessId=507f1f77bcf86cd799439011'
+  );
+  assert.equal(
+    urls.refreshUrl,
+    'https://mosaicbizhub.com/partners/connect/refresh?businessId=507f1f77bcf86cd799439011'
+  );
+});
+
 test('getReturnAndRefreshUrls honors full URL overrides', () => {
   const urls = getReturnAndRefreshUrls(businessId, {
     NODE_ENV: 'production',

--- a/tests/url/frontend-url.test.js
+++ b/tests/url/frontend-url.test.js
@@ -25,6 +25,17 @@ test('getFrontendBaseUrl uses the first approved configured frontend origin', ()
   );
 });
 
+test('getFrontendBaseUrl ignores the legacy app subdomain as a configured default', () => {
+  assert.equal(
+    getFrontendBaseUrl({
+      NODE_ENV: 'production',
+      FRONTEND_URL: 'https://app.mosaicbizhub.com',
+      APP_URL: 'https://app.mosaicbizhub.com',
+    }),
+    'https://mosaicbizhub.com'
+  );
+});
+
 test('getFrontendBaseUrl ignores www because it should redirect to apex', () => {
   assert.equal(
     getFrontendBaseUrl({
@@ -33,6 +44,16 @@ test('getFrontendBaseUrl ignores www because it should redirect to apex', () => 
       APP_URL: 'https://www.mosaicbizhub.com',
     }),
     'https://mosaicbizhub.com'
+  );
+});
+
+test('buildFrontendUrl falls back to apex when production env still points at legacy app', () => {
+  assert.equal(
+    buildFrontendUrl('/partners/connect/return?businessId=abc', {
+      NODE_ENV: 'production',
+      FRONTEND_URL: 'https://app.mosaicbizhub.com',
+    }),
+    'https://mosaicbizhub.com/partners/connect/return?businessId=abc'
   );
 });
 

--- a/utils/frontendUrl.js
+++ b/utils/frontendUrl.js
@@ -1,8 +1,14 @@
 const DEFAULT_FRONTEND_URL = 'https://mosaicbizhub.com';
+const LEGACY_FRONTEND_URL = 'https://app.mosaicbizhub.com';
+const LAUNCH_QA_FRONTEND_URL = 'https://mosaic-biz-frontend-launch.vercel.app';
 const APPROVED_FRONTEND_ORIGINS = [
-  'https://mosaicbizhub.com',
-  'https://app.mosaicbizhub.com',
-  'https://mosaic-biz-frontend-launch.vercel.app',
+  DEFAULT_FRONTEND_URL,
+  LEGACY_FRONTEND_URL,
+  LAUNCH_QA_FRONTEND_URL,
+];
+const GENERATED_FRONTEND_ORIGINS = [
+  DEFAULT_FRONTEND_URL,
+  LAUNCH_QA_FRONTEND_URL,
 ];
 const DEV_FRONTEND_ORIGINS = [
   'http://localhost:3000',
@@ -46,6 +52,16 @@ function getAllowedFrontendOrigins(env = process.env) {
   return [...new Set(origins)];
 }
 
+function getGeneratedFrontendOrigins(env = process.env) {
+  const origins = [...GENERATED_FRONTEND_ORIGINS];
+
+  if (!isProductionEnv(env)) {
+    origins.push(...DEV_FRONTEND_ORIGINS);
+  }
+
+  return [...new Set(origins)];
+}
+
 function getOrigin(value) {
   if (!value) return null;
 
@@ -57,6 +73,12 @@ function isAllowedFrontendOrigin(value, env = process.env) {
   const origin = getOrigin(value);
   if (!origin || DISALLOWED_FRONTEND_ORIGINS.has(origin)) return false;
   return getAllowedFrontendOrigins(env).includes(origin);
+}
+
+function isAllowedGeneratedFrontendOrigin(value, env = process.env) {
+  const origin = getOrigin(value);
+  if (!origin || DISALLOWED_FRONTEND_ORIGINS.has(origin)) return false;
+  return getGeneratedFrontendOrigins(env).includes(origin);
 }
 
 function toBaseUrlString(url) {
@@ -74,7 +96,7 @@ function toBaseUrlString(url) {
 function getFrontendBaseUrl(env = process.env) {
   for (const key of ENV_PRIORITY) {
     const parsed = parseAbsoluteUrl(env[key]);
-    if (parsed && isAllowedFrontendOrigin(parsed, env)) {
+    if (parsed && isAllowedGeneratedFrontendOrigin(parsed, env)) {
       return toBaseUrlString(parsed);
     }
   }
@@ -121,10 +143,15 @@ module.exports = {
   APPROVED_FRONTEND_ORIGINS,
   DEFAULT_FRONTEND_URL,
   DEV_FRONTEND_ORIGINS,
+  GENERATED_FRONTEND_ORIGINS,
+  LAUNCH_QA_FRONTEND_URL,
+  LEGACY_FRONTEND_URL,
   buildFrontendUrl,
   getAllowedFrontendOrigins,
   getFrontendBaseUrl,
+  getGeneratedFrontendOrigins,
   getFrontendLogoUrl,
+  isAllowedGeneratedFrontendOrigin,
   isAllowedFrontendOrigin,
   normalizeFrontendUrl,
   sanitizeFrontendRedirectUrl,

--- a/utils/invoiceHtml.js
+++ b/utils/invoiceHtml.js
@@ -62,7 +62,6 @@ async function invoiceHtmlForOrder({ order }) {
         const unitMajor = Number(it?.price || 0); // unit price captured at purchase (MAJOR)
         const lineMajor = unitMajor * qty;
         subtotalMajor += lineMajor;
-        console.log(subtotalMajor, unitMajor, qty, lineMajor)
         return { name, options, sku, qty, unitMajor, lineMajor };
     });
 

--- a/utils/uploadFile.js
+++ b/utils/uploadFile.js
@@ -11,13 +11,6 @@ const s3 = new S3Client({
 });
 
 exports.uploadFile = async (file, folder = "business") => {
-  console.log("Uploading file to S3", {
-    folder,
-    originalName: file?.originalname || null,
-    mimeType: file?.mimetype || null,
-    size: file?.size || null,
-  });
-  
   if (!file) throw new Error("No file provided");
 
   const fileName = `${folder}/${uuidv4()}-${file.originalname}`;


### PR DESCRIPTION
## Summary
- promote the current launch-hardening stack from `staging` to `main`
- includes canonical frontend link generation hardening and backend runtime debug-log cleanup
- keeps generated Stripe/OAuth/email return links aligned to the apex production domain while preserving transition-safe legacy origin handling

## Validation
- integration PR checks passed for #141 and #142
- latest local `npm run test:contract` passed: 20/20
- latest local `npm test` passed: 394/394
- latest GitHub CI Test and build checks passed on #142

## Cutover note
Merge when the production domain/env cutover is ready to ship from `main`.