### PR TITLE
[codex] Allow launch frontend CORS origins

### DIFF
--- a/scripts/smoke-backend.ps1
+++ b/scripts/smoke-backend.ps1
@@ -130,8 +130,12 @@ foreach ($p in $paths) {
 
 $corsOrigins = @(
     'https://mosaicbizhub.com',
+    'https://www.mosaicbizhub.com',
     'https://app.mosaicbizhub.com',
-    'https://mosaic-biz-frontend-launch.vercel.app'
+    'https://mosaic-biz-frontend-launch.vercel.app',
+    'https://mosaic-biz-frontend-launch-digital-builders.vercel.app',
+    'https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app',
+    'https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app'
 )
 if ($env:FRONTEND_ORIGIN) {
     $corsOrigins = @($env:FRONTEND_ORIGIN)
@@ -159,11 +163,7 @@ foreach ($corsOrigin in $corsOrigins) {
 }
 
 $code = Get-StatusCode "$Base/api/admin/categories"
-if ($code -eq 200) {
-    Write-SmokePass "NOTE GET /api/admin/categories unauth ($code) - public exposure documented"
-} else {
-    Write-SmokeFail "NOTE GET /api/admin/categories $code - expected 200 on current main"
-}
+if ($code -eq 401) { Write-SmokePass "P3.2 GET /api/admin/categories unauth ($code)" } else { Write-SmokeFail "P3.2 GET /api/admin/categories $code - expected 401" }
 
 $code = Get-StatusCode "$Base/admin/api/products/test"
 if ($code -eq 200) {

--- a/scripts/smoke-backend.sh
+++ b/scripts/smoke-backend.sh
@@ -89,8 +89,12 @@ done
 
 CORS_ORIGINS=(
   "https://mosaicbizhub.com"
+  "https://www.mosaicbizhub.com"
   "https://app.mosaicbizhub.com"
   "https://mosaic-biz-frontend-launch.vercel.app"
+  "https://mosaic-biz-frontend-launch-digital-builders.vercel.app"
+  "https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app"
+  "https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app"
 )
 if [ -n "${FRONTEND_ORIGIN:-}" ]; then
   CORS_ORIGINS=("$FRONTEND_ORIGIN")
@@ -108,10 +112,10 @@ for CORS_ORIGIN in "${CORS_ORIGINS[@]}"; do
 done
 
 code=$(http_code "$BASE/api/admin/categories")
-if [ "$code" = "200" ]; then
-  pass "NOTE GET /api/admin/categories unauth ($code) — public exposure documented"
+if [ "$code" = "401" ]; then
+  pass "P3.2 GET /api/admin/categories unauth ($code)"
 else
-  fail "NOTE GET /api/admin/categories ($code, expected 200 on current main)"
+  fail "P3.2 GET /api/admin/categories ($code, expected 401)"
 fi
 
 code=$(http_code "$BASE/admin/api/products/test")

--- a/tests/cors/cors-origins.test.js
+++ b/tests/cors/cors-origins.test.js
@@ -53,18 +53,22 @@ test('parseCorsOrigins trims and filters empty entries', () => {
   }
 });
 
-test('getAllowedOrigins uses CORS_ORIGINS when set', () => {
+test('getAllowedOrigins merges CORS_ORIGINS with approved launch origins when set', () => {
   const { mod, cleanup } = loadCorsOrigins({
     NODE_ENV: 'production',
-    CORS_ORIGINS: 'https://mosaicbizhub.com,https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app',
+    CORS_ORIGINS: 'https://custom-preview.example,https://mosaicbizhub.com',
   });
   try {
     const origins = mod.getAllowedOrigins();
+    assert.ok(origins.includes('https://custom-preview.example'));
     assert.ok(origins.includes('https://mosaicbizhub.com'));
+    assert.ok(origins.includes('https://www.mosaicbizhub.com'));
     assert.ok(origins.includes('https://mosaic-biz-frontend-launch.vercel.app'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-digital-builders.vercel.app'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app'));
     assert.ok(origins.includes('https://app.mosaicbizhub.com'));
-    assert.ok(!origins.includes('https://www.mosaicbizhub.com'));
-    assert.equal(origins.length, 3);
+    assert.equal(origins.length, mod.DEFAULT_CREDENTIAL_ORIGINS.length + 1);
   } finally {
     cleanup();
   }
@@ -76,7 +80,7 @@ test('getAllowedOrigins dedupes CORS_ORIGINS entries', () => {
     CORS_ORIGINS: 'https://mosaicbizhub.com,https://mosaicbizhub.com,*',
   });
   try {
-    assert.deepEqual(mod.getAllowedOrigins(), ['https://mosaicbizhub.com']);
+    assert.deepEqual(mod.getAllowedOrigins(), mod.DEFAULT_CREDENTIAL_ORIGINS);
   } finally {
     cleanup();
   }
@@ -90,9 +94,12 @@ test('getAllowedOrigins falls back to FRONTEND_URL and credentialed production o
   try {
     const origins = mod.getAllowedOrigins();
     assert.ok(origins.includes('https://mosaicbizhub.com'));
+    assert.ok(origins.includes('https://www.mosaicbizhub.com'));
     assert.ok(origins.includes('https://app.mosaicbizhub.com'));
     assert.ok(origins.includes('https://mosaic-biz-frontend-launch.vercel.app'));
-    assert.ok(!origins.includes('https://www.mosaicbizhub.com'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-digital-builders.vercel.app'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app'));
+    assert.ok(origins.includes('https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app'));
     for (const origin of mod.DEFAULT_CREDENTIAL_ORIGINS) {
       assert.ok(origins.includes(origin));
     }

--- a/utils/corsOrigins.js
+++ b/utils/corsOrigins.js
@@ -1,7 +1,11 @@
 const DEFAULT_CREDENTIAL_ORIGINS = [
   'https://mosaicbizhub.com',
+  'https://www.mosaicbizhub.com',
   'https://app.mosaicbizhub.com',
   'https://mosaic-biz-frontend-launch.vercel.app',
+  'https://mosaic-biz-frontend-launch-digital-builders.vercel.app',
+  'https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app',
+  'https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app',
 ];
 
 const DEV_ORIGINS = [
@@ -26,7 +30,10 @@ function getAllowedOrigins() {
   let origins;
 
   if (process.env.CORS_ORIGINS) {
-    origins = parseCorsOrigins(process.env.CORS_ORIGINS);
+    origins = [
+      ...parseCorsOrigins(process.env.CORS_ORIGINS),
+      ...DEFAULT_CREDENTIAL_ORIGINS,
+    ];
   } else {
     origins = [
       process.env.FRONTEND_URL,


### PR DESCRIPTION
## Summary
- Allows the approved Mosaic launch frontend origins even when `CORS_ORIGINS` is already configured.
- Adds `www.mosaicbizhub.com` and the actual Vercel project aliases used during launch testing.
- Updates backend smoke scripts so secured unauthenticated `GET /api/admin/categories` is a pass with 401 instead of a stale public-route expectation.

## Why
Production smoke showed `https://mosaicbizhub.com` is allowed, but `www.mosaicbizhub.com` and the current Vercel aliases returned CORS 500s. That blocks frontend testing before DNS is fully pointed at Vercel.

## Validation
- `node --test tests/cors/cors-origins.test.js tests/cors/cors-login-preflight.test.js`
- normalized `bash -n scripts/smoke-backend.sh`
- PowerShell smoke script parsed successfully
- `npm test` � 394 pass, 0 fail
- `npm run test:contract` � 20 pass, 0 fail
- Earlier in this verification pass: `npm run test:integration` � 49 pass, 0 fail
- Current production public smoke before this deploy: 25 pass, 0 fail, 2 skipped, 5 blocked by missing smoke tokens after local smoke-script fix

## Notes
After this reaches production, rerun `./scripts/smoke-backend.ps1 -ApiBaseUrl https://api.mosaicbizhub.com`; the expanded CORS origin checks should pass against the Vercel aliases and `www`.
