### PR TITLE
[codex] Promote backend release identity fix to production

### DIFF
--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -151,10 +151,14 @@ jobs:
       - name: Post-deploy CORS probe
         env:
           LAUNCH_ORIGIN: https://mosaic-biz-frontend-launch.vercel.app
+          VERCEL_PRODUCTION_ORIGIN: https://mosaic-biz-frontend-launch-digital-builders.vercel.app
+          VERCEL_MAIN_ORIGIN: https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app
+          VERCEL_DEVELOP_ORIGIN: https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app
           APEX_ORIGIN: https://mosaicbizhub.com
+          WWW_ORIGIN: https://www.mosaicbizhub.com
           LEGACY_APP_ORIGIN: https://app.mosaicbizhub.com
         run: |
-          for origin in "$APEX_ORIGIN" "$LEGACY_APP_ORIGIN" "$LAUNCH_ORIGIN"; do
+          for origin in "$APEX_ORIGIN" "$WWW_ORIGIN" "$LEGACY_APP_ORIGIN" "$LAUNCH_ORIGIN" "$VERCEL_PRODUCTION_ORIGIN" "$VERCEL_MAIN_ORIGIN" "$VERCEL_DEVELOP_ORIGIN"; do
             echo "CORS OPTIONS for Origin: $origin"
             headers=$(curl -s -D - -o /dev/null -X OPTIONS \
               -H "Origin: $origin" \

--- a/docs/backend/BACKEND_RELEASE_IDENTITY.md
+++ b/docs/backend/BACKEND_RELEASE_IDENTITY.md
@@ -31,7 +31,7 @@ Tie the running API, Git commit, Elastic Beanstalk version label, smoke proof, r
 - `SENTRY_RELEASE=mosaic-<deployed-git-sha>`
 - `SENTRY_ENVIRONMENT=production`
 
-Deploy workflow already publishes EB version label `mosaic-${{ github.sha }}`. Align the four release variables to that label after each deploy.
+The production deploy workflow packages `release-manifest.json` with the Git SHA, environment, and EB version label. That packaged manifest is the canonical runtime identity for deployed builds and intentionally overrides stale EB release variables. EB release variables are still useful as fallbacks for manually deployed artifacts or local smoke runs.
 
 ---
 
@@ -83,8 +83,10 @@ When release variables are unset locally, `commit` and `deploymentVersion` fall 
 
 Configured in [`instrument.js`](../../instrument.js) via [`utils/releaseIdentity.js`](../../utils/releaseIdentity.js):
 
-- `release` → `SENTRY_RELEASE` or deployment label
-- `environment` → `RELEASE_ENVIRONMENT` → `SENTRY_ENVIRONMENT` → `NODE_ENV`
+For packaged deployments, the release manifest takes precedence before release-related environment variable fallbacks.
+
+- `release` -> packaged deployment label, then `SENTRY_RELEASE` / deployment label fallback
+- `environment` -> packaged environment, then `RELEASE_ENVIRONMENT` -> `SENTRY_ENVIRONMENT` -> `NODE_ENV`
 - Tags: `deployment_version`, `commit_sha`, `environment`
 - HTTP 5xx capture adds the same release tags
 
@@ -115,7 +117,7 @@ API_BASE_URL=http://127.0.0.1:3001 npm run smoke:backend
 ## Rollback notes
 
 1. Roll back EB to prior version label (e.g. `mosaic-<previous-sha>`).
-2. Update **all four** release variables to the rolled-back SHA/label.
+2. Confirm the rolled-back EB application version includes the matching packaged release manifest. If using a manual artifact without a manifest, update all four release variables to the rolled-back SHA/label.
 3. Confirm `/api/health` → `release.deploymentVersion` matches the active EB label.
 4. Confirm Sentry events group under the rolled-back `release` string.
 

--- a/tests/release/releaseIdentity.test.js
+++ b/tests/release/releaseIdentity.test.js
@@ -77,7 +77,7 @@ test('getSentryRelease falls back to deployment label when SENTRY_RELEASE unset'
   );
 });
 
