### PR TITLE
[codex] Document EB env cutover expectations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@ MONGODB_URI=mongodb://localhost:27017/mbh
 FRONTEND_URL=http://localhost:3000
 
 # Comma-separated browser origins allowed for credentialed CORS (production).
-# The root domain is the community site and is not included by default.
-# CORS_ORIGINS=https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app
+# The apex domain is the canonical marketplace frontend. Keep app.mosaicbizhub.com
+# only as a temporary transition origin until final-domain auth/payment smoke passes.
+# CORS_ORIGINS=https://mosaicbizhub.com,https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app
 
 JWT_SECRET=replace-with-a-long-random-secret
 
@@ -54,8 +55,10 @@ CONNECT_RETURN_PATH=/partners/connect/return
 
 CONNECT_REFRESH_PATH=/partners/connect/refresh
 
+# Prefer FRONTEND_URL + CONNECT_RETURN_PATH in production. Use full URL overrides only for an intentional QA/cutover window.
 CONNECT_RETURN_URL=http://localhost:3000/partners/connect/return
 
+# Prefer FRONTEND_URL + CONNECT_REFRESH_PATH in production. Use full URL overrides only for an intentional QA/cutover window.
 CONNECT_REFRESH_URL=http://localhost:3000/partners/connect/refresh
 
 

--- a/docs/EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md
+++ b/docs/EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md
@@ -1,0 +1,87 @@
+# EB Env Drift Cutover Audit
+
+**Date:** 2026-06-26
+**Scope:** Names-only launch cutover evidence for backend issues #82 and #83.
+**Rule:** Do not paste secret values from EB, Vercel, Stripe, Sentry, or email providers into this document or issue comments.
+
+This audit documents the intended production environment shape after the canonical frontend correction:
+
+- `https://mosaicbizhub.com` is the canonical marketplace frontend.
+- `https://app.mosaicbizhub.com` is transition-only.
+- `https://www.mosaicbizhub.com` should redirect to apex and should not be a credentialed app origin by default.
+- `https://api.mosaicbizhub.com` remains the backend API host.
+
+## Code Status
+
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Generated backend frontend links | Ready for cutover | `utils/frontendUrl.js` defaults to apex and ignores stale `FRONTEND_URL=https://app.mosaicbizhub.com` for generated defaults |
+| Stripe Connect return/refresh builder | Ready for cutover | `tests/connect/connect-urls.test.js` covers apex defaults, safe overrides, and legacy app fallback rejection as default |
+| Credentialed CORS defaults | Ready for cutover | `tests/cors/cors-origins.test.js` covers apex, transition app, launch Vercel, and wildcard rejection |
+| Cookie domain guardrails | Ready for cutover | `tests/cookie/cookie-options.test.js` covers `.mosaicbizhub.com` and invalid-domain fallback |
+| Final-domain runtime proof | Not complete | Requires deployed main, DNS/env cutover, and browser smoke |
+
+## EB Variables To Verify
+
+| Variable | Launch expectation | Action if different |
+| --- | --- | --- |
+| `FRONTEND_URL` | `https://mosaicbizhub.com` | Change to apex, then deploy or restart EB |
+| `CORS_ORIGINS` | Explicit comma-separated allowlist including `https://mosaicbizhub.com` and approved temporary origins only | Add apex; remove `https://www.mosaicbizhub.com` unless intentionally tested; deploy or restart EB |
+| `API_BASE_URL` | `https://api.mosaicbizhub.com` | Correct before OAuth smoke |
+| `COOKIE_DOMAIN` | Usually `.mosaicbizhub.com`, unless final smoke chooses host-only cookies | Do not change blindly; verify browser cookie behavior first |
+| `COOKIE_SECURE` | `true` | Correct before final auth smoke |
+| `COOKIE_SAMESITE` | `none` for cross-subdomain browser auth | Correct before final auth smoke |
+| `CONNECT_RETURN_PATH` | `/partners/connect/return` | Correct before Stripe Connect smoke |
+| `CONNECT_REFRESH_PATH` | `/partners/connect/refresh` | Correct before Stripe Connect smoke |
+| `CONNECT_RETURN_URL` | Usually unset in production unless an intentional full override is needed | If set to legacy app, replace with apex or remove and use path-based builder |
+| `CONNECT_REFRESH_URL` | Usually unset in production unless an intentional full override is needed | If set to legacy app, replace with apex or remove and use path-based builder |
+| `BILLING_PORTAL_RETURN_URL` | Apex frontend return URL for billing flows | Replace legacy app values before billing smoke |
+| `SENTRY_DSN` | Set in EB only when backend monitoring is enabled | Do not paste value; verify event after deploy |
+| `SENTRY_ENVIRONMENT` | `production` | Correct before backend Sentry proof |
+| `SENTRY_RELEASE` | Deployed release identifier or commit-based release | Align with deployed artifact |
+
+## Stripe Connect URL Decision
+
+Preferred launch configuration:
+
+```text
+FRONTEND_URL=https://mosaicbizhub.com
+CONNECT_RETURN_PATH=/partners/connect/return
+CONNECT_REFRESH_PATH=/partners/connect/refresh
+```
+
+Use full URL overrides only when QA intentionally targets a non-default frontend origin:
+
+```text
+CONNECT_RETURN_URL=https://mosaicbizhub.com/partners/connect/return
+CONNECT_REFRESH_URL=https://mosaicbizhub.com/partners/connect/refresh
+```
+
+Do not use `https://app.mosaicbizhub.com` as the production Connect return/refresh default after apex cutover.
+
+## Required Human Verification
+
+1. Confirm the EB environment values above in AWS without copying secrets into GitHub.
+2. Apply EB env changes and redeploy or restart the environment.
+3. Confirm the deployed backend release identity matches the intended `main` SHA.
+4. Run backend smoke:
+
+```powershell
+./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+```
+
+5. Run a credentialed CORS preflight from `https://mosaicbizhub.com`.
+6. Run Stripe Connect onboarding from the final frontend and confirm:
+   - onboarding starts
+   - return route lands on `https://mosaicbizhub.com/partners/connect/return`
+   - refresh route lands on `https://mosaicbizhub.com/partners/connect/refresh`
+   - interrupted onboarding can be resumed
+7. Verify backend Sentry only after `SENTRY_DSN` and release metadata are set, then disable any debug route used for verification.
+
+## Issue Status
+
+| Issue | Current state |
+| --- | --- |
+| #82 Stripe Connect return and refresh URL domain alignment | Code and documentation are ready; final Stripe Connect browser smoke remains open |
+| #83 EB environment variable drift audit | Names-only expected values are documented here; actual EB console comparison remains open |
+| #84 Backend production smoke proof | Still blocked until deployed main, final-domain DNS/env, and runtime smoke are available |

