### PR TITLE
[codex] Document vendor plan entitlements

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -97,6 +97,17 @@ npm run dev
 | `npm start` | Run with Node.js |
 | `npm test` | Run the local non-integration test suite with Node's built-in runner; see [docs/TEST_MATRIX.md](docs/TEST_MATRIX.md) |
 
+## Local Seed Reset Guard
+
+`seed/seedCategories.js` deletes and recreates sample category records. It now refuses to run unless `ALLOW_SEED_RESET=true` is set. Use only against a local or disposable database:
+
+```powershell
+$env:MONGODB_URI = "mongodb://localhost:27017/mosaic"
+$env:ALLOW_SEED_RESET = "true"
+node seed/seedCategories.js
+Remove-Item Env:\ALLOW_SEED_RESET
+```
+
 ## Environment file guidance
 
 - Do not commit your real `.env`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,8 @@ Repository root: [README.md](../README.md). Deployment entry point: [../DEPLOYME
 | [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md) | Vendor visibility and checkout eligibility |
 | [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md) | Public/admin/vendor visibility rules |
 | [VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md](VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md) | Silver/Gold/Platinum limits, subscription lifecycle, and MVP vs future-phase entitlement rules |
+| [SEED_AND_LOCAL_BOOTSTRAP_AUDIT_2026_06_28.md](SEED_AND_LOCAL_BOOTSTRAP_AUDIT_2026_06_28.md) | Seed scripts, local reset guardrails, and fake data handling |
+| [UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md](UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md) | Upload route controls, storage lifecycle, and media hardening follow-ups |
 | [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding and approval states |
 | [LIFECYCLE_STATE_AND_LEGACY_ROUTE_POLICY.md](LIFECYCLE_STATE_AND_LEGACY_ROUTE_POLICY.md) | Backend lifecycle states and intentional legacy/duplicate route policy |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ Repository root: [README.md](../README.md). Deployment entry point: [../DEPLOYME
 | [PLATFORM_OPERATING_MODEL.md](PLATFORM_OPERATING_MODEL.md) | Cross-role platform behavior |
 | [MARKETPLACE_VENDOR_ELIGIBILITY.md](MARKETPLACE_VENDOR_ELIGIBILITY.md) | Vendor visibility and checkout eligibility |
 | [MARKETPLACE_VISIBILITY_MATRIX.md](MARKETPLACE_VISIBILITY_MATRIX.md) | Public/admin/vendor visibility rules |
+| [VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md](VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md) | Silver/Gold/Platinum limits, subscription lifecycle, and MVP vs future-phase entitlement rules |
 | [VENDOR_LIFECYCLE.md](VENDOR_LIFECYCLE.md) | Vendor onboarding and approval states |
 | [LIFECYCLE_STATE_AND_LEGACY_ROUTE_POLICY.md](LIFECYCLE_STATE_AND_LEGACY_ROUTE_POLICY.md) | Backend lifecycle states and intentional legacy/duplicate route policy |
 

--- a/docs/SEED_AND_LOCAL_BOOTSTRAP_AUDIT_2026_06_28.md
+++ b/docs/SEED_AND_LOCAL_BOOTSTRAP_AUDIT_2026_06_28.md
@@ -1,0 +1,67 @@
+# Seed Data And Local Bootstrap Audit - 2026-06-28
+
+**Issue:** #70 - Seed data and local development bootstrap cleanup  
+**Branch:** `staging`  
+**Mode:** Vendor soft launch and product build phase  
+**Guardrail:** No production data or fake production proof. Local seed scripts must be treated as disposable-development helpers only.
+
+## Summary
+
+The seed directory now avoids hardcoded production-style database credentials in the current repo. `seed/seedCategories.js` was changed to use `MONGODB_URI` or a local fallback, and it refuses to run destructive category resets unless `ALLOW_SEED_RESET=true` is explicitly set.
+
+## Seed Inventory
+
+| File | Purpose | Current posture |
+| --- | --- | --- |
+| `seed/seedCategories.js` | Deletes and inserts sample product/service/food categories | Uses env/local DB URI and requires `ALLOW_SEED_RESET=true` |
+| `seed/seedMinorityTypes.js` | Inserts minority type records if none exist | Uses `MONGODB_URI` or local fallback and skips when records exist |
+| `seed/insertDummyData.js` | Inserts fake business examples | Marked as local-only dummy data; contains fake contact/business values |
+| `seed/migrate.js` | Migration helper using `MONGODB_URI` | Env-driven; no committed credential found in current scan |
+| `seed/seedTestS3Upload.js` | Manual S3 upload probe | Uses env var names; should only run against a disposable/local test bucket |
+| `seed/testDeleteFile.js` | Manual delete helper | Treat as local/manual only |
+
+## Fixes In This Batch
+
+- Removed a hardcoded MongoDB Atlas connection string from `seed/seedCategories.js`.
+- Added `ALLOW_SEED_RESET=true` guard before category `deleteMany` calls.
+- Added a local-only warning to `seed/insertDummyData.js`.
+
+## Local Reset Steps
+
+Use only with a local or disposable database:
+
+```bash
+set MONGODB_URI=mongodb://localhost:27017/mosaic
+set ALLOW_SEED_RESET=true
+node seed/seedCategories.js
+```
+
+PowerShell equivalent:
+
+```powershell
+$env:MONGODB_URI = "mongodb://localhost:27017/mosaic"
+$env:ALLOW_SEED_RESET = "true"
+node seed/seedCategories.js
+```
+
+Unset `ALLOW_SEED_RESET` after the reset:
+
+```powershell
+Remove-Item Env:\ALLOW_SEED_RESET
+```
+
+## Safety Rules
+
+- Do not run destructive seed scripts against production or shared QA data.
+- Do not commit `.env`, real customer/vendor exports, OTPs, passwords, Stripe keys, AWS keys, or live MongoDB credentials.
+- Treat any credential that appeared in a tracked seed script or shared artifact as rotated/compromised.
+- Use fake names, fake emails, and dummy Stripe IDs only when sample data is needed.
+
+## Verification
+
+- `rg` seed scan found no hardcoded `mongodb+srv`, Stripe key, password, token, or secret values in current `seed/` files after the fix.
+- Remaining seed scan hits are AWS env var names in `seed/seedTestS3Upload.js`, not secret values.
+- `node seed/seedCategories.js` without `ALLOW_SEED_RESET=true` exits before connecting, confirming the reset guard is active.
+- `npm run test:contract` passed on 2026-06-28 after this batch.
+
+Closes #70 when merged with PR validation.

--- a/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
+++ b/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
@@ -1,0 +1,49 @@
+# Upload Security And Storage Lifecycle Audit - 2026-06-28
+
+**Issue:** #71 - File upload security and storage lifecycle audit  
+**Branch:** `staging`  
+**Mode:** Vendor soft launch and product build phase  
+**Guardrail:** No storage provider migration and no secret exposure. This audit documents behavior and logs safe follow-ups.
+
+## Summary
+
+Mosaic backend uses a mix of S3 presigned PUT URLs, direct S3 upload helpers, and a legacy Cloudinary pending-image URL route. Vendor onboarding document uploads have the strongest allowlist: document type validation, MIME normalization, JPEG/PNG/WebP/PDF allowlist, sanitized filenames, user-scoped S3 folders, and five-minute presigned URLs. Product and service image presigns also validate image MIME types and gallery limits. Food and generic S3 presign paths should be aligned with the same MIME normalization pattern in a future hardening PR.
+
+## Upload Surface Inventory
+
+| Surface | Route/file | Auth | File/type behavior | Lifecycle |
+| --- | --- | --- | --- | --- |
+| Vendor onboarding docs | `GET /api/vendor-onboarding/stage1/upload-url`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | Client PUTs to S3, saves returned `fileUrl` in onboarding draft |
+| Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated | Product doc type allowlist; image MIME allowlist; gallery quota check for gallery images | Client PUTs to S3 and stores returned URL |
+| Service images | `GET /api/service/upload-url` | Authenticated | Service doc type allowlist; image MIME allowlist; gallery quota check for gallery images | Client PUTs to S3 and stores returned URL |
+| Food images | `GET /api/food/upload-url` | Authenticated | Food doc type allowlist and gallery quota check; MIME allowlist should be aligned with product/service | Client PUTs to S3 and stores returned URL |
+| Generic S3 presign | `controllers/s3Controller.js` | Business owner or admin via route | Requires `fileName`/`fileType`; should add centralized MIME normalization and filename sanitization | Client PUTs to S3 |
+| Business create upload | `middlewares/upload.js`, `utils/uploadFile.js` | Business owner route | Multer memory storage, 5 MB max, JPEG/JPG/PNG/WebP only | Server uploads file buffer to S3 |
+| Legacy Cloudinary pending image | `POST /api/upload-image`, `routes/uploadImage.js` | Authenticated business owner | Validates Cloudinary image URL format | Stores pending URL for cleanup if not attached |
+
+## Confirmed Controls
+
+- Vendor onboarding MIME allowlist: `image/jpeg`, `image/png`, `image/webp`, `application/pdf`.
+- Product/service presigned uploads validate image MIME types before issuing URLs.
+- Presigned URLs expire after 300 seconds.
+- Filenames are sanitized in vendor onboarding, product, service, and food presign controllers.
+- Gallery upload paths enforce subscription gallery limits where implemented.
+- Multer direct upload path uses memory storage with a 5 MB limit and image-only filter.
+
+## Logged Follow-Ups
+
+1. Align `foodController.getFoodUploadUrl` with the same normalized MIME allowlist pattern used by product/service/vendor onboarding.
+2. Align `s3Controller.getPresignedUrl` with centralized MIME normalization and filename sanitization before broadening its use.
+3. Rename or split legacy `deleteCloudinaryFile.js` if it now deletes S3 objects, so storage lifecycle naming is not misleading.
+4. Add focused tests for food/generic S3 MIME rejection where practical.
+5. Run a live S3 CORS/presigned PUT smoke after production domain/env changes, because unit tests do not prove bucket CORS.
+
+## Verification
+
+- Upload route/middleware/source scan covered S3 presign controllers, Multer middleware, Cloudinary pending route, docs, and upload tests.
+- Existing relevant proof is documented in `docs/S3_UPLOAD_CORS.md` and `docs/VENDOR_LIFECYCLE.md`.
+- `npm run test:contract` passed on 2026-06-28 after this batch.
+- `node --test tests/vendor/vendor-onboarding-upload-mime.test.js tests/vendor/listing-tier-limits.test.js tests/service/service-publication-visibility.test.js` passed on 2026-06-28 after this batch.
+- No storage provider migration was performed in this batch.
+
+Closes #71 when merged with PR validation.

--- a/docs/VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md
+++ b/docs/VENDOR_PLAN_ENTITLEMENT_AUDIT_2026_06_28.md
@@ -1,0 +1,107 @@
+# Vendor Plan Entitlement And Subscription Lifecycle Audit - 2026-06-28
+
+**Issue:** #76 - Vendor plan entitlement and subscription lifecycle audit  
+**Branch:** `staging`  
+**Mode:** Vendor soft launch and product build phase  
+**Guardrail:** This audit documents current behavior only. It does not change live billing, Stripe subscriptions, pricing, webhooks, or entitlement enforcement.
+
+## Executive Summary
+
+Silver, Gold, and Platinum plans are modeled in `models/SubscriptionPlan.js`. Listing quotas are enforced in create and update surfaces for products, services, foods, and gallery images. Subscription state is modeled in `models/Subscription.js`, and listing actions require an active, unexpired subscription before quota checks run.
+
+Feature flags such as analytics, marketing tools, featured placement, search priority, and top-tier visibility are schema fields today. They are not consistently enforced as hard product permissions in controllers. Treat those as future-phase or merchandising assumptions until separate implementation and tests confirm otherwise.
+
+## Plan Fields
+
+`models/SubscriptionPlan.js` defines:
+
+| Area | Fields | Current status |
+| --- | --- | --- |
+| Plan identity | `name` enum: `Silver Plan`, `Gold Plan`, `Platinum Plan` | Live schema |
+| Billing metadata | `price`, `currency`, `interval`, `intervalCount`, `trialPeriodDays`, `durationInDays` | Live schema used by plan/admin/subscription flows |
+| Stripe links | `stripeProductId`, `stripePriceId` | Live schema; values are managed through Stripe-aware plan/subscription flows |
+| Listing limits | `productListings`, `serviceListings`, `foodListings`, `imageLimit`, `videoLimit` | Live schema |
+| Feature flags | `analyticsDashboard`, `marketingTools`, `featuredPlacement`, `supportLevel`, `communityEventsAccess`, `searchPriority`, `listingPriority`, `pushNotifications`, `aiRecommendation`, `topTierPlacement`, `topTierVisibility` | Stored, but not all are controller-enforced MVP permissions |
+
+## Subscription Lifecycle
+
+`models/Subscription.js` stores the customer/vendor subscription state:
+
+| Field | Meaning |
+| --- | --- |
+| `userId` | Vendor user that owns the subscription |
+| `businessId` | Linked after business creation; defaults to `null` |
+| `subscriptionPlanId` | Current plan reference |
+| `stripeSubscriptionId` and `stripeCustomerId` | Stripe linkage |
+| `paymentStatus` | `COMPLETED`, `FAILED`, `PENDING`, or `REFUNDED` |
+| `status` | `active`, `expired`, `cancelled`, or `pending` |
+| `startDate` and `endDate` | Active window used by listing gates |
+
+Listing controllers check for `status: 'active'` and `endDate >= now` before allowing listing creation or expansion. If no active subscription exists, the controller returns a 403 response.
+
+## Enforced MVP Entitlements
+
+| Entitlement | Enforcement surface | Current behavior |
+| --- | --- | --- |
+| Product listing quota | `controllers/productController.js`, `utils/listingTierLimits.js` | Counts parent products plus product variants against `limits.productListings`; blocks create/update when quota would be exceeded |
+| Service listing quota | `controllers/serviceController.js` | Counts child services against `limits.serviceListings`; blocks create/update when quota would be exceeded |
+| Food listing quota | `controllers/foodController.js` | Counts food listings against `limits.foodListings`; blocks create when quota is reached |
+| Gallery image quota | Product, service, and food controllers | Uses `galleryImageLimit` when present, otherwise `imageLimit`; cover images and menu images are intentionally not counted per `tier-listing-limit-implementation.md` |
+| Business usage helper methods | `models/Business.js` | Provides `canAddProduct`, `canAddService`, `canAddFood`, `canUploadImage`, and remaining-limit helpers for business-level checks |
+
+## Existing Test Coverage
+
+| Test area | Files |
+| --- | --- |
+| Product + variant quota helper | `tests/vendor/listing-tier-limits.test.js` |
+| Vendor listing ownership and limits fixture coverage | `tests/vendor/vendor-listing-ownership.test.js` |
+| Service publication visibility and limit fixtures | `tests/service/service-publication-visibility.test.js` |
+| Integration factories for default plan limits | `tests/integration/helpers/factories.js` |
+
+## Feature Flag Assumptions
+
+| Feature flag | MVP classification | Notes |
+| --- | --- | --- |
+| `analyticsDashboard` | Future-phase permission | Schema exists; do not promise tier-gated analytics until dashboard gate and tests exist |
+| `marketingTools` | Future-phase permission | Schema exists; no launch-critical controller gate confirmed in this audit |
+| `featuredPlacement` | Partially supported merchandising concept | Public featured placements exist, but tier entitlement enforcement should be verified before sales language promises it |
+| `supportLevel` | Future-phase/support operations | Schema exists; operational SLA should be documented before public promise |
+| `communityEventsAccess` | Future-phase | Schema exists; no hard controller gate confirmed |
+| `searchPriority` and `listingPriority` | Future-phase/search relevance | Schema exists; do not claim ranking benefits until ranking implementation and tests are documented |
+| `pushNotifications` | Future-phase | Schema exists; no entitlement gate confirmed |
+| `aiRecommendation` | Future-phase | Schema exists; avoid public AI entitlement claims until implementation is live |
+| `topTierPlacement` and `topTierVisibility` | Future-phase merchandising | Schema exists; needs ranking/visibility contract before launch claims |
+
+## MVP Versus Future-Phase Rule
+
+MVP launch-safe entitlements:
+
+- Active subscription status gate.
+- Product, product variant, service, food, and gallery image quotas.
+- Trust-badge and onboarding status as vendor credibility signals.
+
+Future-phase entitlements:
+
+- Analytics dashboards.
+- Marketing tools.
+- Ranking priority.
+- Featured/top-tier placement guarantees.
+- Push notifications.
+- AI recommendations.
+- Support-level SLA promises.
+
+## Safe Follow-Ups
+
+1. Add controller or route-level tests for food and service quota edge cases if not already covered by integration lanes.
+2. Add an explicit feature-flag route contract before public plan copy advertises analytics, ranking priority, marketing tools, AI, or top-tier placement.
+3. Review `subscriptionPlanController` sorting because the sort order currently uses base names while plan names include the `Plan` suffix.
+4. Capture production/staging plan documents in a redacted evidence packet before live pricing copy is finalized.
+5. Confirm Stripe webhook-driven status transitions with a controlled runtime smoke before switching from test to live keys.
+
+## Verification
+
+- This audit only changed documentation.
+- Current code inspection confirms listing quota gates exist in product, service, and food controllers.
+- Current code inspection confirms feature flags are stored in `SubscriptionPlan` but should not be treated as fully enforced MVP permissions without follow-up implementation evidence.
+- `npm run test:contract` passed on 2026-06-28.
+- `node --test tests/vendor/listing-tier-limits.test.js tests/service/service-publication-visibility.test.js` passed on 2026-06-28.

--- a/seed/insertDummyData.js
+++ b/seed/insertDummyData.js
@@ -1,6 +1,8 @@
 const mongoose = require("mongoose");
 const Business = require("../models/Business"); // Adjust path to your Business model
 
+// Local-only dummy data. Do not point this script at production data.
+
 // Import ObjectId from mongoose.Types
 const { ObjectId } = mongoose.Types;
 

--- a/seed/seedCategories.js
+++ b/seed/seedCategories.js
@@ -1,15 +1,23 @@
 const mongoose = require("mongoose");
+require("dotenv").config();
 
-const uri = "mongodb+srv://webdevelopmenttwh:gslF8QrdKKNfONlU@mosiac.dyjco5y.mongodb.net/mosaic?retryWrites=true&w=majority&appName=mosiac";
+const uri = process.env.MONGODB_URI || "mongodb://localhost:27017/mosaic";
+const allowSeedReset = process.env.ALLOW_SEED_RESET === "true";
+
+if (!allowSeedReset) {
+  console.error("Refusing to reset category seed data without ALLOW_SEED_RESET=true.");
+  console.error("Set MONGODB_URI to a local or disposable database before running this script.");
+  process.exit(1);
+}
 
 mongoose.connect(uri, { useNewUrlParser: true, useUnifiedTopology: true })
-  .then(() => console.log("✅ Connected to mosaic DB"))
-  .catch((err) => console.error("❌ MongoDB Connection Error:", err));
+  .then(() => console.log("Connected to seed database"))
+  .catch((err) => console.error("MongoDB connection error:", err));
 
 const categorySchema = new mongoose.Schema({
   name: String,
   slug: String,
-  isActive: { type: Boolean, default: true }
+  isActive: { type: Boolean, default: true },
 });
 
 const ProductCategory = mongoose.model("productcategories", categorySchema);
@@ -23,20 +31,20 @@ async function seed() {
 
   await ProductCategory.insertMany([
     { name: "Electronics", slug: "electronics" },
-    { name: "Fashion", slug: "fashion" }
+    { name: "Fashion", slug: "fashion" },
   ]);
 
   await ServiceCategory.insertMany([
     { name: "Plumbing", slug: "plumbing" },
-    { name: "Home Cleaning", slug: "home-cleaning" }
+    { name: "Home Cleaning", slug: "home-cleaning" },
   ]);
 
   await FoodCategory.insertMany([
     { name: "Restaurant", slug: "restaurant" },
-    { name: "Bakery", slug: "bakery" }
+    { name: "Bakery", slug: "bakery" },
   ]);
 
-  console.log("✅ Dummy categories inserted into mosaic DB!");
+  console.log("Dummy categories inserted into seed database.");
   mongoose.connection.close();
 }
 


### PR DESCRIPTION
## Summary
- Added the vendor plan entitlement and subscription lifecycle audit for issue #76.
- Documented upload/storage lifecycle controls and seed/local bootstrap guardrails for issues #71 and #70.
- Removed the hardcoded MongoDB URI from the current category seed script and added an explicit ALLOW_SEED_RESET guard before destructive category resets.
- Linked the new audits from the backend docs hub and documented local seed reset usage in SETUP.md.

## Validation
- npm run test:contract
- node --test tests/vendor/vendor-onboarding-upload-mime.test.js tests/vendor/listing-tier-limits.test.js tests/service/service-publication-visibility.test.js
- node seed/seedCategories.js without ALLOW_SEED_RESET=true exits before connecting
- seed directory scan found no hardcoded mongodb+srv, Stripe key, password, token, or secret values in current seed files

## Notes
- No live billing, Stripe subscription, webhook, pricing, or entitlement behavior changed.
- No storage provider migration was performed.
- Rotate any credential that ever appeared in a tracked or shared seed script.

Closes #76
Closes #70
Closes #71