### PR TITLE
Promote staging: auth email readiness and smoke tooling

### DIFF
--- a/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
+++ b/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
@@ -1,0 +1,122 @@
+# Production Auth Email Delivery Investigation — 2026-06-29
+
+## Scope
+
+OTP registration, forgot-password, and resend-otp mail delivery on production API. No deploy performed. No secrets, OTPs, or credentials printed or committed.
+
+## Branch and commit
+
+| Item | Value |
+| --- | --- |
+| Feature branch | `fix/production-auth-email-delivery` |
+| Base (staging) | `370bb42df6f856ab39b327678d54e3dca6544bf9` |
+| Production live commit (probed) | `90d7292` (`GET /api/build-info`) |
+| Production API | `https://api.mosaicbizhub.com` |
+
+## Files inspected
+
+| File | Purpose |
+| --- | --- |
+| `utils/mailer.js` | Gmail Nodemailer transporter, OTP + reset mail |
+| `utils/authEmailDelivery.js` | `MAIL_USER`/`MAIL_PASSWORD` gate, safe error logging |
+| `controllers/userController.js` | Register/resend 502; forgot-password 500 on mail failure |
+| `routes/userRoutes.js` | Rate limiters (5 req / 15 min / IP) |
+| `routes/healthRoutes.js` | Added `authEmail.configured` on `/api/ready` (post-merge, pre-deploy on prod) |
+| `scripts/auth-email-smoke.ps1` | Spaced production probes (status codes only) |
+| `docs/production-env-checklist.md` | EB mail setup, probe matrix, restart requirement |
+| `tests/health/health-readiness.test.js` | `authEmail.configured` tests |
+| `tests/auth/otp-email-delivery.test.js` | 502 OTP delivery contract |
+| `tests/utils/auth-email-delivery.test.js` | Env gate tests |
+
+## Required env var names (auth OTP)
+
+| Variable | Required for auth OTP |
+| --- | --- |
+| `MAIL_USER` | Yes |
+| `MAIL_PASSWORD` | Yes (Google App Password) |
+
+`ADMIN_EMAIL` is **not** required for auth OTP (admin notifications only).
+
+## EB production env names to verify
+
+**P0:** `MAIL_USER`, `MAIL_PASSWORD`
+
+**P1 (other mail):** `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL`
+
+EB application: `mosaic-biz-hub-backend`  
+EB environment: `mosaic-backend-env` (us-east-1)
+
+AWS CLI was **not available** in the investigation session. Operator must run:
+
+```powershell
+aws elasticbeanstalk describe-configuration-settings `
+  --application-name mosaic-biz-hub-backend `
+  --environment-name mosaic-backend-env `
+  --region us-east-1 `
+  --query "ConfigurationSettings[0].OptionSettings[?Namespace=='aws:elasticbeanstalk:application:environment'].[OptionName,Value]" `
+  --output table
+```
+
+Redact values before sharing. After setting mail vars: **restart EB environment**.
+
+CloudWatch log grep (safe signatures only): `Auth OTP email skipped`, `MAIL_USER/MAIL_PASSWORD not configured`, `Auth OTP email delivery failed`, `Failed to send password reset OTP email`, `EAUTH`, `535`, `Invalid login`.
+
+## Root-cause assessment
+
+| Rank | Cause | Status |
+| --- | --- | --- |
+| 1 | Missing/invalid `MAIL_USER` or `MAIL_PASSWORD` on EB | **Confirmed likely** — production returns **502** on register/resend (SMTP delivery failure path, not missing-route) |
+| 2 | Invalid Gmail App Password / revoked credentials | **Possible** — same symptom; confirm via EB logs (`EAUTH`, `535`) |
+| 3 | Rate limiting from burst probes | **Not primary** in this run — no **429** observed (10s spacing used) |
+| 4 | EB outbound SMTP network block | **Unverified** — requires operator network test to `smtp.gmail.com:587` |
+| 5 | Application code regression | **Ruled out** — `npm test` 438 pass; failure contract matches design |
+
+**Conclusion:** Infrastructure/configuration blocker. Application correctly surfaces SMTP failure. Production cannot deliver auth email until EB mail env is set with valid Gmail App Password and environment is restarted.
+
+## Commands / probes run
+
+```powershell
+git checkout staging && git pull origin staging
+git checkout -b fix/production-auth-email-delivery
+npm test
+node --test tests/auth/otp-email-delivery.test.js tests/utils/auth-email-delivery.test.js
+node --test tests/health/health-readiness.test.js
+Invoke-RestMethod https://api.mosaicbizhub.com/api/build-info
+Invoke-RestMethod https://api.mosaicbizhub.com/api/ready
+./scripts/auth-email-smoke.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -DisposableDomain example.invalid -ProbeDelaySeconds 10
+```
+
+## Route / status table (production probes 2026-06-29)
+
+| Probe | Route | Status | Expected (mail working) | Result |
+| --- | --- | ---: | ---: | --- |
+| Build identity | `GET /api/build-info` | 200 | 200 | Pass |
+| Readiness | `GET /api/ready` | 200 | 200 | Pass |
+| Customer forgot-password | `POST /api/users/forgot-password` | — | 200 | Skip (no `SMOKE_TEST_CUSTOMER_EMAIL`) |
+| Vendor forgot-password | `POST /api/users/forgot-password` | — | 200 | Skip (no `SMOKE_TEST_VENDOR_EMAIL`) |
+| Customer register (disposable) | `POST /api/users/register` | **502** | 201 | **Fail** — OTP delivery blocked |
+| Vendor register (disposable) | `POST /api/users/register` | **502** | 201 | **Fail** — OTP delivery blocked |
+| Resend OTP (disposable customer) | `POST /api/users/resend-otp` | **502** | 200 | **Fail** — OTP delivery blocked |
+| Unknown forgot-password | `POST /api/users/forgot-password` | 200 | 200 | Pass (anti-enumeration) |
+
+## Email delivery status
+
+**Still blocked** on production (`90d7292`). Register and resend return **502** `OTP_DELIVERY_FAILED`. Inbox delivery not confirmed.
+
+## Code changes in this branch (operability, no auth behavior change)
+
+1. `GET /api/ready` includes `authEmail: { configured: boolean }` (env presence only, no SMTP probe).
+2. `scripts/auth-email-smoke.ps1` — spaced status-code probes.
+3. `docs/production-env-checklist.md` — EB restart, probe matrix, `ADMIN_EMAIL` clarification.
+
+## Secrets confirmation
+
+No env values, OTPs, passwords, tokens, SMTP credentials, or email contents were printed in logs or committed to git.
+
+## Recommended next actions
+
+1. **Operator (P0):** Set `MAIL_USER` and `MAIL_PASSWORD` (Google App Password) on `mosaic-backend-env`; restart EB.
+2. **Operator:** Grep CloudWatch for SMTP signatures listed above.
+3. **Deploy:** Merge this branch to `staging`, promote/deploy so `/api/ready` exposes `authEmail.configured` for quick env checks.
+4. **Re-probe:** After EB fix + optional deploy, run `./scripts/auth-email-smoke.ps1` with known `SMOKE_TEST_CUSTOMER_EMAIL` / `SMOKE_TEST_VENDOR_EMAIL` and a disposable domain you control; wait ≥15 min if prior burst caused **429**.
+5. **Long-term:** Consider transactional provider (SES/SendGrid) with verified `mosaicbizhub.com` sender if Gmail limits persist.

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -70,20 +70,41 @@ Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-regist
 |----------|--------------|
 | `MAIL_USER` | OTP, order, onboarding mail (Gmail address; also used as From header) |
 | `MAIL_PASSWORD` | SMTP auth — must be a **Google App Password**, not the account login password |
-| `ADMIN_EMAIL` | Admin notifications |
+| `ADMIN_EMAIL` | Admin notifications (vendor onboarding, contact form) — **not** required for auth OTP |
 | `SUPPORT_EMAIL` | Optional; email templates |
 | `APP_NAME` | Optional branding |
 | `APP_URL` | Optional order email links |
+
+**After changing mail env vars on EB:** restart the environment (or redeploy) so Node processes reload `process.env`. Env-only updates do not always reach running instances without restart.
+
+**Readiness probe:** After deploy of `authEmail.configured` on `GET /api/ready`, `authEmail.configured: false` means `MAIL_USER` or `MAIL_PASSWORD` is missing/empty in the running process (names only — no SMTP probe, no secrets).
 
 ### Auth OTP email (registration / resend / unverified login)
 
 OTP is sent **by email only** via Nodemailer + Gmail (`utils/mailer.js`). There is no SMS/mobile OTP channel.
 
+**Auth OTP requires only `MAIL_USER` and `MAIL_PASSWORD`.** `ADMIN_EMAIL` does not gate registration or forgot-password OTP delivery.
+
 **Production inbox smoke (disposable test account only):**
 
-1. Set `MAIL_USER` and `MAIL_PASSWORD` (App Password) on Elastic Beanstalk; redeploy.
-2. `POST /api/users/register` with a disposable email you control — expect **201** and inbox delivery within ~2 minutes.
-3. Do **not** paste OTP values or credentials into tickets, Slack, or logs.
+1. Set `MAIL_USER` and `MAIL_PASSWORD` (App Password) on Elastic Beanstalk; **restart** the environment.
+2. Run spaced probes (≥30s apart to avoid 429 rate limits): `./scripts/auth-email-smoke.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -DisposableDomain <your-disposable-domain>`
+3. Optional known-account forgot-password: set session-only `SMOKE_TEST_CUSTOMER_EMAIL` and `SMOKE_TEST_VENDOR_EMAIL` before running the script.
+4. `POST /api/users/register` with a disposable email you control — expect **201** and inbox delivery within ~2 minutes.
+5. Do **not** paste OTP values or credentials into tickets, Slack, or logs.
+
+**Spaced probe matrix (status codes only in automation):**
+
+| Probe | Route | Expected on success | Mail failure |
+| --- | --- | ---: | ---: |
+| Customer forgot-password | `POST /api/users/forgot-password` | 200 | 500 |
+| Vendor forgot-password | `POST /api/users/forgot-password` | 200 | 500 |
+| Customer register | `POST /api/users/register` | 201 | 502 `OTP_DELIVERY_FAILED` |
+| Vendor register | `POST /api/users/register` (`role: business_owner`) | 201 | 502 |
+| Resend OTP | `POST /api/users/resend-otp` | 200 | 502 |
+| Unknown forgot-password | `POST /api/users/forgot-password` | 200 (generic body) | 200 (no enumeration) |
+
+Wait **≥15 minutes** after a burst of failed probes that returned **429** before re-running auth email smoke from the same IP.
 
 **When SMTP delivery fails**, auth endpoints return **502** with `code: OTP_DELIVERY_FAILED` (account may still be saved; user can retry via `POST /api/users/resend-otp` after mail recovery).
 

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const { getPublicReleaseInfo } = require('../utils/releaseIdentity');
+const { isAuthEmailConfigured } = require('../utils/authEmailDelivery');
 
 const router = express.Router();
 const SERVICE_NAME = 'mosaic-backend';
@@ -21,6 +22,9 @@ router.get('/ready', (_req, res) => {
   res.status(connected ? 200 : 503).json({
     status: connected ? 'ready' : 'not_ready',
     database: connected ? 'connected' : 'disconnected',
+    authEmail: {
+      configured: isAuthEmailConfigured(),
+    },
     timestamp: new Date().toISOString(),
     release: getPublicReleaseInfo(),
   });

--- a/scripts/auth-email-smoke.ps1
+++ b/scripts/auth-email-smoke.ps1
@@ -1,0 +1,159 @@
+# Auth OTP / forgot-password email delivery smoke — production-safe probes.
+# Logs HTTP status codes only; never prints OTPs, tokens, or response bodies.
+#
+# Usage:
+#   ./scripts/auth-email-smoke.ps1 -ApiBaseUrl https://api.mosaicbizhub.com
+#   ./scripts/auth-email-smoke.ps1 -DisposableDomain your-disposable.testmail.app
+#
+# Optional env (session-only — do not commit):
+#   SMOKE_TEST_CUSTOMER_EMAIL — known customer for forgot-password probe
+#   SMOKE_TEST_VENDOR_EMAIL   — known vendor for forgot-password probe
+
+param(
+    [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "https://api.mosaicbizhub.com" }),
+    [string]$DisposableDomain = $(if ($env:SMOKE_DISPOSABLE_DOMAIN) { $env:SMOKE_DISPOSABLE_DOMAIN } else { "example.invalid" }),
+    [int]$ProbeDelaySeconds = 30
+)
+
+$Base = $ApiBaseUrl.TrimEnd('/')
+$Pass = 0
+$Fail = 0
+$Skip = 0
+
+function Write-ProbePass($msg) { Write-Host "PASS  $msg" -ForegroundColor Green; $script:Pass++ }
+function Write-ProbeFail($msg) { Write-Host "FAIL  $msg" -ForegroundColor Red; $script:Fail++ }
+function Write-ProbeSkip($msg, $reason) { Write-Host "SKIP  $msg - $reason" -ForegroundColor Yellow; $script:Skip++ }
+
+function Get-StatusCode($Uri, $Method = 'GET', $Body = $null) {
+    try {
+        $params = @{
+            Uri             = $Uri
+            Method          = $Method
+            UseBasicParsing = $true
+            ErrorAction     = 'Stop'
+        }
+        if ($Body) {
+            $params.Body = $Body
+            $params.ContentType = 'application/json'
+        }
+        $r = Invoke-WebRequest @params
+        return [int]$r.StatusCode
+    }
+    catch {
+        if ($_.Exception.Response) {
+            return [int]$_.Exception.Response.StatusCode.value__
+        }
+        throw
+    }
+}
+
+function Wait-ProbeDelay {
+    if ($ProbeDelaySeconds -gt 0) {
+        Write-Host "Waiting ${ProbeDelaySeconds}s before next probe (rate-limit spacing)..."
+        Start-Sleep -Seconds $ProbeDelaySeconds
+    }
+}
+
+Write-Host "=== Auth Email Smoke ==="
+Write-Host "API_BASE_URL=$Base"
+Write-Host "PROBE_DELAY_SECONDS=$ProbeDelaySeconds"
+Write-Host ""
+
+# 1. Release identity (status only)
+try {
+    $buildCode = Get-StatusCode "$Base/api/build-info"
+    if ($buildCode -eq 200) { Write-ProbePass "A1 GET /api/build-info ($buildCode)" } else { Write-ProbeFail "A1 GET /api/build-info ($buildCode, expected 200)" }
+}
+catch {
+    Write-ProbeFail "A1 GET /api/build-info (request error)"
+}
+
+Wait-ProbeDelay
+
+# 2. Ready probe (authEmail.configured when deployed)
+try {
+    $readyCode = Get-StatusCode "$Base/api/ready"
+    if ($readyCode -eq 200) { Write-ProbePass "A2 GET /api/ready ($readyCode)" } else { Write-ProbeFail "A2 GET /api/ready ($readyCode, expected 200)" }
+}
+catch {
+    Write-ProbeFail "A2 GET /api/ready (request error)"
+}
+
+Wait-ProbeDelay
+
+# 3. Known customer forgot-password
+$customerEmail = $env:SMOKE_TEST_CUSTOMER_EMAIL
+if ($customerEmail) {
+    $body = @{ email = $customerEmail } | ConvertTo-Json -Compress
+    $code = Get-StatusCode "$Base/api/users/forgot-password" -Method POST -Body $body
+    if ($code -eq 200) { Write-ProbePass "A3 POST forgot-password customer ($code)" } else { Write-ProbeFail "A3 POST forgot-password customer ($code, expected 200)" }
+}
+else {
+    Write-ProbeSkip "A3 POST forgot-password customer", "set SMOKE_TEST_CUSTOMER_EMAIL"
+}
+
+Wait-ProbeDelay
+
+# 4. Known vendor forgot-password
+$vendorEmail = $env:SMOKE_TEST_VENDOR_EMAIL
+if ($vendorEmail) {
+    $body = @{ email = $vendorEmail } | ConvertTo-Json -Compress
+    $code = Get-StatusCode "$Base/api/users/forgot-password" -Method POST -Body $body
+    if ($code -eq 200) { Write-ProbePass "A4 POST forgot-password vendor ($code)" } else { Write-ProbeFail "A4 POST forgot-password vendor ($code, expected 200)" }
+}
+else {
+    Write-ProbeSkip "A4 POST forgot-password vendor", "set SMOKE_TEST_VENDOR_EMAIL"
+}
+
+Wait-ProbeDelay
+
+# 5. Disposable customer registration
+$stamp = Get-Date -Format 'yyyyMMddHHmmss'
+$customerDisposable = "mbh-smoke-customer-$stamp@$DisposableDomain"
+$registerBody = @{
+    name     = 'Smoke Customer'
+    email    = $customerDisposable
+    password = 'SmokeTest1!'
+    mobile   = "+1555555$((Get-Random -Maximum 9999).ToString('0000'))"
+    role     = 'customer'
+} | ConvertTo-Json -Compress
+$code = Get-StatusCode "$Base/api/users/register" -Method POST -Body $registerBody
+if ($code -eq 201) { Write-ProbePass "A5 POST register customer ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A5 POST register customer ($code, OTP delivery failed - check MAIL_USER/MAIL_PASSWORD on EB)" } else { Write-ProbeFail "A5 POST register customer ($code, expected 201)" }
+
+Wait-ProbeDelay
+
+# 6. Disposable vendor registration
+$stamp = Get-Date -Format 'yyyyMMddHHmmss'
+$vendorDisposable = "mbh-smoke-vendor-$stamp@$DisposableDomain"
+$registerBody = @{
+    name     = 'Smoke Vendor'
+    email    = $vendorDisposable
+    password = 'SmokeTest1!'
+    mobile   = "+1555556$((Get-Random -Maximum 9999).ToString('0000'))"
+    role     = 'business_owner'
+} | ConvertTo-Json -Compress
+$code = Get-StatusCode "$Base/api/users/register" -Method POST -Body $registerBody
+if ($code -eq 201) { Write-ProbePass "A6 POST register vendor ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A6 POST register vendor ($code, OTP delivery failed - check MAIL_USER/MAIL_PASSWORD on EB)" } else { Write-ProbeFail "A6 POST register vendor ($code, expected 201)" }
+
+Wait-ProbeDelay
+
+# 7. Resend OTP for disposable customer (from A5 if 201)
+$resendEmail = $customerDisposable
+$body = @{ email = $resendEmail } | ConvertTo-Json -Compress
+$code = Get-StatusCode "$Base/api/users/resend-otp" -Method POST -Body $body
+if ($code -eq 200) { Write-ProbePass "A7 POST resend-otp disposable customer ($code)" } elseif ($code -eq 404) { Write-ProbeSkip "A7 POST resend-otp", "account not created (register may have failed)" } elseif ($code -eq 502) { Write-ProbeFail "A7 POST resend-otp ($code, OTP delivery failed)" } else { Write-ProbeFail "A7 POST resend-otp ($code, expected 200)" }
+
+Wait-ProbeDelay
+
+# 8. Anti-enumeration — unknown forgot-password
+$body = @{ email = 'nonexistent-smoke@example.invalid' } | ConvertTo-Json -Compress
+$code = Get-StatusCode "$Base/api/users/forgot-password" -Method POST -Body $body
+if ($code -eq 200) { Write-ProbePass "A8 POST forgot-password unknown ($code)" } else { Write-ProbeFail "A8 POST forgot-password unknown ($code, expected 200)" }
+
+Write-Host ""
+Write-Host "=== Summary ==="
+Write-Host "PASS=$Pass FAIL=$Fail SKIP=$Skip"
+Write-Host "Confirm inbox delivery manually for probes that returned 200/201 (do not log OTP values)."
+
+if ($Fail -gt 0) { exit 1 }
+exit 0

--- a/scripts/auth-email-smoke.ps1
+++ b/scripts/auth-email-smoke.ps1
@@ -6,8 +6,8 @@
 #   ./scripts/auth-email-smoke.ps1 -DisposableDomain your-disposable.testmail.app
 #
 # Optional env (session-only — do not commit):
-#   SMOKE_TEST_CUSTOMER_EMAIL — known customer for forgot-password probe
-#   SMOKE_TEST_VENDOR_EMAIL   — known vendor for forgot-password probe
+#   SMOKE_TEST_CUSTOMER_EMAIL or MBH_TEST_CUSTOMER_EMAIL — known customer for forgot-password probe
+#   SMOKE_TEST_VENDOR_EMAIL or MBH_TEST_VENDOR_EMAIL   — known vendor for forgot-password probe
 
 param(
     [string]$ApiBaseUrl = $(if ($env:API_BASE_URL) { $env:API_BASE_URL } else { "https://api.mosaicbizhub.com" }),
@@ -54,6 +54,18 @@ function Wait-ProbeDelay {
     }
 }
 
+function Get-TestAccountEmail($smokeVarName, $mbhVarName) {
+    $smoke = [Environment]::GetEnvironmentVariable($smokeVarName)
+    if ($smoke -and [string]::IsNullOrWhiteSpace($smoke) -eq $false) {
+        return $smoke.Trim()
+    }
+    $mbh = [Environment]::GetEnvironmentVariable($mbhVarName)
+    if ($mbh -and [string]::IsNullOrWhiteSpace($mbh) -eq $false) {
+        return $mbh.Trim()
+    }
+    return $null
+}
+
 Write-Host "=== Auth Email Smoke ==="
 Write-Host "API_BASE_URL=$Base"
 Write-Host "PROBE_DELAY_SECONDS=$ProbeDelaySeconds"
@@ -82,27 +94,27 @@ catch {
 Wait-ProbeDelay
 
 # 3. Known customer forgot-password
-$customerEmail = $env:SMOKE_TEST_CUSTOMER_EMAIL
+$customerEmail = Get-TestAccountEmail 'SMOKE_TEST_CUSTOMER_EMAIL' 'MBH_TEST_CUSTOMER_EMAIL'
 if ($customerEmail) {
     $body = @{ email = $customerEmail } | ConvertTo-Json -Compress
     $code = Get-StatusCode "$Base/api/users/forgot-password" -Method POST -Body $body
     if ($code -eq 200) { Write-ProbePass "A3 POST forgot-password customer ($code)" } else { Write-ProbeFail "A3 POST forgot-password customer ($code, expected 200)" }
 }
 else {
-    Write-ProbeSkip "A3 POST forgot-password customer", "set SMOKE_TEST_CUSTOMER_EMAIL"
+    Write-ProbeSkip "A3 POST forgot-password customer", "set SMOKE_TEST_CUSTOMER_EMAIL or MBH_TEST_CUSTOMER_EMAIL"
 }
 
 Wait-ProbeDelay
 
 # 4. Known vendor forgot-password
-$vendorEmail = $env:SMOKE_TEST_VENDOR_EMAIL
+$vendorEmail = Get-TestAccountEmail 'SMOKE_TEST_VENDOR_EMAIL' 'MBH_TEST_VENDOR_EMAIL'
 if ($vendorEmail) {
     $body = @{ email = $vendorEmail } | ConvertTo-Json -Compress
     $code = Get-StatusCode "$Base/api/users/forgot-password" -Method POST -Body $body
     if ($code -eq 200) { Write-ProbePass "A4 POST forgot-password vendor ($code)" } else { Write-ProbeFail "A4 POST forgot-password vendor ($code, expected 200)" }
 }
 else {
-    Write-ProbeSkip "A4 POST forgot-password vendor", "set SMOKE_TEST_VENDOR_EMAIL"
+    Write-ProbeSkip "A4 POST forgot-password vendor", "set SMOKE_TEST_VENDOR_EMAIL or MBH_TEST_VENDOR_EMAIL"
 }
 
 Wait-ProbeDelay

--- a/tests/health/health-readiness.test.js
+++ b/tests/health/health-readiness.test.js
@@ -6,6 +6,22 @@ const Module = require('node:module');
 
 const healthRoutesPath = path.resolve(__dirname, '../../routes/healthRoutes.js');
 
+const originalMailUser = process.env.MAIL_USER;
+const originalMailPassword = process.env.MAIL_PASSWORD;
+
+function restoreMailEnv() {
+  if (originalMailUser === undefined) {
+    delete process.env.MAIL_USER;
+  } else {
+    process.env.MAIL_USER = originalMailUser;
+  }
+  if (originalMailPassword === undefined) {
+    delete process.env.MAIL_PASSWORD;
+  } else {
+    process.env.MAIL_PASSWORD = originalMailPassword;
+  }
+}
+
 function mockResponse() {
   return {
     statusCode: null,
@@ -56,6 +72,8 @@ test('GET /health returns ok without database dependency', () => {
 });
 
 test('GET /ready returns 200 when database is connected', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+  process.env.MAIL_PASSWORD = 'app-password';
   const router = loadHealthRouter({ connection: { readyState: 1 } });
   const handler = getRouteHandler(router, 'get', '/ready');
   const res = mockResponse();
@@ -65,6 +83,22 @@ test('GET /ready returns 200 when database is connected', async () => {
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.status, 'ready');
   assert.equal(res.body.database, 'connected');
+  assert.equal(res.body.authEmail.configured, true);
+  restoreMailEnv();
+});
+
+test('GET /ready reports authEmail.configured false when SMTP env missing', async () => {
+  delete process.env.MAIL_USER;
+  delete process.env.MAIL_PASSWORD;
+  const router = loadHealthRouter({ connection: { readyState: 1 } });
+  const handler = getRouteHandler(router, 'get', '/ready');
+  const res = mockResponse();
+
+  await handler({}, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.authEmail.configured, false);
+  restoreMailEnv();
 });
 
 test('GET /ready returns 503 when database is disconnected', async () => {
@@ -84,4 +118,6 @@ test('healthRoutes source does not expose secrets', () => {
   const source = fs.readFileSync(healthRoutesPath, 'utf8');
   assert.ok(!source.includes('process.env.MONGODB_URI'));
   assert.ok(!source.includes('JWT_SECRET'));
+  assert.ok(!source.includes('MAIL_PASSWORD'));
+  assert.ok(!source.includes('MAIL_USER'));
 });


### PR DESCRIPTION
## Summary
- Expose authEmail.configured on GET /api/ready (env presence only, no secrets)
- Add scripts/auth-email-smoke.ps1 for spaced production OTP/mail probes
- Support MBH_TEST_* email vars as fallback for SMOKE_TEST_* in auth-email smoke
- Document production auth email investigation
- Extend production-env-checklist with EB restart and probe matrix

## Test plan
- [ ] GHA deploy workflow passes on merge
- [ ] GET /api/build-info shows deployed commit
- [ ] GET /api/ready includes authEmail.configured
- [ ] ./scripts/auth-email-smoke.ps1 (status codes only)

Made with [Cursor](https://cursor.com)