--- a/docs/ROOT_DOMAIN_CUTOVER_CHECKLIST.md
+++ b/docs/ROOT_DOMAIN_CUTOVER_CHECKLIST.md
@@ -29,6 +29,7 @@ This checklist is names-only and value-safe. It records human configuration work
 ## AWS Elastic Beanstalk
 
 - Env var names to reconcile: `FRONTEND_URL`, `CORS_ORIGINS`, `API_BASE_URL`, `COOKIE_DOMAIN`, `CONNECT_RETURN_URL`, `CONNECT_REFRESH_URL`, `CONNECT_RETURN_PATH`, `CONNECT_REFRESH_PATH`, `BILLING_PORTAL_RETURN_URL`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`.
+- Names-only EB drift audit: [EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md](EB_ENV_DRIFT_CUTOVER_AUDIT_2026_06_26.md).
 - Do not automatically change `COOKIE_DOMAIN`; first confirm whether cookies are host-only or intentionally shared across `mosaicbizhub.com` subdomains.
 - Preserve HttpOnly auth cookies, Secure in production, SameSite behavior, credentialed requests, and explicit CORS origins.
 

--- a/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
+++ b/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
@@ -35,6 +35,16 @@ Unit tests: [`tests/connect/connect-urls.test.js`](../tests/connect/connect-urls
 
 **Note:** Production EB should use the apex marketplace origin. Use `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` only when a full override is intentionally required.
 
+Preferred launch configuration:
+
+```text
+FRONTEND_URL=https://mosaicbizhub.com
+CONNECT_RETURN_PATH=/partners/connect/return
+CONNECT_REFRESH_PATH=/partners/connect/refresh
+```
+
+Full URL overrides are valid for intentional QA or cutover windows, but they should not point at `https://app.mosaicbizhub.com` after apex launch except during a documented temporary rollback window.
+
 ---
 
 ## Runtime verification
@@ -66,6 +76,7 @@ Connect **code** aligns with frontend route expectations. No connect controller 
 2. `POST https://api.mosaicbizhub.com/api/connect/<businessId>/account-link` with Bearer token.
 3. Confirm 200 + Stripe onboarding URL (do not complete onboarding in production without approval).
 4. Verify EB `FRONTEND_URL` matches intended frontend host before relying on default URL builder.
+5. If `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` are set, verify they point to the intended apex or QA host and not an accidental legacy app default.
 
 ---
 

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -47,7 +47,7 @@ Set these in the Elastic Beanstalk environment configuration (or secret manager 
 | `PLATFORM_FEE_CENTS` | Order Connect fees |
 | `BILLING_PORTAL_RETURN_URL` | Billing portal return |
 | `CONNECT_RETURN_PATH` / `CONNECT_REFRESH_PATH` | Connect onboarding paths |
-| `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` | Optional full URL overrides |
+| `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` | Optional full URL overrides. Prefer `FRONTEND_URL` + path vars in production; use full overrides only for intentional QA/cutover windows. |
 
 Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-registration.md)
 
@@ -127,7 +127,7 @@ Note: Backend code does **not** read `STRIPE_PUBLIC_KEY` (frontend uses `NEXT_PU
 | `NEXT_PUBLIC_CLIENT_BASE_URL` | `https://mosaicbizhub.com` if still required as fallback |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Live publishable key |
 | `NEXT_PUBLIC_GOOGLE_MAPS_KEY` | Address autocomplete |
-| `JWT_SECRET` | Must match backend `JWT_SECRET` for middleware |
+| `JWT_SECRET` | Must match backend `JWT_SECRET` for the frontend Next proxy |
 
 See `mosaic-biz-frontend/.env.example` when present.
 


### PR DESCRIPTION
Backend docs-only launch cutover evidence batch. Adds a names-only EB env drift audit for issues #82/#83, updates Stripe Connect domain guidance to prefer apex FRONTEND_URL plus path vars, and aligns env docs with the frontend Next proxy migration. Validation: npm test passed 394/394; npm run test:contract passed 20/20 earlier in this batch; git diff --check passed.