### PR TITLE
Consolidate backend launch documentation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -26,7 +26,8 @@ This document defines the backend deployment flow, rollback approach, and produc
 | EB hostname | `mosaic-backend.us-east-1.elasticbeanstalk.com` |
 | Canonical HTTPS API | `https://api.mosaicbizhub.com` |
 | Frontend (canonical) | `https://mosaicbizhub.com` |
-| Frontend (transition) | `https://app.mosaicbizhub.com` |
+| Frontend (transition / historical) | `https://app.mosaicbizhub.com` |
+| Frontend alias | `https://www.mosaicbizhub.com` should be treated as an apex alias/redirect target, not a credentialed API origin |
 
 Use **`https://api.mosaicbizhub.com`** for smoke tests and Stripe webhook URLs. Avoid HTTPS on the raw EB hostname (TLS cert CN mismatch).
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm run dev
 | `npm install` | Install project dependencies |
 | `npm run dev` | Start the API with `nodemon` |
 | `npm start` | Start the API with `node index.js` |
-| `npm test` | Run automated tests (`node --test tests/**/*.test.js`) — see [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) and [docs/MVP_BACKEND_PROGRAM_STATUS.md](docs/MVP_BACKEND_PROGRAM_STATUS.md) for current count |
+| `npm test` | Run automated tests (`node --test tests/**/*.test.js`) — see [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) for coverage and [docs/MVP_BACKEND_PROGRAM_STATUS.md](docs/MVP_BACKEND_PROGRAM_STATUS.md) for release posture |
 | `./scripts/smoke-backend.ps1` | Post-deploy smoke (PowerShell) — public P0/P1 checks; optional auth with `SMOKE_TEST_*` env vars |
 | `./scripts/smoke-backend.sh` | Same smoke helper for bash/Linux/macOS |
 | `npm run smoke:backend` | Cross-platform wrapper (runs `.ps1` on Windows, `.sh` elsewhere) |
@@ -113,13 +113,16 @@ Full matrix: [docs/BACKEND_FULL_SMOKE_PROOF_PACK.md](docs/BACKEND_FULL_SMOKE_PRO
 
 **Documentation home:** [docs/README.md](docs/README.md) — full index, read-first guides, and maintenance rules.
 
-**MVP sprint status:** [docs/MVP_BACKEND_PROGRAM_STATUS.md](docs/MVP_BACKEND_PROGRAM_STATUS.md) — production deploy, open PRs, issue #26–#35 roadmap.
+**Backend program status:** [docs/MVP_BACKEND_PROGRAM_STATUS.md](docs/MVP_BACKEND_PROGRAM_STATUS.md) — current production release, open backend work, and domain/CORS posture.
+
+**Documentation consolidation:** [docs/DOCUMENTATION_CONSOLIDATION_2026_06_28.md](docs/DOCUMENTATION_CONSOLIDATION_2026_06_28.md) — current vs historical docs map.
 
 Key entry points:
 
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — backend map for contributors and LLMs
 - [docs/API_SURFACE.md](docs/API_SURFACE.md) — HTTP route map, auth boundaries, smoke notes
 - [docs/PRODUCTION_RUNBOOK.md](docs/PRODUCTION_RUNBOOK.md) — production deploy, smoke, rollback, sign-off
+- [docs/DOMAIN_MIGRATION_URL_INVENTORY.md](docs/DOMAIN_MIGRATION_URL_INVENTORY.md) — canonical, alias, transition, preview, and API origin policy
 - [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) — automated tests vs manual smoke mapping
 - [docs/DECISION_REGISTER.md](docs/DECISION_REGISTER.md) — MVP decisions, deferrals, and launch assumptions
 - [SETUP.md](SETUP.md) · [STAGING.md](STAGING.md) · [DEPLOYMENT.md](DEPLOYMENT.md)

--- a/docs/BACKEND_ROADMAP_ISSUES.md
+++ b/docs/BACKEND_ROADMAP_ISSUES.md
@@ -1,5 +1,7 @@
 # Backend Roadmap Issues Plan
 
+> Historical roadmap context. This file preserves the 2026-06-18 issue planning snapshot and may reference old PRs, SHAs, or "prod verify pending" states. For current backend production posture and open work, start with [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) and verify live GitHub issues before acting.
+
 **Branch:** `main` @ `fbe3aac` (PR #78 merged)  
 **Date:** 2026-06-18 (Batch 3 audit update)  
 **Purpose:** GitHub-ready issue backlog grouped by priority lane. Maps to existing open issues where possible — do not duplicate filing without review.

--- a/docs/DOCUMENTATION_CONSOLIDATION_2026_06_28.md
+++ b/docs/DOCUMENTATION_CONSOLIDATION_2026_06_28.md
@@ -1,0 +1,53 @@
+# Backend Documentation Consolidation - 2026-06-28
+
+**Purpose:** record what is current, what is historical, and what changed during the documentation drift cleanup.
+
+---
+
+## Current Truth
+
+| Area | Current source |
+| --- | --- |
+| Status | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) |
+| Docs index | [README.md](README.md) |
+| Platform behavior | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md) |
+| Deployment | [BACKEND_EB_DEPLOY_RUNBOOK.md](BACKEND_EB_DEPLOY_RUNBOOK.md), [../DEPLOYMENT.md](../DEPLOYMENT.md) |
+| Route/API contract | [API_SURFACE.md](API_SURFACE.md), [contracts/BACKEND_ROUTE_MANIFEST.md](contracts/BACKEND_ROUTE_MANIFEST.md) |
+
+---
+
+## Consolidation Decisions
+
+| Drift found | Decision |
+| --- | --- |
+| `MVP_BACKEND_PROGRAM_STATUS.md` still described June 18 sprint state | Replaced it with the 2026-06-28 production state. |
+| Older proof packs contain old production SHAs and app-domain references | Keep as evidence only; current status lives in the program status hub. |
+| Frontend backend-coordination issues were parked in frontend repo | Moved remaining backend work into backend issues #151-#155. |
+| Apex/domain docs mixed current and pre-cutover language | Current policy is now summarized in the status hub and docs index. |
+| `www.mosaicbizhub.com` policy was easy to overclaim | Documented as alias/redirect target, not a credentialed API origin. |
+
+---
+
+## Still Current And Useful
+
+- [API_SURFACE.md](API_SURFACE.md)
+- [AUTH_FLOW.md](AUTH_FLOW.md)
+- [BACKEND_EB_DEPLOY_RUNBOOK.md](BACKEND_EB_DEPLOY_RUNBOOK.md)
+- [BACKEND_FRONTEND_ROUTE_CONTRACT.md](BACKEND_FRONTEND_ROUTE_CONTRACT.md)
+- [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md)
+- [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md)
+- [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md)
+- [TEST_MATRIX.md](TEST_MATRIX.md)
+- [contracts/BACKEND_ROUTE_MANIFEST.md](contracts/BACKEND_ROUTE_MANIFEST.md)
+- [qa/FRESH_ACCOUNT_E2E_PLAN.md](qa/FRESH_ACCOUNT_E2E_PLAN.md)
+
+---
+
+## Historical Evidence Only
+
+- Old batch smoke packs and launch blocker audits.
+- MVP sprint issue matrix sections that predate PR #149 and PR #150.
+- Deployment proofs that name `app.mosaicbizhub.com` as the production frontend.
+- Dated evidence docs showing blocked tiers because credentials were absent in that session.
+
+Historical docs should not be deleted because they preserve audit trail. When they conflict with current code or runtime proof, trust [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md), current runtime evidence, and the code.