-test('getPublicReleaseInfo prefers packaged manifest over stale Sentry release env', () => {
+test('getPublicReleaseInfo prefers packaged manifest over stale release env vars', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mosaic-release-'));
   const manifestPath = path.join(tempDir, 'release-manifest.json');
 
@@ -94,16 +94,20 @@ test('getPublicReleaseInfo prefers packaged manifest over stale Sentry release e
     withReleaseIdentity(
       {
         RELEASE_MANIFEST_PATH: manifestPath,
+        RELEASE_COMMIT_SHA: 'badcafe1234567890abcdef1234567890abcdef1',
+        RELEASE_ENVIRONMENT: 'staging',
+        DEPLOYMENT_VERSION_LABEL: 'mosaic-badcafe1234567890abcdef1234567890abcdef1',
         SENTRY_RELEASE: 'mosaic-deadbee1234567890abcdef1234567890abcdef1',
         SENTRY_ENVIRONMENT: 'staging',
       },
-      ({ getPublicReleaseInfo, getSentryTags }) => {
+      ({ getPublicReleaseInfo, getSentryRelease, getSentryTags }) => {
         const info = getPublicReleaseInfo();
         assert.deepEqual(info, {
           commit: 'feedbee',
           environment: 'production',
           deploymentVersion: 'mosaic-feedbee1234567890abcdef1234567890abcdef1',
         });
+        assert.equal(getSentryRelease(), 'mosaic-feedbee1234567890abcdef1234567890abcdef1');
         assert.deepEqual(getSentryTags(), {
           deployment_version: 'mosaic-feedbee1234567890abcdef1234567890abcdef1',
           commit_sha: 'feedbee',

--- a/utils/releaseIdentity.js
+++ b/utils/releaseIdentity.js
@@ -50,9 +50,9 @@ function getReleaseCommitSha() {
   const manifest = readReleaseManifest();
 
   return (
-    sanitizeCommitSha(process.env.RELEASE_COMMIT_SHA)
-    || sanitizeCommitSha(manifest.commit)
+    sanitizeCommitSha(manifest.commit)
     || extractCommitFromVersionLabel(manifest.deploymentVersion)
+    || sanitizeCommitSha(process.env.RELEASE_COMMIT_SHA)
     || extractCommitFromVersionLabel(process.env.DEPLOYMENT_VERSION_LABEL)
     || extractCommitFromVersionLabel(process.env.SENTRY_RELEASE)
     || 'unknown'
@@ -68,8 +68,8 @@ function getReleaseEnvironment() {
   const manifest = readReleaseManifest();
 
   return (
-    normalizeOptionalString(process.env.RELEASE_ENVIRONMENT)
-    || normalizeOptionalString(manifest.environment)
+    normalizeOptionalString(manifest.environment)
+    || normalizeOptionalString(process.env.RELEASE_ENVIRONMENT)
     || normalizeOptionalString(process.env.SENTRY_ENVIRONMENT)
     || normalizeOptionalString(process.env.NODE_ENV)
     || 'development'
@@ -103,10 +103,17 @@ function getDeploymentVersionLabel() {
 
 function getSentryRelease() {
   const sentryRelease = normalizeOptionalString(process.env.SENTRY_RELEASE);
+  const deploymentLabel = getDeploymentVersionLabel();
+
+  if (deploymentLabel !== 'mosaic-unknown') {
+    return deploymentLabel;
+  }
+
   if (sentryRelease && SAFE_LABEL_PATTERN.test(sentryRelease)) {
     return sentryRelease;
   }
-  return getDeploymentVersionLabel();
+
+  return deploymentLabel;
 }
 
 function getPublicReleaseInfo() {


### PR DESCRIPTION
## Summary
- promote the backend release-identity fix merged in #147
- ensures production deploys read the packaged release manifest before stale EB release env vars
- keeps expanded launch-domain CORS verification in the production deploy workflow

## Validation
- PR #147 checks passed
- local `npm test` passed: 394/394
- local `npm run test:contract` passed: 20/20
- local `npm run test:integration` passed: 49/49