### PR TITLE
Align production CORS deploy probe with domain policy

### DIFF
--- a/.github/workflows/deploy-eb-production.yml
+++ b/.github/workflows/deploy-eb-production.yml
@@ -155,10 +155,9 @@ jobs:
           VERCEL_MAIN_ORIGIN: https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app
           VERCEL_DEVELOP_ORIGIN: https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app
           APEX_ORIGIN: https://mosaicbizhub.com
-          WWW_ORIGIN: https://www.mosaicbizhub.com
           LEGACY_APP_ORIGIN: https://app.mosaicbizhub.com
         run: |
-          for origin in "$APEX_ORIGIN" "$WWW_ORIGIN" "$LEGACY_APP_ORIGIN" "$LAUNCH_ORIGIN" "$VERCEL_PRODUCTION_ORIGIN" "$VERCEL_MAIN_ORIGIN" "$VERCEL_DEVELOP_ORIGIN"; do
+          for origin in "$APEX_ORIGIN" "$LEGACY_APP_ORIGIN" "$LAUNCH_ORIGIN" "$VERCEL_PRODUCTION_ORIGIN" "$VERCEL_MAIN_ORIGIN" "$VERCEL_DEVELOP_ORIGIN"; do
             echo "CORS OPTIONS for Origin: $origin"
             headers=$(curl -s -D - -o /dev/null -X OPTIONS \
               -H "Origin: $origin" \

--- a/docs/BACKEND_EB_DEPLOY_RUNBOOK.md
+++ b/docs/BACKEND_EB_DEPLOY_RUNBOOK.md
@@ -11,17 +11,17 @@ No secrets in this document.
 
 ## Auto-deploy status
 
-Push-to-`main` deploy is **disabled**. The workflow triggers **only** on `workflow_dispatch`:
+Push-to-`main` deploy is **enabled**. The workflow triggers on merges/pushes to `main` and can also be run manually with `workflow_dispatch`:
 
 ```yaml
 on:
   workflow_dispatch:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 ```
 
-**Every merge to `main` requires a manual deploy** until push deploy is re-enabled.
+Agents should not manually trigger production deploys unless explicitly acting as the release owner. Normal staging-to-main PR merges deploy automatically.
 
 ---
 
@@ -48,14 +48,14 @@ Or: GitHub → Actions → **Deploy to Elastic Beanstalk** → Run workflow → 
 
 ### 3. Workflow steps (automated)
 
-1. `npm ci` + `npm test` (196 tests)
+1. `npm ci` + `npm test`
 2. Zip deploy bundle (excludes `tests/`, `docs/`, `.github/`)
 3. Deploy to EB version label `mosaic-<sha>`
-4. Post-deploy probes: `/`, `/api/users/auth/check` (401), `/api/health`, `/api/ready`, CORS for apex, transition app, and launch QA origins
+4. Post-deploy probes: `/`, `/api/users/auth/check` (401), `/api/health`, `/api/ready`, release identity, and CORS for the approved credentialed browser origins
 
 ### 4. Post-deploy manual verification
 
-GHA CORS probe checks the approved browser origins. After deploy, verify the apex, transition app, and launch QA origins:
+GHA CORS probe checks the approved browser origins. After deploy, verify the apex, transition app, and launch QA origins. `https://www.mosaicbizhub.com` is redirect-only and should not be a credentialed API origin.
 
 ```powershell
 $origins = @(
@@ -141,10 +141,10 @@ Full Sentry doc: [`docs/SENTRY_EB_DEPLOY_VERIFICATION.md`](SENTRY_EB_DEPLOY_VERI
 
 | Symptom | Likely cause | Action |
 |---------|--------------|--------|
-| `/api/health` 404 after merge | Deploy not run (push disabled) | Manual `workflow_dispatch` |
+| `/api/health` 404 after merge | Deploy did not run or did not finish | Check the merge-triggered deploy run; use manual `workflow_dispatch` only for release-owner redeploys |
 | Apex CORS 500 | `CORS_ORIGINS` unset or missing apex | Set EB env; apply config |
 | CORS 500 after env change | Instances not restarted | Apply config; wait for Green |
-| Deploy workflow fails CORS | Wrong origin in probe | Check EB `CORS_ORIGINS`; manual approved-origin probe |
+| Deploy workflow fails CORS | EB `CORS_ORIGINS` missing an approved browser origin or the probe drifted from policy | Check EB `CORS_ORIGINS`; manual approved-origin probe; keep `www` redirect-only |
 | Auth smoke BLOCKED | No test tokens | See [`docs/SMOKE_TEST_TOKENS.md`](SMOKE_TEST_TOKENS.md) |
 
 ---

--- a/tests/cors/deploy-cors-probe.test.js
+++ b/tests/cors/deploy-cors-probe.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const workflowPath = path.resolve(__dirname, '../../.github/workflows/deploy-eb-production.yml');
+
+test('production deploy CORS probe matches credentialed browser origins', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+  assert.ok(workflow.includes('APEX_ORIGIN: https://mosaicbizhub.com'));
+  assert.ok(workflow.includes('LEGACY_APP_ORIGIN: https://app.mosaicbizhub.com'));
+  assert.ok(workflow.includes('LAUNCH_ORIGIN: https://mosaic-biz-frontend-launch.vercel.app'));
+  assert.ok(workflow.includes('VERCEL_PRODUCTION_ORIGIN: https://mosaic-biz-frontend-launch-digital-builders.vercel.app'));
+  assert.ok(workflow.includes('VERCEL_MAIN_ORIGIN: https://mosaic-biz-frontend-launch-git-main-digital-builders.vercel.app'));
+  assert.ok(workflow.includes('VERCEL_DEVELOP_ORIGIN: https://mosaic-biz-frontend-launch-git-develop-digital-builders.vercel.app'));
+
+  assert.equal(workflow.includes('WWW_ORIGIN'), false);
+  assert.equal(workflow.includes('https://www.mosaicbizhub.com'), false);
+});


### PR DESCRIPTION
## Summary
- remove redirect-only www origin from the production EB CORS deploy probe
- document that push-to-main auto-deploy is enabled and www is redirect-only
- add a static test guard so the deploy probe stays aligned with credentialed CORS policy

## Validation
- npm test