### PR TITLE
Release staging: vendor OTP email delivery hardening

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -85,12 +85,34 @@ const OTP_DELIVERY_FAILED_MESSAGES = {
         'Your account still needs verification, but we could not send the verification email. Please try again later.',
 };
 
-function respondOtpDeliveryFailed(res, context) {
-    return res.status(502).json({
+function respondOtpDeliveryFailed(res, context, { user } = {}) {
+    const body = {
         success: false,
         code: 'OTP_DELIVERY_FAILED',
         message: OTP_DELIVERY_FAILED_MESSAGES[context],
-    });
+        otpPending: true,
+    };
+
+    if (user) {
+        body.user = {
+            email: user.email,
+            role: user.role,
+        };
+    }
+
+    if (context === 'register') {
+        body.accountCreated = true;
+        res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
+    }
+
+    return res.status(502).json(body);
+}
+
+function logOtpDeliveryFailure(context, emailError) {
+    const reason = emailError && emailError.message
+        ? String(emailError.message)
+        : 'Unknown email error';
+    console.error(`Auth OTP email delivery failed (${context}):`, reason);
 }
 
 exports.registerUser = async (req, res) => {
@@ -130,10 +152,12 @@ exports.registerUser = async (req, res) => {
         await newUser.save();
 
         try {
-            await sendOtpEmail(email, otp);
+            await sendOtpEmail(email, otp, 'register');
         } catch (emailError) {
-            console.error('Failed to send OTP email:', emailError);
-            return respondOtpDeliveryFailed(res, 'register');
+            logOtpDeliveryFailure('register', emailError);
+            return respondOtpDeliveryFailed(res, 'register', {
+                user: { email, role: safeRole },
+            });
         }
 
         res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
@@ -243,10 +267,10 @@ exports.resendOtp = async (req, res) => {
         await user.save();
 
         try {
-            await sendOtpEmail(user.email, otp);
+            await sendOtpEmail(user.email, otp, 'resend');
         } catch (emailError) {
-            console.error('Failed to send OTP email:', emailError);
-            return respondOtpDeliveryFailed(res, 'resend');
+            logOtpDeliveryFailure('resend', emailError);
+            return respondOtpDeliveryFailed(res, 'resend', { user });
         }
 
         res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));
@@ -408,10 +432,10 @@ exports.loginUser = async (req, res) => {
             await user.save();
 
             try {
-                await sendOtpEmail(user.email, otp);
+                await sendOtpEmail(user.email, otp, 'unverifiedLogin');
             } catch (emailError) {
-                console.error('Failed to send OTP email:', emailError);
-                return respondOtpDeliveryFailed(res, 'unverifiedLogin');
+                logOtpDeliveryFailure('unverifiedLogin', emailError);
+                return respondOtpDeliveryFailed(res, 'unverifiedLogin', { user });
             }
 
             res.cookie('otpPending', 'true', getCookieOptions(10 * 60 * 1000));

--- a/docs/AUTH_FLOW.md
+++ b/docs/AUTH_FLOW.md
@@ -12,7 +12,7 @@ Implementation reference for Mosaic Biz Hub backend auth. Documents **actual cod
 | Controllers | [`controllers/userController.js`](../controllers/userController.js), [`controllers/authController.js`](../controllers/authController.js) |
 | Middleware | [`middlewares/authenticate.js`](../middlewares/authenticate.js), role gates in [`middlewares/`](../middlewares/) |
 | Model | [`models/User.js`](../models/User.js) |
-| Helpers | [`utils/cookieHelper.js`](../utils/cookieHelper.js), [`utils/toPublicAuthUser.js`](../utils/toPublicAuthUser.js) |
+| Helpers | [`utils/cookieHelper.js`](../utils/cookieHelper.js), [`utils/toPublicAuthUser.js`](../utils/toPublicAuthUser.js), [`utils/authEmailDelivery.js`](../utils/authEmailDelivery.js), [`utils/mailer.js`](../utils/mailer.js) |
 | Tests | [`tests/auth/`](../tests/auth/) |
 
 ---
@@ -48,7 +48,7 @@ Auth is **stateless JWT** with optional **HTTP-only cookies**. There is no serve
 7. `sendOtpEmail(email, otp)` — OTP delivered by **email** (Nodemailer + Gmail SMTP).
 8. On successful send: `otpPending` cookie set (10 min, via `getCookieOptions`).
 9. Returns **201** with message *"OTP sent to email"* — no JWT until OTP verified.
-10. On SMTP failure after user save: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', message: '...' }` — account preserved; no `otpPending` cookie; user may call `POST /api/users/resend-otp` after mail recovery.
+10. On SMTP failure after user save: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', message: '...', otpPending: true, accountCreated: true, user: { email, role } }` — account preserved; `otpPending` cookie set; user may call `POST /api/users/resend-otp` after mail recovery.
 
 ### Diagram
 
@@ -107,14 +107,14 @@ OTP is used for **email verification after registration** and for **re-verificat
 - Rejects if user not found, deleted, blocked, or already verified.
 - Generates new OTP, updates hash/expiry, emails OTP.
 - On successful send: sets `otpPending` cookie, returns **200**.
-- On SMTP failure after OTP saved: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED' }` — no `otpPending` cookie; OTP hash remains in DB for verify/resend after recovery.
+- On SMTP failure after OTP saved: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', otpPending: true, user: { email, role } }` — OTP hash remains in DB for verify/resend after recovery.
 
 ### Login-triggered OTP
 
 If `loginUser` finds valid credentials but `!user.isOtpVerified`, it generates a **new** OTP, saves hash/expiry, then emails OTP.
 
 - On successful send: sets `otpPending`, returns **403** with `otpPending: true` (no JWT).
-- On SMTP failure: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED' }` — no session, no `otpPending` cookie; account preserved for resend.
+- On SMTP failure: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', otpPending: true, user: { email, role } }` — no session; account preserved for resend.
 
 ---
 

--- a/tests/auth/otp-email-delivery.test.js
+++ b/tests/auth/otp-email-delivery.test.js
@@ -155,6 +155,8 @@ test('registerUser returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async 
   }
   SavingMockUser.findOne = async () => null;
 
+  const vendorBody = { ...registerBody, role: 'business_owner' };
+
   const userController = withMocks(userControllerPath, {
     ...buildControllerMocks({
       mailer: {
@@ -167,13 +169,17 @@ test('registerUser returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async 
   });
 
   const res = createResponse();
-  await userController.registerUser({ body: registerBody }, res);
+  await userController.registerUser({ body: vendorBody }, res);
 
   assert.equal(res.statusCode, 502);
   assert.equal(res.body.success, false);
   assert.equal(res.body.code, 'OTP_DELIVERY_FAILED');
   assert.match(res.body.message, /account was created/i);
-  assert.equal(res.cookies.otpPending, undefined);
+  assert.equal(res.body.otpPending, true);
+  assert.equal(res.body.accountCreated, true);
+  assert.equal(res.body.user.email, vendorBody.email);
+  assert.equal(res.body.user.role, 'business_owner');
+  assert.equal(res.cookies.otpPending, 'true');
   assert.ok(savedUser && savedUser.saveCalled, 'unverified account should be preserved');
   assertNoOtpInBody(res.body);
 });
@@ -202,6 +208,9 @@ test('resendOtp returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () 
   assert.equal(res.body.success, false);
   assert.equal(res.body.code, 'OTP_DELIVERY_FAILED');
   assert.match(res.body.message, /try again later/i);
+  assert.equal(res.body.otpPending, true);
+  assert.equal(res.body.user.email, unverifiedUser.email);
+  assert.equal(res.body.user.role, unverifiedUser.role);
   assert.equal(res.cookies.otpPending, undefined);
   assertNoOtpInBody(res.body);
 });
@@ -259,6 +268,9 @@ test('loginUser returns OTP_DELIVERY_FAILED for unverified user when sendOtpEmai
     res.body.message,
     'Your account still needs verification, but we could not send the verification email. Please try again later.'
   );
+  assert.equal(res.body.otpPending, true);
+  assert.equal(res.body.user.email, unverifiedUser.email);
+  assert.equal(res.body.user.role, unverifiedUser.role);
   assert.equal(res.cookies.otpPending, undefined);
   assert.equal(res.authCookies, null);
   assert.equal(getSetAuthCookiesCalled(), false);

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -14,6 +14,7 @@ const {
   registerUser,
   verifyRegistrationOtp,
 } = require('./helpers/factories');
+const { setOtpEmailFailCount } = require('./helpers/providerStubs');
 const User = require('../../models/User');
 
 test.before(async () => {
@@ -128,4 +129,61 @@ test('register sets otpPending cookie', async () => {
   const cookies = parseCookies(res.headers['set-cookie']);
   assert.equal(cookies.otpPending, 'true');
   assert.ok(email);
+});
+
+test('business_owner register OTP delivery failure → resend → verify → login → auth/check', async () => {
+  setOtpEmailFailCount(1);
+
+  const agent = createAgent(getApp());
+  const password = 'Secret123!';
+  const email = `business_owner-${Date.now()}-${Math.random().toString(16).slice(2)}@example.test`;
+  const mobile = `+1415555${String(Date.now()).slice(-4)}`;
+
+  const registerRes = await agent.post('/api/users/register').send({
+    name: 'business_owner Integration',
+    email,
+    password,
+    mobile,
+    role: 'business_owner',
+  });
+
+  assert.equal(registerRes.status, 502);
+  assert.equal(registerRes.body.code, 'OTP_DELIVERY_FAILED');
+  assert.equal(registerRes.body.accountCreated, true);
+  assert.equal(registerRes.body.otpPending, true);
+  assert.equal(registerRes.body.user.role, 'business_owner');
+  assert.equal(registerRes.body.user.email, email);
+
+  const cookies = parseCookies(registerRes.headers['set-cookie']);
+  assert.equal(cookies.otpPending, 'true');
+
+  const resendRes = await agent.post('/api/users/resend-otp').send({ email });
+  assert.equal(resendRes.status, 200);
+  assert.equal(resendRes.body.success, true);
+
+  const verifyRes = await verifyRegistrationOtp(agent, email);
+  assert.equal(verifyRes.status, 200);
+  assert.equal(verifyRes.body.user.role, 'business_owner');
+
+  const loginRes = await login(agent, email, password);
+  assert.equal(loginRes.status, 200);
+  assert.equal(loginRes.body.user.role, 'business_owner');
+
+  const authCheck = await agent.get('/api/users/auth/check');
+  assert.equal(authCheck.status, 200);
+  assert.equal(authCheck.body.user.role, 'business_owner');
+  assert.equal(authCheck.body.user.isOtpVerified, true);
+});
+
+test('verify-otp rejects invalid OTP with 400', async () => {
+  const agent = createAgent(getApp());
+  const { email } = await registerUser(agent, { role: 'business_owner' });
+
+  const verifyRes = await agent.post('/api/users/verify-otp').send({
+    email,
+    otp: '000000',
+  });
+
+  assert.equal(verifyRes.status, 400);
+  assert.equal(verifyRes.body.success, false);
 });

--- a/tests/integration/helpers/providerStubs.js
+++ b/tests/integration/helpers/providerStubs.js
@@ -4,9 +4,18 @@ const { captureOtp } = require('./otpCapture');
 
 let originalLoad = null;
 let stripeShouldFail = false;
+let otpEmailFailCount = 0;
 
 function setStripeShouldFail(value) {
   stripeShouldFail = Boolean(value);
+}
+
+function setOtpEmailFailCount(count) {
+  otpEmailFailCount = Math.max(0, Number(count) || 0);
+}
+
+function resetOtpEmailFailCount() {
+  otpEmailFailCount = 0;
 }
 
 function createStripeClient() {
@@ -73,6 +82,12 @@ function createStripeClient() {
 function createMailerStub() {
   return {
     sendOtpEmail: async (email, otp) => {
+      if (otpEmailFailCount > 0) {
+        otpEmailFailCount -= 1;
+        const err = new Error('SMTP connection failed (integration stub)');
+        err.code = 'EMAIL_DELIVERY_FAILED';
+        throw err;
+      }
       captureOtp(email, otp);
     },
     sendWelcomeEmail: async () => {},
@@ -117,6 +132,8 @@ function installProviderStubs() {
 module.exports = {
   installProviderStubs,
   setStripeShouldFail,
+  setOtpEmailFailCount,
+  resetOtpEmailFailCount,
   resetStripeStub: () => {
     stripeShouldFail = false;
   },

--- a/tests/integration/setup/harness.js
+++ b/tests/integration/setup/harness.js
@@ -3,6 +3,7 @@ const { MongoMemoryServer } = require('mongodb-memory-server');
 const {
   installProviderStubs,
   resetStripeStub,
+  resetOtpEmailFailCount,
 } = require('../helpers/providerStubs');
 const { resetOtpCapture } = require('../helpers/otpCapture');
 
@@ -64,6 +65,7 @@ async function startHarness() {
 async function resetDatabase() {
   resetOtpCapture();
   resetStripeStub();
+  resetOtpEmailFailCount();
 
   if (mongoose.connection.readyState !== 1) {
     return;

--- a/tests/utils/auth-email-delivery.test.js
+++ b/tests/utils/auth-email-delivery.test.js
@@ -1,0 +1,117 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  isAuthEmailConfigured,
+  deliverAuthOtpEmail,
+} = require('../../utils/authEmailDelivery');
+
+const deliveryPath = path.resolve(__dirname, '../../utils/authEmailDelivery.js');
+
+const originalMailUser = process.env.MAIL_USER;
+const originalMailPassword = process.env.MAIL_PASSWORD;
+
+function restoreMailEnv() {
+  if (originalMailUser === undefined) {
+    delete process.env.MAIL_USER;
+  } else {
+    process.env.MAIL_USER = originalMailUser;
+  }
+  if (originalMailPassword === undefined) {
+    delete process.env.MAIL_PASSWORD;
+  } else {
+    process.env.MAIL_PASSWORD = originalMailPassword;
+  }
+}
+
+test('isAuthEmailConfigured returns false when MAIL_USER or MAIL_PASSWORD missing', () => {
+  process.env.MAIL_USER = '';
+  process.env.MAIL_PASSWORD = 'secret';
+  assert.equal(isAuthEmailConfigured(), false);
+
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = '';
+  assert.equal(isAuthEmailConfigured(), false);
+
+  restoreMailEnv();
+});
+
+test('isAuthEmailConfigured returns true when both env vars are set', () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+  assert.equal(isAuthEmailConfigured(), true);
+  restoreMailEnv();
+});
+
+test('deliverAuthOtpEmail returns email_not_configured when SMTP not configured', async () => {
+  process.env.MAIL_USER = '';
+  process.env.MAIL_PASSWORD = '';
+
+  const warnLogs = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnLogs.push(args.join(' '));
+
+  const result = await deliverAuthOtpEmail({
+    context: 'register',
+    send: async () => {
+      throw new Error('should not run');
+    },
+  });
+
+  console.warn = originalWarn;
+  restoreMailEnv();
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, 'email_not_configured');
+  assert.ok(warnLogs.some((line) => line.includes('register')));
+});
+
+test('deliverAuthOtpEmail returns sent on success', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+
+  const result = await deliverAuthOtpEmail({
+    context: 'resend',
+    send: async () => {},
+  });
+
+  restoreMailEnv();
+
+  assert.equal(result.sent, true);
+  assert.equal(result.skipped, false);
+});
+
+test('deliverAuthOtpEmail logs message only on failure', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
+
+  const errorLogs = [];
+  const originalError = console.error;
+  console.error = (...args) => errorLogs.push(args.join(' '));
+
+  const result = await deliverAuthOtpEmail({
+    context: 'unverifiedLogin',
+    send: async () => {
+      throw new Error('EAUTH invalid credentials');
+    },
+  });
+
+  console.error = originalError;
+  restoreMailEnv();
+
+  assert.equal(result.sent, false);
+  assert.equal(result.skipped, false);
+  assert.equal(result.error, 'EAUTH invalid credentials');
+  assert.ok(errorLogs.some((line) => line.includes('unverifiedLogin')));
+  assert.ok(!errorLogs.some((line) => line.includes('app-password')));
+});
+
+test('authEmailDelivery source avoids logging credential values', () => {
+  const source = fs.readFileSync(deliveryPath, 'utf8');
+  assert.ok(source.includes('err.message'));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_PASSWORD/));
+  assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_USER/));
+});

--- a/utils/authEmailDelivery.js
+++ b/utils/authEmailDelivery.js
@@ -1,0 +1,36 @@
+/**
+ * Auth OTP email delivery with SMTP preflight.
+ * Never logs secrets, OTP values, or full error payloads.
+ */
+
+function isAuthEmailConfigured() {
+  return Boolean(
+    process.env.MAIL_USER && String(process.env.MAIL_USER).trim()
+    && process.env.MAIL_PASSWORD && String(process.env.MAIL_PASSWORD).trim()
+  );
+}
+
+/**
+ * @param {{ context: string, send: () => Promise<void> }} options
+ * @returns {Promise<{ sent: boolean, skipped?: boolean, reason?: string, error?: string }>}
+ */
+async function deliverAuthOtpEmail({ context, send }) {
+  if (!isAuthEmailConfigured()) {
+    console.warn(`Auth OTP email skipped (${context}): MAIL_USER/MAIL_PASSWORD not configured`);
+    return { sent: false, skipped: true, reason: 'email_not_configured' };
+  }
+
+  try {
+    await send();
+    return { sent: true, skipped: false };
+  } catch (err) {
+    const message = err && err.message ? String(err.message) : 'Unknown email error';
+    console.error(`Auth OTP email delivery failed (${context}):`, message);
+    return { sent: false, skipped: false, error: message };
+  }
+}
+
+module.exports = {
+  isAuthEmailConfigured,
+  deliverAuthOtpEmail,
+};

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -1,15 +1,56 @@
 const nodemailer = require('nodemailer');
 const { buildFrontendUrl } = require('./frontendUrl');
+const { deliverAuthOtpEmail } = require('./authEmailDelivery');
 
-const transporter = nodemailer.createTransport({
-  service: 'gmail',
-  auth: {
-    user: process.env.MAIL_USER,     // your email
-    pass: process.env.MAIL_PASSWORD, // app password
-  },
-});
+let transporter = null;
+let verifyPromise = null;
 
-exports.sendOtpEmail = async (to, otp) => {
+function getTransporter() {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.MAIL_USER,
+        pass: process.env.MAIL_PASSWORD,
+      },
+    });
+  }
+  return transporter;
+}
+
+function verifyTransporterOnce() {
+  if (!verifyPromise) {
+    verifyPromise = getTransporter().verify().catch((err) => {
+      verifyPromise = null;
+      throw err;
+    });
+  }
+  return verifyPromise;
+}
+
+async function sendMailWithAuthDelivery(context, mailOptions) {
+  const delivery = await deliverAuthOtpEmail({
+    context,
+    send: async () => {
+      await verifyTransporterOnce();
+      await getTransporter().sendMail(mailOptions);
+    },
+  });
+
+  if (delivery.skipped) {
+    const err = new Error('Auth email not configured');
+    err.code = 'EMAIL_NOT_CONFIGURED';
+    throw err;
+  }
+
+  if (!delivery.sent) {
+    const err = new Error(delivery.error || 'Auth email delivery failed');
+    err.code = 'EMAIL_DELIVERY_FAILED';
+    throw err;
+  }
+}
+
+exports.sendOtpEmail = async (to, otp, context = 'register') => {
   const mailOptions = {
     from: `"Mosaic Biz Hub" <${process.env.MAIL_USER}>`,
     to,
@@ -17,7 +58,7 @@ exports.sendOtpEmail = async (to, otp) => {
     text: `Your OTP is ${otp}. It will expire in 10 minutes.`,
   };
 
-  await transporter.sendMail(mailOptions);
+  await sendMailWithAuthDelivery(context, mailOptions);
 };
 
 exports.sendPasswordResetOtpEmail = async (to, otp) => {
@@ -28,7 +69,7 @@ exports.sendPasswordResetOtpEmail = async (to, otp) => {
     text: `Your password reset OTP is ${otp}. It will expire in 10 minutes.`,
   };
 
-  await transporter.sendMail(mailOptions);
+  await sendMailWithAuthDelivery('passwordReset', mailOptions);
 };
 
 exports.sendWelcomeEmail = async (to, firstName, role) => {
@@ -39,7 +80,6 @@ exports.sendWelcomeEmail = async (to, firstName, role) => {
     let html = '';
 
     if (role === 'business_owner') {
-      // Vendor Email
       subject = 'Welcome to Mosaic Biz Hub — Grow your business and build generational wealth';
 
       html = `
@@ -73,7 +113,6 @@ exports.sendWelcomeEmail = async (to, firstName, role) => {
       `;
 
     } else {
-      // Customer Email
       subject = "You just joined a movement — here's what happens next";
 
       html = `
@@ -89,7 +128,7 @@ exports.sendWelcomeEmail = async (to, firstName, role) => {
           <h3>Here's what you can do right now:</h3>
           <ul>
             <li>Browse categories like beauty, wellness, food, fashion, and services.</li>
-            <li>Discover unique vendors you won’t find elsewhere.</li>
+            <li>Discover unique vendors you won't find elsewhere.</li>
             <li>Shop with confidence — every listing is verified.</li>
           </ul>
 
@@ -120,59 +159,10 @@ exports.sendWelcomeEmail = async (to, firstName, role) => {
 
     console.log(`Sending ${role || 'customer'} welcome email`);
 
-    await transporter.sendMail(mailOptions);
+    await getTransporter().sendMail(mailOptions);
 
   } catch (error) {
     console.error('Error sending welcome email:', error);
-    throw error; // optional: rethrow if you want upstream handling
+    throw error;
   }
 };
-
-// exports.sendWelcomeEmail = async (to, firstName) => {
-//   const mailOptions = {
-//     from: `"Mosaic Biz Hub" <${process.env.MAIL_USER}>`,
-//     to,
-//     subject: 'Welcome to Mosaic Biz Hub — Grow your business and build generational wealth',
-//     html: `
-//       <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
-//         <p>Hi ${firstName},</p>
-        
-//         <p>Welcome to <strong>Mosaic Biz Hub</strong> — we're glad you joined. You didn't just create an account; you joined a purpose-driven marketplace built to help businesses gain visibility, attract loyal customers, and scale confidently.</p>
-        
-//         <h3>How Mosaic will help your business grow</h3>
-//         <ul>
-//           <li><strong>Get discovered</strong> — curated placement, searchable profiles, and category features that put your business in front of buyers actively looking to support independent brands.</li>
-//           <li><strong>Sell smarter</strong> — conversion-focused storefront tools, simplified onboarding, and clear analytics so you can increase revenue without extra guesswork.</li>
-//           <li><strong>Build credibility</strong> — verified badges, peer reviews, and an outcomes-driven recognition system that increases trust and repeat business.</li>
-//           <li><strong>Access resources and networks</strong> — including educational materials, mentorship initiatives, and partnership opportunities that facilitate connections to funding, expert guidance, and expanded markets.</li>
-//           <li><strong>Track progress</strong> — an easy vendor dashboard with starter KPIs so you can measure growth, test offers, and celebrate milestones.</li>
-//         </ul>
-        
-//         <h3>How joining supports our community and long-term wealth</h3>
-//         <ul>
-//           <li>We design features to strengthen local economies and circulate value within neighborhoods.</li>
-//           <li>We amplify founder stories through editorial spotlights and community events that drive customers to mission-led businesses.</li>
-//           <li>We focus on sustainable growth: more customers, stronger brands, and steps toward generational wealth for business owners and their families.</li>
-//         </ul>
-        
-//         <h3>Quick next steps</h3>
-//         <ol>
-//           <li>Complete your profile and upload a primary product or service to improve discoverability.</li>
-//           <li>Explore your vendor dashboard and review the starter analytics we prepared for you.</li>
-//           <li>Reply to this email with the single biggest challenge you want to solve in the next 90 days so we can connect you to targeted resources and partners.</li>
-//         </ol>
-        
-//         <p>Your feedback shapes Mosaic Biz Hub. If you want to be an early voice in building this movement, reply now and tell us where to focus first.</p>
-        
-//         <p>Welcome to the movement — let's build something that lasts.</p>
-        
-//         <p>Warm regards,<br>
-//         <strong>Bryan Harris</strong><br>
-//         Founder, Mosaic Biz Hub</p>
-//       </div>
-//     `,
-//   };
-
-//   await transporter.sendMail(mailOptions);
-// };
-


### PR DESCRIPTION
## Summary
Promote staging to main with the vendor registration email verification fix (PR #160).

- Add auth OTP email preflight and safe logging via `utils/authEmailDelivery.js`
- Enrich `OTP_DELIVERY_FAILED` responses with `otpPending`, `accountCreated`, and `user` for frontend resend recovery
- Lazy SMTP transporter with verify-once in `utils/mailer.js`
- Integration test: business_owner register (mail fail) -> resend -> verify -> login -> auth/check

## Commits included
- `92a624e` Harden vendor OTP email delivery and enrich failure responses for resend recovery.
- `5b5623f` Merge pull request #160 from Techware-Hut/fix/vendor-registration-email-verification-flow

## Test plan
- [x] npm test
- [x] npm run test:integration
- [x] npm run test:contract
- [ ] Confirm production EB has MAIL_USER + MAIL_PASSWORD (Google App Password) before/after deploy
- [ ] Smoke: POST /api/users/register (business_owner) -> verify-otp -> login -> auth/check

## Env vars (names only)
MAIL_USER, MAIL_PASSWORD, JWT_SECRET, MONGODB_URI, FRONTEND_URL, CORS_ORIGINS, COOKIE_DOMAIN, COOKIE_SECURE, COOKIE_SAMESITE

## Rollback
Revert merge commit on main and redeploy previous Elastic Beanstalk application version if needed.

Made with [Cursor](https://cursor.com)