--- a/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
+++ b/docs/DOMAIN_MIGRATION_URL_INVENTORY.md
@@ -1,29 +1,29 @@
 # Domain Migration URL Inventory
 
-Updated: 2026-06-24
+Updated: 2026-06-28
 
 ## Current Architecture Truth
 
-The prior `app.mosaicbizhub.com` canonical-domain plan is superseded. Do not promote `staging -> main` until this correction is integrated with the frontend correction and external cutover verification is complete.
+The prior `app.mosaicbizhub.com` canonical-domain plan is superseded. The apex-domain correction has been integrated and promoted; current production generated links, redirects, and credentialed CORS should treat `https://mosaicbizhub.com` as canonical. See [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) for the current production release and soft-launch mode.
 
 | URL | Role | Backend Policy |
 | --- | --- | --- |
 | `https://mosaicbizhub.com` | Canonical production marketplace frontend | Primary frontend origin for generated links, redirects, and credentialed CORS |
-| `https://www.mosaicbizhub.com` | Alias for the marketplace | Should redirect to apex; not a default credentialed app origin |
-| `https://app.mosaicbizhub.com` | Temporary transition / legacy app origin | Temporarily approved for safe cutover; remove after apex auth/payment smoke passes and redirect strategy is approved |
-| `https://mosaic-biz-frontend-launch.vercel.app` | Temporary QA / preview origin | Approved QA origin |
+| `https://www.mosaicbizhub.com` | Alias/redirect target for the marketplace | Not a default credentialed app origin |
+| `https://app.mosaicbizhub.com` | Transition / historical app origin | Keep only for documented rollback or compatibility checks |
+| `https://mosaic-biz-frontend-launch.vercel.app` | QA / preview origin | Approved QA origin |
 | `https://api.mosaicbizhub.com` | Canonical backend API | API host only; never a frontend redirect target |
 
 ## Runtime References
 
 | Area | File | Behavior |
 | --- | --- | --- |
-| Frontend URL generation | `utils/frontendUrl.js` | Defaults generated links to `https://mosaicbizhub.com`; ignores stale `app.mosaicbizhub.com` env defaults; approves temporary app only for transition redirects/CORS preservation; approves Vercel QA and dev localhost outside production; rejects `www`, API, and arbitrary origins |
+| Frontend URL generation | `utils/frontendUrl.js` | Defaults generated links to `https://mosaicbizhub.com`; ignores stale `app.mosaicbizhub.com` env defaults; approves the app host only for transition/rollback compatibility; approves Vercel QA and dev localhost outside production; rejects `www`, API, and arbitrary origins |
 | Stripe Connect return and refresh URLs | `lib/connect/connectUrls.js` | Uses the shared frontend URL allowlist and preserves approved full URL overrides |
 | Google OAuth redirect state | `controllers/authController.js` | Sanitizes supplied redirects before state creation and again before callback redirect |
 | Billing portal return URL | `controllers/billing.controller.js` | Sanitizes user-supplied or configured return URLs to an approved frontend origin or fallback account path |
-| Credentialed CORS defaults | `utils/corsOrigins.js` | Defaults to apex + temporary app + Vercel QA; dev origins are appended outside production; wildcard origins are filtered out |
-| Production smoke probes | `.github/workflows/deploy-eb-production.yml`, `scripts/smoke-backend.ps1`, `scripts/smoke-backend.sh` | Probe apex, temporary app, and Vercel QA for credentialed CORS |
+| Credentialed CORS defaults | `utils/corsOrigins.js` | Defaults to apex plus approved transition/QA origins; dev origins are appended outside production; wildcard origins are filtered out |
+| Production smoke probes | `.github/workflows/deploy-eb-production.yml`, `scripts/smoke-backend.ps1`, `scripts/smoke-backend.sh` | Probe apex and approved transition/QA origins for credentialed CORS |
 
 ## Redirect Security Evidence
 
@@ -43,7 +43,7 @@ Covered flows:
 | --- | --- |
 | `https://mosaicbizhub.com` | Canonical production marketplace frontend |
 | `https://www.mosaicbizhub.com` | Redirect-only alias; explicitly rejected by backend URL sanitizer and omitted from default CORS |
-| `https://app.mosaicbizhub.com` | Temporary transition / legacy app origin; keep only until cutover smoke passes |
+| `https://app.mosaicbizhub.com` | Transition / historical app origin; keep only while explicitly approved |
 | `https://mosaic-biz-frontend-launch.vercel.app` | QA / preview origin |
 | `https://api.mosaicbizhub.com` | Backend API base URL only |
 

--- a/docs/MVP_BACKEND_PROGRAM_STATUS.md
+++ b/docs/MVP_BACKEND_PROGRAM_STATUS.md
@@ -1,148 +1,95 @@
-# MVP Backend Program Status
+# Backend Program Status
 
-**Last updated:** 2026-06-18 (post #62 merge + closeout audit sync)  
-**Canonical hub** for backend MVP sprint (#26–#35): where Mosaic is today, what is live in production, what is in flight, and what comes next.
+**Type:** Living document
+**Last updated:** 2026-06-28
+**Audience:** backend engineers, QA, release control, AI agents
 
-For deep technical detail, follow links to issue-specific docs — do not duplicate them here.
+This is the current backend status hub. Older MVP sprint docs and smoke proof packs remain useful evidence, but they are no longer the source of truth for current production posture.
+
+For documentation drift cleanup see [DOCUMENTATION_CONSOLIDATION_2026_06_28.md](DOCUMENTATION_CONSOLIDATION_2026_06_28.md).
 
 ---
 
-## Executive snapshot
+## Current Production Snapshot
 
-| Item | Value |
+| Item | Current state |
 | --- | --- |
-| **Product** | Mosaic Biz Hub backend — minority-owned business marketplace REST API |
-| **Production API** | `https://api.mosaicbizhub.com` |
-| **Production deploy SHA** | `7d01011` — issues #33 + #42 ([PR #48](https://github.com/Techware-Hut/mosaic-backend/pull/48), [PR #49](https://github.com/Techware-Hut/mosaic-backend/pull/49)) |
-| **EB version label** | `mosaic-7d01011c55cb3ea367ff928b4b5fe2c30897d65e` |
-| **`main` HEAD** | `a03305a` — #18 Sentry merged ([PR #62](https://github.com/Techware-Hut/mosaic-backend/pull/62)) |
-| **Open PR** | None |
-| **Automated tests** | **173/173** on `main` |
-| **Release model** | Controlled issue-by-issue merge → manual GHA EB deploy → tiered prod smoke → evidence in [deploy-verification.md](deploy-verification.md) |
+| Repository | `Techware-Hut/mosaic-backend` |
+| Integration branch | `staging` |
+| Production branch | `main` |
+| Latest production promotion | PR [#150](https://github.com/Techware-Hut/mosaic-backend/pull/150), merged 2026-06-28 |
+| Production API | `https://api.mosaicbizhub.com` |
+| Production deployed SHA | `7c2b10d` |
+| EB deployment version | `mosaic-7c2b10dca32c746311ee79e9179c312b1c3743b9` |
+| Runtime health | `/api/health`, `/api/ready`, and `/api/build-info` returned production release `7c2b10d` on 2026-06-28 |
+| Frontend production | `https://mosaicbizhub.com` |
+| Current mode | Vendor soft launch and product build phase; Stripe test-mode purchase flows are allowed for controlled QA |
 
 ---
 
-## Issue tracker (#26–#35)
+## Current Source-Of-Truth Docs
 
-| Issue | Title | Code status | Production | Evidence |
-| --- | --- | --- | --- | --- |
-| [#26](https://github.com/Techware-Hut/mosaic-backend/issues/26) | Backend MVP API audit | **Merged** | N/A (docs) | [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) |
-| [#27](https://github.com/Techware-Hut/mosaic-backend/issues/27) | Smoke proof pack | **Partial evidence** | Partial P0–P6 | [MVP_BACKEND_SMOKE_PROOF_PACK.md](MVP_BACKEND_SMOKE_PROOF_PACK.md) |
-| [#28](https://github.com/Techware-Hut/mosaic-backend/issues/28) | Marketplace data contract | **Merged** (PR #37) | **Live** | [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md) |
-| [#29](https://github.com/Techware-Hut/mosaic-backend/issues/29) | Search/filter readiness | **Merged** (PR #38) | **Live** (`9f66c07`+) | [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) |
-| [#30](https://github.com/Techware-Hut/mosaic-backend/issues/30) | Vendor onboarding + email | **Merged** (PR #39) | **Live** (`6cdf587`) | [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) |
-| [#31](https://github.com/Techware-Hut/mosaic-backend/issues/31) | Vendor self-service APIs | **Merged** (PR #40) | **Live** (`2134231`) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
-| [#32](https://github.com/Techware-Hut/mosaic-backend/issues/32) | Stripe Connect runtime | **Merged** (PR #47) | **Live** (`7f7e293` docs/tests) | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) |
-| [#33](https://github.com/Techware-Hut/mosaic-backend/issues/33) | Email notifications | **Merged** (PR #48) | **Live** (`7d01011`) | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
-| [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) | Admin APIs | **Not started** | N/A | Audit §10 |
-| [#35](https://github.com/Techware-Hut/mosaic-backend/issues/35) | Reviews | **Not started** | N/A | Audit §10 |
-| [#42](https://github.com/Techware-Hut/mosaic-backend/issues/42) | Checkout approval + safe PI | **Merged** (PR #49) | **Live** (`7d01011`) | [MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md](MVP_BACKEND_STRIPE_CONNECT_RUNTIME_VERIFICATION.md) §#42 |
-
-**Deploy log:** chronological merge/deploy/smoke records → [deploy-verification.md](deploy-verification.md)
-
----
-
-## Phase 2 roadmap (#50–#60)
-
-| Issue | Title | Code status | Evidence |
-| --- | --- | --- | --- |
-| [#50](https://github.com/Techware-Hut/mosaic-backend/issues/50) | Agent onboarding + architecture pack | **Merged** (PR #61) | [LLM_CONTEXT.md](LLM_CONTEXT.md), [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md), [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) |
-| #51–#60 | Platform audit, OpenAPI, fixtures, pagination, indexes, media, validation, logging, jobs, dead-code | **Open** | See [LLM_CONTEXT.md](LLM_CONTEXT.md) issue map |
-
----
-
-## Where we are going
-
-### Immediate gate
-
-Issues #33 and #42 merged and deployed to production (`7d01011`). GHA health/auth probes pass. Tiered checkout/email smoke **PENDING** `SMOKE_TEST_*` accounts — tracked in #27 and follow-ups #41–#43.
-
-### Active sprint item
-
-- **#41** Payment route hardening (P0 security follow-up from #32 audit) — **active next** per 2026-06-18 GitHub closeout audit
-
-### Next scheduled work
-
-- **#43** Order email timing and webhook retry idempotency
-- **#55** OpenAPI / API contract docs (docs-only Phase 2 item)
-
-### Parallel / later
-
-- **#27** — full P0–P6 smoke proof pack ([production-proof-pack-template.md](production-proof-pack-template.md))
-- **#34–#35** — admin aggregation, reviews tests/DTO audit
-- **#19–#21, #23** — post-deploy ops hardening (IAM tighten, rollback doc, CORS GHA smoke, push-to-main criteria); **#18 merged to `main` (PR #62), EB deploy pending**; **#22 closed as not planned** ([hosted-staging-decision.md](hosted-staging-decision.md))
-- **Security hardening** — auth on exposed admin/stripe routes (tracked in audit and [DECISION_REGISTER.md](DECISION_REGISTER.md))
-
-Issue dependency diagram: [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) §10 (Recommended backend fix order).
-
-### GitHub closeout audit (2026-06-18)
-
-Audited open issues #18–#23, #34–#35, #41, #43–#46, #51–#60 against `main` @ `3205731`. Post-audit: #18 code merged via [PR #62](https://github.com/Techware-Hut/mosaic-backend/pull/62) (`a03305a`); issue remains open until EB deploy + Sentry verification.
-
-| Outcome | Count | Notes |
-| --- | --- | --- |
-| Closed as completed | 0 | No issue met full acceptance criteria |
-| Closed as not planned | 1 | [#22](https://github.com/Techware-Hut/mosaic-backend/issues/22) — hosted staging deferred |
-| Left open | 20 | Checklist comments posted on each open issue |
-
----
-
-## How to read the documentation set
-
-```mermaid
-flowchart TD
-  hub["MVP_BACKEND_PROGRAM_STATUS"]
-  index["docs/README.md"]
-  audit["MVP_BACKEND_API_AUDIT"]
-  issueDocs["MVP_BACKEND_* per issue"]
-  ops["PRODUCTION_RUNBOOK + deploy-verification"]
-  llm["LLM_CONTEXT"]
-  hub --> audit
-  hub --> issueDocs
-  hub --> ops
-  index --> hub
-  llm --> hub
-  audit --> issueDocs
-```
-
-| Role | Read in this order |
+| Need | Read first |
 | --- | --- |
-| **Release / deploy owner** | This doc → [deploy-verification.md](deploy-verification.md) → issue-specific production section → [production-proof-pack-template.md](production-proof-pack-template.md) |
-| **Developer / LLM** | [LLM_CONTEXT.md](LLM_CONTEXT.md) → this doc → [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) → relevant issue doc |
-| **QA / smoke tester** | [production-smoke-checklist.md](production-smoke-checklist.md) → [TEST_MATRIX.md](TEST_MATRIX.md) → issue doc production section |
-
-**Full index:** [docs/README.md](README.md)
-
----
-
-## Known gaps (honest inventory)
-
-| Gap | Impact | Where tracked |
-| --- | --- | --- |
-| No dedicated `SMOKE_TEST_*` vendor/admin accounts | Submit/finalize and tier-limit prod smoke **PENDING** / **SKIP** | [#30 deploy verification](deploy-verification.md), vendor self-service doc |
-| Live SMTP inbox proof not captured | Email delivery unverified on production | [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) |
-| `PATCH /business-profile` skips Business sync | PUT works; PATCH partial sync gap | [business-sync.md](business-sync.md), [DECISION_REGISTER.md](DECISION_REGISTER.md) |
-| `Business.usage` counters not wired | Tier limits use live product/variant counts (#31) | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
-| Service/food/private-listing ownership | Not covered by #31 unit tests | [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) |
-| `/stripe/*` routes lack auth | Pre-#32 security risk | [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md), [security-remediation-notes.md](security-remediation-notes.md) |
+| Backend docs index | [README.md](README.md) |
+| Platform behavior | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md) |
+| API surface | [API_SURFACE.md](API_SURFACE.md), [contracts/BACKEND_ROUTE_MANIFEST.md](contracts/BACKEND_ROUTE_MANIFEST.md) |
+| Frontend/backend route contract | [BACKEND_FRONTEND_ROUTE_CONTRACT.md](BACKEND_FRONTEND_ROUTE_CONTRACT.md), [contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md](contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md) |
+| Auth/CORS/cookie behavior | [AUTH_FLOW.md](AUTH_FLOW.md), [backend/AUTH_CORS_COOKIE_AUDIT.md](backend/AUTH_CORS_COOKIE_AUDIT.md) |
+| Vendor eligibility | [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md), [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md) |
+| Deployment/runbook | [BACKEND_EB_DEPLOY_RUNBOOK.md](BACKEND_EB_DEPLOY_RUNBOOK.md), [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md), [../DEPLOYMENT.md](../DEPLOYMENT.md) |
+| QA gaps | [qa/FRESH_ACCOUNT_E2E_PLAN.md](qa/FRESH_ACCOUNT_E2E_PLAN.md), [qa/REGRESSION_CLAIM_LEDGER.md](qa/REGRESSION_CLAIM_LEDGER.md) |
 
 ---
 
-## Maintenance rule
+## Production Domain And CORS Policy
 
-When sprint state changes (merge, deploy, smoke, or issue closed):
-
-1. Update **this file first** (snapshot table, issue matrix, known gaps).
-2. Patch counts and conclusions in linked docs ([TEST_MATRIX.md](TEST_MATRIX.md), [deploy-verification.md](deploy-verification.md), issue-specific MVP docs).
-3. Add new `docs/` files to [docs/README.md](README.md).
-
----
-
-## Related documentation
-
-| Doc | Purpose |
+| Origin | Current role |
 | --- | --- |
-| [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) | Full API surface audit and fix order |
-| [DECISION_REGISTER.md](DECISION_REGISTER.md) | MVP decisions and deferrals |
-| [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) | Deploy, smoke, rollback |
-| [TEST_MATRIX.md](TEST_MATRIX.md) | Automated tests ↔ manual smoke mapping |
+| `https://mosaicbizhub.com` | Canonical production frontend |
+| `https://app.mosaicbizhub.com` | Transition/historical origin; keep only while approved |
+| `https://mosaic-biz-frontend-launch.vercel.app` | QA/preview origin |
+| `https://www.mosaicbizhub.com` | Alias/redirect target; do not treat as a credentialed API origin |
+
+Backend generated frontend links should use the apex marketplace origin unless a specific QA or rollback flow intentionally overrides it.
+
+---
+
+## Open Backend Work That Still Matters
+
+| Lane | Tracking |
+| --- | --- |
+| Production smoke proof for domain/API/auth | Backend [#84](https://github.com/Techware-Hut/mosaic-backend/issues/84) |
+| Isolated integration tests for auth/onboarding/orders/admin | Backend [#151](https://github.com/Techware-Hut/mosaic-backend/issues/151) |
+| Lifecycle state contracts and legacy route policy | Backend [#152](https://github.com/Techware-Hut/mosaic-backend/issues/152) |
+| Internal audit trail for sensitive admin/moderation actions | Backend [#153](https://github.com/Techware-Hut/mosaic-backend/issues/153) |
+| Refund, return, and dispute workflow audit | Backend [#154](https://github.com/Techware-Hut/mosaic-backend/issues/154) |
+| Route authorization matrix and negative-access contract tests | Backend [#155](https://github.com/Techware-Hut/mosaic-backend/issues/155) |
+| Validation/error response consistency | Backend [#46](https://github.com/Techware-Hut/mosaic-backend/issues/46) |
+| OpenAPI/API contract documentation | Backend [#55](https://github.com/Techware-Hut/mosaic-backend/issues/55) |
+| Admin dashboard APIs | Backend [#34](https://github.com/Techware-Hut/mosaic-backend/issues/34) |
+| Ops/security audits | Backend [#19](https://github.com/Techware-Hut/mosaic-backend/issues/19), [#70](https://github.com/Techware-Hut/mosaic-backend/issues/70), [#71](https://github.com/Techware-Hut/mosaic-backend/issues/71), [#76](https://github.com/Techware-Hut/mosaic-backend/issues/76) |
+
+---
+
+## Superseded Or Historical
+
+Treat the old MVP issue matrix, batch smoke docs, and dated proof packs as evidence snapshots. They may contain old production SHAs, `app.mosaicbizhub.com` as a then-current frontend, or blocked smoke tiers that have since changed.
+
+Do not delete them casually. Instead:
+
+1. Read this file first.
+2. Check current runtime proof and code.
+3. Use old proof packs only to understand why a decision was made at that time.
+4. If an old doc is still linked as active, update the link or add an archive note.
+
+---
+
+## Maintenance Rule
+
+When release state changes:
+
+1. Update this file first.
+2. Update [README.md](README.md) if the active/historical doc map changes.
+3. Keep proof packs as historical evidence; do not rewrite old failures into passes.
+4. Link new runtime proof from the relevant QA/release docs.

--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -30,7 +30,7 @@ Operational guide for release owners: deployment verification, rollback confirma
 | `http://mosaic-backend.us-east-1.elasticbeanstalk.com/` | EB hostname — **HTTP only** for optional raw health probe |
 | `https://mosaic-backend.us-east-1.elasticbeanstalk.com` | **Do not use** for production smoke — TLS certificate CN mismatch |
 
-Frontend (canonical): `https://mosaicbizhub.com` (transition: `https://app.mosaicbizhub.com`)
+Frontend (canonical): `https://mosaicbizhub.com` (transition/historical fallback only: `https://app.mosaicbizhub.com`)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,234 +1,104 @@
-# Mosaic Backend — Documentation Home
+# Mosaic Backend - Documentation Home
 
-**Start here.** This index is the entry point for contributors, QA, release owners, and LLMs working on `mosaic-backend`.
+**Audience:** backend engineers, QA, release control, AI agents
+**Last updated:** 2026-06-28
 
-Repository root: [README.md](../README.md) (stack, commands, env vars).  
-Application map: [ARCHITECTURE.md](ARCHITECTURE.md).
+This is the entry point for current backend documentation. Older sprint, smoke, and proof-pack docs are retained as evidence, but the living docs below are the source of truth for current behavior.
+
+Repository root: [README.md](../README.md). Deployment entry point: [../DEPLOYMENT.md](../DEPLOYMENT.md).
+
+---
+
+## Current Production Posture
+
+| Item | Current state |
+| --- | --- |
+| Production API | `https://api.mosaicbizhub.com` |
+| Production branch | `main` |
+| Integration branch | `staging` |
+| Latest production promotion | PR #150, merged 2026-06-28 |
+| Production deployed SHA | `7c2b10d` |
+| EB deployment version | `mosaic-7c2b10dca32c746311ee79e9179c312b1c3743b9` |
+| Canonical frontend | `https://mosaicbizhub.com` |
+| Current mode | Vendor soft launch and product build phase |
+| Payments | Stripe test-mode flows are allowed for controlled QA; do not present as unrestricted live commerce |
+| Main status hub | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) |
+
+---
+
+## Start Here
+
+| Question | Read |
+| --- | --- |
+| Where are we today? | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) |
+| What docs changed or became historical? | [DOCUMENTATION_CONSOLIDATION_2026_06_28.md](DOCUMENTATION_CONSOLIDATION_2026_06_28.md) |
+| What is the platform supposed to do? | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md) |
+| How is the backend organized? | [ARCHITECTURE.md](ARCHITECTURE.md), [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) |
+| What API routes exist? | [API_SURFACE.md](API_SURFACE.md), [contracts/BACKEND_ROUTE_MANIFEST.md](contracts/BACKEND_ROUTE_MANIFEST.md) |
+| How do frontend/backend contracts line up? | [BACKEND_FRONTEND_ROUTE_CONTRACT.md](BACKEND_FRONTEND_ROUTE_CONTRACT.md), [contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md](contracts/BACKEND_FRONTEND_CONTRACT_RISK_REPORT.md) |
+| How do we deploy? | [BACKEND_EB_DEPLOY_RUNBOOK.md](BACKEND_EB_DEPLOY_RUNBOOK.md), [../DEPLOYMENT.md](../DEPLOYMENT.md), [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) |
+| What is historical only? | [archive/README.md](archive/README.md) |
 
 ---
 
 ## Active Documentation
 
-Use this section before trusting older sprint, audit, or proof-pack docs.
+### Living
 
-| Tier | Docs | Use for |
-| --- | --- | --- |
-| **Source of truth** | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md), [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md) | How the platform is supposed to work |
-| **Living** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md), [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Current ship state and next work |
-| **Reference** | [ARCHITECTURE.md](ARCHITECTURE.md), [API_SURFACE.md](API_SURFACE.md), [AUTH_FLOW.md](AUTH_FLOW.md), [PAYMENT_FLOW.md](PAYMENT_FLOW.md), [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Day-to-day development |
-| **Deep indexes** | [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md), [backend/BACKEND_ROUTE_REGISTRATION.md](backend/BACKEND_ROUTE_REGISTRATION.md), [backend/API_CONTRACT_AS_BUILT.md](backend/API_CONTRACT_AS_BUILT.md) | Route/API-level detail |
-| **Archive / evidence** | Proof packs, smoke docs, dated audits | Audit trail only; check source-of-truth and living docs before relying on them |
+| Document | Use for |
+| --- | --- |
+| [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) | Current production SHA, open backend work, domain/CORS posture |
+| [DOCUMENTATION_CONSOLIDATION_2026_06_28.md](DOCUMENTATION_CONSOLIDATION_2026_06_28.md) | What was consolidated and what should be treated as historical |
+| [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Older roadmap context; verify against current GitHub issues before acting |
 
-Practical rule: if a behavior is not in the active source-of-truth docs, verify it against code and runtime before treating an older evidence doc as current.
+### Source Of Truth - Platform Behavior
+
+| Document | Use for |
+| --- | --- |
+| [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md) | Cross-role platform behavior |
+| [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md) | Vendor visibility and checkout eligibility |
+| [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md) | Public/admin/vendor visibility rules |
+| [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding and approval states |
+
+### Architecture, API, And Contracts
+
+| Document | Use for |
+| --- | --- |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Backend architecture and env overview |
+| [API_SURFACE.md](API_SURFACE.md) | Full HTTP route map |
+| [AUTH_FLOW.md](AUTH_FLOW.md) | Auth, OTP, JWT, Google OAuth, CORS/cookies |
+| [PAYMENT_FLOW.md](PAYMENT_FLOW.md) | Orders, payment intents, subscriptions, Connect |
+| [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) | Stripe webhook endpoints and behavior |
+| [DOMAIN_MIGRATION_URL_INVENTORY.md](DOMAIN_MIGRATION_URL_INVENTORY.md) | Canonical, alias, transition, preview, and API origin policy |
+| [STRIPE_CONNECT_DOMAIN_VERIFICATION.md](STRIPE_CONNECT_DOMAIN_VERIFICATION.md) | Stripe Connect return/refresh domain intent |
+| [BACKEND_FRONTEND_ROUTE_CONTRACT.md](BACKEND_FRONTEND_ROUTE_CONTRACT.md) | Contract between frontend calls and backend routes |
+| [contracts/BACKEND_ROUTE_MANIFEST.md](contracts/BACKEND_ROUTE_MANIFEST.md) | Generated/curated route manifest |
+| [backend/API_CONTRACT_AS_BUILT.md](backend/API_CONTRACT_AS_BUILT.md) | As-built API contract snapshot |
+| [backend/AUTH_CORS_COOKIE_AUDIT.md](backend/AUTH_CORS_COOKIE_AUDIT.md) | Auth/CORS/cookie audit |
+
+### Operations, QA, And Release
+
+| Document | Use for |
+| --- | --- |
+| [BACKEND_EB_DEPLOY_RUNBOOK.md](BACKEND_EB_DEPLOY_RUNBOOK.md) | EB deploy and smoke runbook |
+| [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) | Release-owner runbook |
+| [TEST_MATRIX.md](TEST_MATRIX.md) | Automated tests mapped to manual smoke |
+| [SMOKE_TEST_TOKENS.md](SMOKE_TEST_TOKENS.md) | How token-protected smoke tiers work |
+| [qa/FRESH_ACCOUNT_E2E_PLAN.md](qa/FRESH_ACCOUNT_E2E_PLAN.md) | Fresh account production QA plan |
+| [qa/REGRESSION_CLAIM_LEDGER.md](qa/REGRESSION_CLAIM_LEDGER.md) | Runtime claims and gaps ledger |
+| [release/WORK_ORDER_2026_06_26_MOSAIC_LAUNCH_HARDENING.md](release/WORK_ORDER_2026_06_26_MOSAIC_LAUNCH_HARDENING.md) | June 26 work order evidence |
 
 ---
 
-## Read first (by role)
+## Historical / Evidence Only
 
-| If you are… | Read in this order |
-| --- | --- |
-| **LLM / AI agent** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [LLM_CONTEXT.md](LLM_CONTEXT.md) → [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) → [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) → [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) → [API_SURFACE.md](API_SURFACE.md) |
-| **New backend developer** | [ARCHITECTURE.md](ARCHITECTURE.md) → [SETUP.md](../SETUP.md) → [AUTH_FLOW.md](AUTH_FLOW.md) → [API_SURFACE.md](API_SURFACE.md) |
-| **QA / smoke tester** | [BACKEND_VENDOR_AUTH_SMOKE_PROOF.md](BACKEND_VENDOR_AUTH_SMOKE_PROOF.md) → [BACKEND_FULL_SMOKE_PROOF_PACK.md](BACKEND_FULL_SMOKE_PROOF_PACK.md) → [production-smoke-checklist.md](production-smoke-checklist.md) → [TEST_MATRIX.md](TEST_MATRIX.md) → [API_SURFACE.md](API_SURFACE.md) |
-| **Release / deploy owner** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) → [DEPLOYMENT.md](../DEPLOYMENT.md) → [production-proof-pack-template.md](production-proof-pack-template.md) |
-| **Product / launch reviewer** | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) → [backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md](backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md) → [DECISION_REGISTER.md](DECISION_REGISTER.md) → [launch-readiness-report.md](launch-readiness-report.md) |
+Use [archive/README.md](archive/README.md) for old batch audits, smoke packs, proof packs, and dated deployment evidence. These files preserve history and should not be deleted casually.
 
----
+Current domain rule:
 
-## Launch readiness — as-built evidence pack
+- `https://mosaicbizhub.com` is the canonical production frontend.
+- `https://app.mosaicbizhub.com` is transition/historical unless explicitly approved for rollback.
+- `https://mosaic-biz-frontend-launch.vercel.app` is QA/preview or historical evidence.
+- `https://www.mosaicbizhub.com` is an alias/redirect target, not a credentialed API origin.
 
-**Start here for launch contract reconciliation:** [backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md](backend/BACKEND_DOCUMENTATION_EVIDENCE_LOG.md)
-
-| Doc | What it covers |
-| --- | --- |
-| [backend/BACKEND_ARCHITECTURE_AS_BUILT.md](backend/BACKEND_ARCHITECTURE_AS_BUILT.md) | Stack, bootstrap, middleware order, integrations |
-| [backend/BACKEND_ROUTE_REGISTRATION.md](backend/BACKEND_ROUTE_REGISTRATION.md) | All registered routes with auth/role/status |
-| [backend/API_CONTRACT_AS_BUILT.md](backend/API_CONTRACT_AS_BUILT.md) | Request/response shapes for frontend reconciliation |
-| [backend/DATA_MODEL_DICTIONARY.md](backend/DATA_MODEL_DICTIONARY.md) | Mongoose models and key fields |
-| [backend/AUTH_CORS_COOKIE_AUDIT.md](backend/AUTH_CORS_COOKIE_AUDIT.md) | Auth, CORS, cookie audit |
-| [backend/STRIPE_PAYMENT_CONNECT_AUDIT.md](backend/STRIPE_PAYMENT_CONNECT_AUDIT.md) | Stripe webhooks, checkout, Connect |
-| [backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md](backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md) | Env var names only |
-| [backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md](backend/BACKEND_DEPLOYMENT_RUNBOOK_DRAFT.md) | Deploy/smoke draft runbook |
-| [backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md](backend/BACKEND_LAUNCH_CONTRACT_VERIFICATION.md) | P0/P1 contract tests and route verification evidence |
-| [backend/BACKEND_P0_P1_RISK_REGISTER.md](backend/BACKEND_P0_P1_RISK_REGISTER.md) | Launch risk register with approval gates |
-
-## MVP backend sprint (#26–#35)
-
-**Start here for sprint state:** [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) — production SHA, open PRs, roadmap, known gaps.
-
-| Doc | What it covers |
-| --- | --- |
-| [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) | **Canonical hub** — where we are, what's live, what's next |
-| [MVP_BACKEND_API_AUDIT.md](MVP_BACKEND_API_AUDIT.md) | Full API audit, coverage matrix (#26–#35), recommended fix order |
-| [MVP_BACKEND_SMOKE_PROOF_PACK.md](MVP_BACKEND_SMOKE_PROOF_PACK.md) | Issue #27 smoke proof pack evidence |
-| [MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md](MVP_BACKEND_MARKETPLACE_DATA_CONTRACT.md) | Issue #28 public listing/featured/detail DTO contract |
-| [MVP_BACKEND_SEARCH_FILTER_READINESS.md](MVP_BACKEND_SEARCH_FILTER_READINESS.md) | Issue #29 search/filter API readiness |
-| [MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md](MVP_BACKEND_VENDOR_ONBOARDING_EMAIL_FLOW.md) | Issue #30 vendor onboarding validation + email flow |
-| [MVP_BACKEND_EMAIL_NOTIFICATIONS.md](MVP_BACKEND_EMAIL_NOTIFICATIONS.md) | Issue #33 email notification audit + tests |
-| [MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md](MVP_BACKEND_VENDOR_SELF_SERVICE_APIS.md) | Issue #31 vendor profile, listings, orders, stock |
-| [deploy-verification.md](deploy-verification.md) | Chronological MVP deploy verification log |
-
----
-
-## Core guides
-
-Canonical deep-dives. Prefer these over duplicating detail in chat or new docs.
-
-| Doc | What it covers |
-| --- | --- |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Repo layout, request lifecycle, route registry by domain, models index, where to look first |
-| [LLM_CONTEXT.md](LLM_CONTEXT.md) | Safe-edit rules, env names, issue map, and fast navigation for AI assistants |
-| [BACKEND_ARCHITECTURE_MAP.md](BACKEND_ARCHITECTURE_MAP.md) | Route → controller → model ownership, boundaries, and no-touch zones (issue #50) |
-| [AGENT_WORKFLOW.md](AGENT_WORKFLOW.md) | Branch/PR guardrails, before-coding and before-PR checklists for agents |
-| [BACKEND_STABILITY_AGENT_PROMPT.md](BACKEND_STABILITY_AGENT_PROMPT.md) | Controlled stabilization sprint prompt for Cursor/OpenClaw |
-| [BACKEND_STABILITY_ROADMAP_AUDIT.md](BACKEND_STABILITY_ROADMAP_AUDIT.md) | Stability audit snapshot (working / fragile / deferred) |
-| [BACKEND_STABILITY_PROOF.md](BACKEND_STABILITY_PROOF.md) | Test and manual verification evidence for stability sprint |
-| [BACKEND_ROADMAP_ISSUES.md](BACKEND_ROADMAP_ISSUES.md) | Prioritized GitHub-ready issue backlog by lane |
-| [BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md) | Batch 2 audit — payment auth, email timing, health (#41/#43/#69) |
-| [BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md](BACKEND_LAUNCH_BLOCKERS_BATCH_2_PROOF.md) | Batch 2 test and smoke proof |
-| [BACKEND_BATCH_3_DEPLOY_SMOKE_AUDIT.md](BACKEND_BATCH_3_DEPLOY_SMOKE_AUDIT.md) | Batch 3 deploy/smoke/Sentry audit snapshot |
-| [BACKEND_FULL_SMOKE_PROOF_PACK.md](BACKEND_FULL_SMOKE_PROOF_PACK.md) | P0–P6 smoke matrix (#27) |
-| [SENTRY_EB_DEPLOY_VERIFICATION.md](SENTRY_EB_DEPLOY_VERIFICATION.md) | Sentry EB verification (#18) |
-| [EB_DEPLOYMENT_READINESS_CHECKLIST.md](EB_DEPLOYMENT_READINESS_CHECKLIST.md) | Pre/post EB deploy checklist |
-| [BACKEND_REMAINING_BLOCKERS_AFTER_BATCH_3.md](BACKEND_REMAINING_BLOCKERS_AFTER_BATCH_3.md) | Post-Batch 3 blocker classification |
-| [GITHUB_ISSUE_TRIAGE_2026-06-18.md](GITHUB_ISSUE_TRIAGE_2026-06-18.md) | GitHub issue close/comment/reopen log |
-| [ENV_VAR_INVENTORY.md](ENV_VAR_INVENTORY.md) | Env var names by environment (#64) |
-| [PUSH_TO_MAIN_DEPLOY_CRITERIA.md](PUSH_TO_MAIN_DEPLOY_CRITERIA.md) | Criteria to re-enable push-to-main deploy (#23) |
-| [BACKUP_ROLLBACK_RUNBOOK.md](BACKUP_ROLLBACK_RUNBOOK.md) | Code rollback + Atlas backup assumptions (#75) |
-| [API_SURFACE.md](API_SURFACE.md) | Full HTTP route map, middleware, auth/role boundaries, smoke and risk notes |
-| [AUTH_FLOW.md](AUTH_FLOW.md) | Login, register, OTP, password reset, JWT, Google OAuth, rate limits |
-| [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding states, admin review, payments, uploads, resubmit |
-| [DECISION_REGISTER.md](DECISION_REGISTER.md) | MVP decisions, open blockers, deferred items, launch assumptions |
-
----
-
-## Payments and Stripe
-
-| Doc | What it covers |
-| --- | --- |
-| [PAYMENT_FLOW.md](PAYMENT_FLOW.md) | Orders, payment intents, vendor fee, subscriptions, Connect (non-webhook paths) |
-| [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) | Five webhook endpoints, events, signature behavior, smoke guidance |
-| [stripe-webhook-registration.md](stripe-webhook-registration.md) | How to register webhook URLs in Stripe Dashboard |
-| [business-sync.md](business-sync.md) | Onboarding → `Business` document sync behavior |
-
----
-
-## Operations, deployment, and environment
-
-| Doc | What it covers |
-| --- | --- |
-| [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md) | Deploy, smoke tiers, rollback, Go/No-Go, sign-off |
-| [DEPLOYMENT.md](../DEPLOYMENT.md) | AWS Elastic Beanstalk deploy process |
-| [STAGING.md](../STAGING.md) | `staging` branch integration gate (no hosted staging deploy) |
-| [SETUP.md](../SETUP.md) | Local development bootstrap |
-| [production-env-checklist.md](production-env-checklist.md) | Production environment variable audit |
-| [hosted-staging-decision.md](hosted-staging-decision.md) | **Deferred:** hosted staging backend — rationale and implications |
-
----
-
-## Testing and launch readiness
-
-| Doc | What it covers |
-| --- | --- |
-| [TEST_MATRIX.md](TEST_MATRIX.md) | Automated tests (`npm test`) mapped to manual smoke and gaps |
-| [production-smoke-checklist.md](production-smoke-checklist.md) | Tiered post-deploy smoke (P0–P6) on production API |
-| [BACKEND_FULL_SMOKE_PROOF_PACK.md](BACKEND_FULL_SMOKE_PROOF_PACK.md) | Full P0–P6 evidence matrix with pass/fail/blocked status |
-| [launch-readiness-report.md](launch-readiness-report.md) | Route audit, blockers, and launch-risk inventory |
-
----
-
-## Proof packs and release evidence
-
-Keep **confirmed launch evidence** here — not in chat logs or ad-hoc notes.
-
-| Doc | What it covers |
-| --- | --- |
-| [production-proof-pack-template.md](production-proof-pack-template.md) | Per-release evidence template (deploy SHA, smoke, rollback) |
-| [deploy-verification.md](deploy-verification.md) | Deploy verification log format |
-| [integration-gate-asana-evidence.md](integration-gate-asana-evidence.md) | Integration gate evidence (Asana-linked) |
-| [wave2-auth-verification-evidence.md](wave2-auth-verification-evidence.md) | Wave 2 auth verification evidence archive |
-| [wave2-stripe-webhook-verification-evidence.md](wave2-stripe-webhook-verification-evidence.md) | Wave 2 Stripe webhook verification evidence archive |
-
----
-
-## Admin, vendor, and security reference
-
-| Doc | What it covers |
-| --- | --- |
-| [admin-read-mutation.md](admin-read-mutation.md) | Admin API read/mutation behavior |
-| [admin-pending-applications-statuses.md](admin-pending-applications-statuses.md) | Vendor application status definitions |
-| [vendor-field-protection.md](vendor-field-protection.md) | Vendor field allowlists and protection rules |
-| [security-remediation-notes.md](security-remediation-notes.md) | Security remediation tracking (Stripe routes, secrets, auth gaps) |
-| [auth.md](auth.md) | Legacy auth notes; see [AUTH_FLOW.md](AUTH_FLOW.md) for the canonical flow doc |
-
----
-
-## Internal / misc
-
-| Doc | What it covers |
-| --- | --- |
-| [../todo.md](../todo.md) | Informal dev notes (not maintained as operational docs) |
-| [../README.md](../README.md) | Project overview, commands, env var tables |
-
----
-
-## Documentation maintenance rules
-
-Follow these when changing code **or** docs.
-
-### When to update
-
-1. **Behavior changes** — Update the relevant guide (auth, vendor, payments, webhooks, API surface) in the same PR or immediately after merge.
-2. **New routes** — Add rows to [API_SURFACE.md](API_SURFACE.md) and mount notes in [ARCHITECTURE.md](ARCHITECTURE.md).
-3. **New decisions or deferrals** — Add a row to [DECISION_REGISTER.md](DECISION_REGISTER.md) with status and evidence link.
-4. **Deploy or smoke process changes** — Update [PRODUCTION_RUNBOOK.md](PRODUCTION_RUNBOOK.md), [DEPLOYMENT.md](../DEPLOYMENT.md), and smoke checklists as needed.
-5. **Launch evidence** — Record in proof-pack docs ([production-proof-pack-template.md](production-proof-pack-template.md), [deploy-verification.md](deploy-verification.md)), not in unrelated files.
-
-### Linking and discoverability
-
-- **Every new doc in `docs/` must be linked from this file** (`docs/README.md`).
-- Prefer cross-links between related docs instead of copying long sections.
-- Root [README.md](../README.md) Operational docs section should point here for the full index.
-
-### Content standards
-
-| Rule | Detail |
-| --- | --- |
-| **No secrets** | Never commit API keys, webhook secrets, passwords, JWTs, or `.env` values. Use placeholder names only. |
-| **No private data** | Do not include real user, vendor, or customer PII, emails, or production IDs in docs. |
-| **Facts vs assumptions** | Label uncertain items explicitly (e.g. *Assumption*, *Unverified*, *Deferred*). |
-| **Deferred items** | Mark clearly in [DECISION_REGISTER.md](DECISION_REGISTER.md) and link from affected runbooks. |
-| **Evidence** | Confirmed production behavior belongs in proof-pack / evidence docs with date and deploy SHA when applicable. |
-| **No overclaiming** | Do not mark launch items complete without linked evidence. **Launch-ready** requires EB deployed commit confirmed, rollback recorded, post-deploy smoke (commit confirmed), proof pack, and product owner written approval (Bryan). |
-
-### Doc ownership hints
-
-| Area | Primary docs to touch |
-| --- | --- |
-| Routes / middleware | `API_SURFACE.md`, `ARCHITECTURE.md` |
-| Auth | `AUTH_FLOW.md`, `auth.md` (if legacy parity needed) |
-| Vendor | `VENDOR_LIFECYCLE.md`, `vendor-field-protection.md`, `business-sync.md` |
-| Stripe | `STRIPE_WEBHOOKS.md`, `PAYMENT_FLOW.md`, `stripe-webhook-registration.md` |
-| Release | `PRODUCTION_RUNBOOK.md`, proof-pack templates, `DECISION_REGISTER.md` |
-| Security | `security-remediation-notes.md`, `launch-readiness-report.md` |
-
----
-
-## Quick links (required deliverables)
-
-- [MVP program status](MVP_BACKEND_PROGRAM_STATUS.md)
-- [Architecture map](ARCHITECTURE.md)
-- [LLM context guide](LLM_CONTEXT.md)
-- [Auth flow](AUTH_FLOW.md)
-- [Vendor lifecycle](VENDOR_LIFECYCLE.md)
-- [Stripe webhook docs](STRIPE_WEBHOOKS.md)
-- [Payment flow docs](PAYMENT_FLOW.md)
-- [Production runbook](PRODUCTION_RUNBOOK.md)
-- [Test matrix](TEST_MATRIX.md)
-- [API surface map](API_SURFACE.md)
-- [Decision register](DECISION_REGISTER.md)
-- [Proof-pack template](production-proof-pack-template.md)
-- [Backend stability audit](BACKEND_STABILITY_ROADMAP_AUDIT.md)
-- [Backend roadmap issues](BACKEND_ROADMAP_ISSUES.md)
-- [Launch blockers batch 2 audit](BACKEND_LAUNCH_BLOCKERS_BATCH_2_AUDIT.md)
-- [Deployment docs](../DEPLOYMENT.md) · [Staging](../STAGING.md) · [Setup](../SETUP.md)
+If a historical doc conflicts with [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md), current code, or runtime proof, trust the current source and update/link the stale doc instead of copying its old conclusion forward.

--- a/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
+++ b/docs/STRIPE_CONNECT_DOMAIN_VERIFICATION.md
@@ -1,9 +1,10 @@
 # Stripe Connect Domain Verification
 
-**Issue:** [#82 Stripe Connect return and refresh URL domain alignment](https://github.com/Techware-Hut/mosaic-backend/issues/82)  
-**Branch:** `release/backend-post-merge-production-stabilization`  
-**Frontend routes:** `/partners/connect/return`, `/partners/connect/refresh`  
-**Evidence date:** 2026-06-22  
+**Issue:** [#82 Stripe Connect return and refresh URL domain alignment](https://github.com/Techware-Hut/mosaic-backend/issues/82)
+**Branch:** `release/backend-post-merge-production-stabilization`
+**Frontend routes:** `/partners/connect/return`, `/partners/connect/refresh`
+**Evidence date:** 2026-06-22
+**Domain policy updated:** 2026-06-28
 
 No secrets in this document.
 
@@ -30,7 +31,7 @@ Unit tests: [`tests/connect/connect-urls.test.js`](../tests/connect/connect-urls
 | Environment | `FRONTEND_URL` (expected) | Return URL shape |
 |-------------|---------------------------|------------------|
 | Production | `https://mosaicbizhub.com` | `https://mosaicbizhub.com/partners/connect/return?businessId=<id>` |
-| Transition | `https://app.mosaicbizhub.com` | Temporary only until apex smoke passes |
+| Transition / rollback | `https://app.mosaicbizhub.com` | Use only while explicitly approved for rollback or compatibility checks |
 | QA / launch Vercel | `https://mosaic-biz-frontend-launch.vercel.app` | Same path on launch host (via override or FRONTEND_URL) |
 
 **Note:** Production EB should use the apex marketplace origin. Use `CONNECT_RETURN_URL` / `CONNECT_REFRESH_URL` only when a full override is intentionally required.
@@ -43,7 +44,7 @@ CONNECT_RETURN_PATH=/partners/connect/return
 CONNECT_REFRESH_PATH=/partners/connect/refresh
 ```
 
-Full URL overrides are valid for intentional QA or cutover windows, but they should not point at `https://app.mosaicbizhub.com` after apex launch except during a documented temporary rollback window.
+Full URL overrides are valid for intentional QA or rollback windows, but they should not point at `https://app.mosaicbizhub.com` during normal production operation.
 
 ---
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -4,9 +4,13 @@
 
 Files are not physically moved in this PR to avoid breaking links. Treat older proof and audit docs as historical evidence, not current operating rules. For current behavior, start with:
 
+- [../MVP_BACKEND_PROGRAM_STATUS.md](../MVP_BACKEND_PROGRAM_STATUS.md)
+- [../DOCUMENTATION_CONSOLIDATION_2026_06_28.md](../DOCUMENTATION_CONSOLIDATION_2026_06_28.md)
 - [../PLATFORM_OPERATING_MODEL.md](../PLATFORM_OPERATING_MODEL.md)
 - [../MARKETPLACE_VENDOR_ELIGIBILITY.md](../MARKETPLACE_VENDOR_ELIGIBILITY.md)
 - [../README.md](../README.md)
+
+Current production/domain state lives in the status and consolidation docs above. Older proof packs may name previous SHAs, old preview domains, app-domain transition wording, or pre-cutover gates.
 
 ## Archive Categories
 


### PR DESCRIPTION
## Summary
- Consolidates backend documentation around the current production soft-launch posture.
- Updates backend domain/CORS, production runbook, Stripe Connect domain guidance, archive routing, and roadmap context.
- Adds a documentation consolidation map for current vs historical docs.

## Validation
- Active-doc local links resolve.
- git diff --check passed on promoted docs.
- Stale cutover/domain phrase scan passed for active docs.