### PR TITLE
Promote staging auth SMTP fix to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,11 +79,21 @@ AWS_S3_BUCKET=replace-me
 
 
 
-# Email and notifications (Gmail SMTP via Nodemailer — use a Google App Password for MAIL_PASSWORD)
+# Email and notifications
+# Auth OTP/password-reset mail supports either Gmail fallback or provider-neutral SMTP.
+# Leave MAIL_HOST unset for Gmail fallback. Set MAIL_HOST/MAIL_PORT/MAIL_SECURE for SMTP providers.
 
 MAIL_USER=you@example.com
 
 MAIL_PASSWORD=replace-with-google-app-password
+
+MAIL_HOST=
+
+MAIL_PORT=
+
+MAIL_SECURE=false
+
+MAIL_FROM=
 
 ADMIN_EMAIL=admin@example.com
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,12 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `MAIL_USER` | Yes for email features | SMTP sender/login identity used by mail utilities |
-| `MAIL_PASSWORD` | Yes for email features | Gmail **App Password** (not your Google account login password) for SMTP auth |
+| `MAIL_USER` | Yes for email features | SMTP login identity. When `MAIL_HOST` is unset, auth OTP mail keeps the Gmail fallback. |
+| `MAIL_PASSWORD` | Yes for email features | SMTP password/app password for auth OTP mail and existing mail utilities |
+| `MAIL_HOST` | Optional | Provider-neutral SMTP host for auth OTP/password-reset mail; leave unset for Gmail fallback |
+| `MAIL_PORT` | Optional | SMTP port for provider-neutral auth mail, parsed as a number |
+| `MAIL_SECURE` | Optional | Set `true` for secure SMTP such as port `465`; otherwise false |
+| `MAIL_FROM` | Optional | From header for provider-neutral auth mail; falls back to `MAIL_USER` for Gmail compatibility |
 | `ADMIN_EMAIL` | Recommended | Admin notification recipient for onboarding, category requests, and contact inquiries |
 | `SUPPORT_EMAIL` | Optional | Support/contact email used in outbound templates |
 | `APP_NAME` | Optional | Branding label used in some email content |

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -109,9 +109,9 @@ function respondOtpDeliveryFailed(res, context, { user } = {}) {
 }
 
 function logOtpDeliveryFailure(context, emailError) {
-    const reason = emailError && emailError.message
-        ? String(emailError.message)
-        : 'Unknown email error';
+    const reason = emailError && emailError.code
+        ? `code=${String(emailError.code)}`
+        : 'delivery_failed';
     console.error(`Auth OTP email delivery failed (${context}):`, reason);
 }
 
@@ -312,8 +312,8 @@ exports.forgotPassword = async (req, res) => {
         try {
             await sendPasswordResetOtpEmail(user.email, otp);
         } catch (emailError) {
-            console.error('Failed to send password reset OTP email:', emailError);
-            return res.status(500).json({ success: false, message: 'Failed to send reset OTP' });
+            logOtpDeliveryFailure('passwordReset', emailError);
+            return res.status(200).json(FORGOT_PASSWORD_RESPONSE);
         }
 
         return res.status(200).json(FORGOT_PASSWORD_RESPONSE);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,7 +384,7 @@ Authoritative template: [`.env.example`](../.env.example). Never commit real val
 | Auth | `JWT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `COOKIE_DOMAIN`, `COOKIE_SECURE`, `COOKIE_SAMESITE` | JWT and OAuth |
 | Stripe | `STRIPE_SECRET_KEY`, `STRIPE_ORDER_WEBHOOK_SECRET`, `STRIPE_BUSINESS_DRAFT_WEBHOOK_SECRET`, `STRIPE_SUBSCRIPTION_WEBHOOK_SECRET`, `STRIPE_VENDOR_VERIFICATION_WEBHOOK_SECRET`, `STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET`, `PLATFORM_FEE_CENTS`, `BILLING_PORTAL_RETURN_URL`, `CONNECT_*` | Payments, webhooks, Connect |
 | AWS S3 | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_BUCKET` | File uploads |
-| Email | `MAIL_USER`, `MAIL_PASSWORD`, `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL` | Nodemailer notifications |
+| Email | `MAIL_USER`, `MAIL_PASSWORD`, optional auth SMTP `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, `MAIL_FROM`, `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL` | Nodemailer notifications |
 | Optional | `PAYPAL_*`, `CLOUDINARY_*`, `GOOGLE_GEOCODING_API_KEY`, `PUPPETEER_EXECUTABLE_PATH`, `LISTING_DEBUG` | Legacy or feature-specific |
 
 Database connection: [`config/Db.js`](../config/Db.js) reads `MONGODB_URI` (falls back to `mongodb://localhost:27017/mbh`).

--- a/docs/AUTH_FLOW.md
+++ b/docs/AUTH_FLOW.md
@@ -45,7 +45,7 @@ Auth is **stateless JWT** with optional **HTTP-only cookies**. There is no serve
 4. `bcrypt.hash(password, 12)` → `passwordHash`.
 5. 6-digit OTP generated, `bcrypt.hash(otp, 10)` stored in `user.otp` with `otpExpiry` = now + 10 minutes.
 6. User saved with `isOtpVerified: false`, `provider: 'local'` (default).
-7. `sendOtpEmail(email, otp)` — OTP delivered by **email** (Nodemailer + Gmail SMTP).
+7. `sendOtpEmail(email, otp)` — OTP delivered by **email** through Nodemailer SMTP. Auth mail uses provider-neutral SMTP when `MAIL_HOST` is set and keeps the Gmail fallback when `MAIL_HOST` is unset.
 8. On successful send: `otpPending` cookie set (10 min, via `getCookieOptions`).
 9. Returns **201** with message *"OTP sent to email"* — no JWT until OTP verified.
 10. On SMTP failure after user save: **502** `{ success: false, code: 'OTP_DELIVERY_FAILED', message: '...', otpPending: true, accountCreated: true, user: { email, role } }` — account preserved; `otpPending` cookie set; user may call `POST /api/users/resend-otp` after mail recovery.
@@ -194,7 +194,7 @@ Separate OTP fields from registration — no JWT issued during reset.
 
 - Always returns the same generic `200` message (`FORGOT_PASSWORD_RESPONSE`) — **no email enumeration**.
 - OTP email sent only when user exists, is not deleted/blocked, and has `passwordHash` (local accounts).
-- On send failure returns `500`; otherwise generic success even for unknown emails.
+- On send failure logs a sanitized delivery reason and still returns the same generic `200` response; no provider error, OTP, or account existence detail is exposed.
 
 ### Reset password
 
@@ -532,7 +532,8 @@ npm test   # runs tests/auth/*.test.js among others
 | Test file | Covers |
 |-----------|--------|
 | `auth-check-payload.test.js` | `toPublicAuthUser` whitelist, `/auth/check` shape, JWT `sub` claim |
-| `password-reset-abuse-protection.test.js` | Forgot-password generic response, reset OTP lockout, rate limit wiring |
+| `password-reset-abuse-protection.test.js` | Forgot-password generic response, reset OTP lockout, generic reset email failure, rate limit wiring |
+| `smtp-transport.test.js` / `auth-mailer-smtp.test.js` | Provider-neutral SMTP config, Gmail fallback, auth mail From header |
 | `password-reset-session-invalidation.test.js` | `sessionVersion` bump, `authenticate` reject/accept |
 | `google-oauth-security.test.js` | Temp cookie TTL, OAuth rate limits |
 

--- a/docs/BACKEND_ARCHITECTURE_MAP.md
+++ b/docs/BACKEND_ARCHITECTURE_MAP.md
@@ -175,9 +175,10 @@ All admin routers typically use `router.use(authenticate, isAdmin)` at the top.
 | Order paid confirmation | [OrderMail.js](../utils/OrderMail.js) | Webhook-triggered |
 | Bookings | [bookingMailer.js](../utils/bookingMailer.js) | |
 | Business profile | [BuisnessprofileMail.js](../utils/BuisnessprofileMail.js) | |
-| Generic OTP / notifications | [mailer.js](../utils/mailer.js) | |
+| Auth OTP / password reset | [mailer.js](../utils/mailer.js), [smtpTransport.js](../utils/smtpTransport.js) | Provider-neutral SMTP when `MAIL_HOST` is set; Gmail fallback when unset |
+| Generic notifications | [mailer.js](../utils/mailer.js) | |
 
-Env names: `MAIL_USER`, `MAIL_PASSWORD`, `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL`
+Env names: `MAIL_USER`, `MAIL_PASSWORD`, optional auth SMTP `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, `MAIL_FROM`, `ADMIN_EMAIL`, `SUPPORT_EMAIL`, `APP_NAME`, `APP_URL`
 
 ---
 

--- a/docs/BACKEND_LLM_INSTRUCTIONS.md
+++ b/docs/BACKEND_LLM_INSTRUCTIONS.md
@@ -50,7 +50,7 @@ flowchart TB
     MongoDB[(MongoDB Atlas)]
     Stripe[Stripe Connect + Subscriptions]
     S3[AWS S3]
-    SMTP[Nodemailer Gmail SMTP]
+    SMTP[Nodemailer SMTP]
     Google[Google OAuth + Places + Geocoding]
     Sentry[Sentry optional]
   end
@@ -316,8 +316,9 @@ flowchart LR
 
 ### 6.9 Email Notifications
 
-All via Nodemailer (Gmail SMTP). Key files:
-- [`utils/mailer.js`](../utils/mailer.js) — OTP, password reset
+All via Nodemailer. Auth OTP/password-reset mail uses provider-neutral SMTP through [`utils/smtpTransport.js`](../utils/smtpTransport.js) when `MAIL_HOST` is set and keeps the Gmail fallback when `MAIL_HOST` is unset. Other legacy mailers still use their existing Gmail-style transport. Key files:
+- [`utils/mailer.js`](../utils/mailer.js) — OTP, password reset, welcome email
+- [`utils/smtpTransport.js`](../utils/smtpTransport.js) — auth SMTP config + From header
 - [`utils/WellcomeMailer.js`](../utils/WellcomeMailer.js) — vendor onboarding
 - [`utils/approvalMail.js`](../utils/approvalMail.js) — admin finalize
 - [`utils/OrderMail.js`](../utils/OrderMail.js) — post-payment order emails
@@ -401,7 +402,7 @@ Documented in [DATABASE_INDEX_AUDIT.md](DATABASE_INDEX_AUDIT.md). Notable: User 
 | Stripe | Payments, Connect, subscriptions, verification fee | `STRIPE_SECRET_KEY`, 5× webhook secrets, `PLATFORM_FEE_CENTS` |
 | AWS S3 | Product images, vendor document uploads | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_BUCKET` |
 | Cloudinary | Legacy image storage + PendingImage cleanup | `CLOUDINARY_*` |
-| Gmail SMTP | All transactional email | `MAIL_USER`, `MAIL_PASSWORD`, `ADMIN_EMAIL`, `SUPPORT_EMAIL` |
+| SMTP email | Auth OTP provider-neutral SMTP + legacy transactional mail | `MAIL_USER`, `MAIL_PASSWORD`, optional `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, `MAIL_FROM`, `ADMIN_EMAIL`, `SUPPORT_EMAIL` |
 | Google OAuth | Social login | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `API_BASE_URL` |
 | Google Places/Geocoding | Address autocomplete, geo | `GOOGLE_GEOCODING_API_KEY` |
 | Sentry | Error monitoring (optional) | `SENTRY_DSN`, `SENTRY_ENABLED` |

--- a/docs/ENV_VAR_INVENTORY.md
+++ b/docs/ENV_VAR_INVENTORY.md
@@ -95,6 +95,10 @@ Sources compared: [`.env.example`](../.env.example), [README.md](../README.md), 
 | --- | --- | --- |
 | `MAIL_USER` | Required-prod mail | Yes |
 | `MAIL_PASSWORD` | Required-prod mail | Yes |
+| `MAIL_HOST` | Optional auth SMTP provider | Yes for provider-neutral auth mail |
+| `MAIL_PORT` | Optional auth SMTP provider | Yes for provider-neutral auth mail |
+| `MAIL_SECURE` | Optional auth SMTP provider | Yes for provider-neutral auth mail |
+| `MAIL_FROM` | Optional auth SMTP From header | Yes for provider-neutral auth mail |
 | `ADMIN_EMAIL` | Optional | Yes |
 | `SUPPORT_EMAIL` | Optional | Optional |
 | `APP_NAME` | Optional | Optional |

--- a/docs/MVP_BACKEND_API_AUDIT.md
+++ b/docs/MVP_BACKEND_API_AUDIT.md
@@ -223,7 +223,7 @@ Dual mount: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (
 | [`utils/bookingMailer.js`](../utils/bookingMailer.js) | Service booking notifications |
 | [`utils/BuisnessprofileMail.js`](../utils/BuisnessprofileMail.js) | Business profile Step-3 admin notification |
 
-**Transport:** Nodemailer + Gmail (`MAIL_USER`, `MAIL_PASSWORD` on Elastic Beanstalk).
+**Transport:** Nodemailer SMTP. Auth OTP/password-reset mail supports provider-neutral SMTP via `MAIL_HOST` and keeps Gmail fallback when `MAIL_HOST` is unset; other legacy mailers still use the existing Gmail-style transport.
 
 ### 1.12 Models index (Mongoose)
 
@@ -294,7 +294,7 @@ Cannot be proven by CI alone (mocked MongoDB/Stripe/email):
 |------|-----------------|
 | Live Stripe PaymentIntent checkout + Connect destination/split | P4 in [production-smoke-checklist.md](production-smoke-checklist.md) |
 | All 5 webhook endpoints with Stripe Dashboard test events | [STRIPE_WEBHOOKS.md](STRIPE_WEBHOOKS.md) |
-| Email delivery (Gmail via EB env vars) | P5 |
+| Email delivery (auth SMTP via EB env vars) | P5 |
 | S3 presigned uploads (onboarding docs, product images) | P2–P3 |
 | Full order: cart → initiate → pay → webhook → order emails + PDF | P4 |
 | Admin finalize approve/reject with real MongoDB | P2.6 |

--- a/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
+++ b/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
@@ -12,7 +12,7 @@
 
 Audit and document launch-safe backend email notification behavior for vendor onboarding, order confirmation, and review follow-up readiness. Add tests proving graceful SMTP failure handling and logging safety without faking delivery.
 
-**Principle:** Do not fake email delivery. When SMTP is missing or send fails, auth OTP flows return **502** `OTP_DELIVERY_FAILED` after persisting the unverified account/OTP hash. Vendor onboarding skips sends when env is missing; forgot-password returns **500** on send failure.
+**Principle:** Do not fake email delivery. When SMTP is missing or send fails, registration/resend/unverified-login OTP flows return **502** `OTP_DELIVERY_FAILED` after persisting the unverified account/OTP hash. Forgot-password stays anti-enumeration safe and returns the same generic **200** response on send failure. Vendor onboarding skips sends when env is missing.
 
 ---
 
@@ -34,6 +34,7 @@ Audit and document launch-safe backend email notification behavior for vendor on
 
 | File | Functions | Domain |
 | --- | --- | --- |
+| [`utils/smtpTransport.js`](../utils/smtpTransport.js) | Provider-neutral auth SMTP config + Gmail fallback | Auth |
 | [`utils/mailer.js`](../utils/mailer.js) | `sendOtpEmail`, `sendPasswordResetOtpEmail`, `sendWelcomeEmail` | Auth |
 | [`utils/WellcomeMailer.js`](../utils/WellcomeMailer.js) | Onboarding submit/approve/reject/badge, admin alerts | Vendor onboarding |
 | [`utils/vendorOnboardingEmailDelivery.js`](../utils/vendorOnboardingEmailDelivery.js) | `deliverVendorOnboardingEmail(s)` | Graceful SMTP gate |
@@ -57,20 +58,25 @@ Audit and document launch-safe backend email notification behavior for vendor on
 
 | Endpoint | On SMTP success | On SMTP failure after DB save |
 | --- | --- | --- |
-| `POST /api/users/register` | **201** — OTP sent to email; `otpPending` cookie | **502** `OTP_DELIVERY_FAILED` — account saved; no cookie |
+| `POST /api/users/register` | **201** — OTP sent to email; `otpPending` cookie | **502** `OTP_DELIVERY_FAILED` — account saved; `otpPending` cookie |
 | `POST /api/users/resend-otp` | **200** — OTP resent; `otpPending` cookie | **502** `OTP_DELIVERY_FAILED` — new OTP hash saved; no cookie |
 | `POST /api/users/login` (unverified) | **403** `otpPending: true` — OTP emailed | **502** `OTP_DELIVERY_FAILED` — no session/cookie |
+| `POST /api/users/forgot-password` | **200** generic anti-enumeration response | **200** same generic response; sanitized log only |
 
-**Gmail setup:** `MAIL_USER` + `MAIL_PASSWORD` where `MAIL_PASSWORD` is a [Google App Password](https://support.google.com/accounts/answer/185833) (requires 2-Step Verification).
+**Auth SMTP setup:** `MAIL_USER` + `MAIL_PASSWORD` are required. When `MAIL_HOST` is unset, auth mail uses the existing Gmail fallback. When `MAIL_HOST` is set, auth mail uses `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, and `MAIL_FROM` for provider-neutral SMTP.
 
-**Production inbox smoke (auth OTP):** Register with a disposable inbox; confirm delivery or **502** + log grep for `Failed to send OTP email:` / `EAUTH` / `535`. Never log OTP values or `MAIL_PASSWORD`.
+**Production inbox smoke (auth OTP):** Register with a disposable inbox; confirm delivery or **502** + log grep for `Auth OTP email delivery failed` and sanitized code/response-code markers. Never log OTP values or `MAIL_PASSWORD`.
 
 ### Environment variables (names only — never commit values)
 
 | Variable | Used for |
 | --- | --- |
 | `MAIL_USER` | SMTP auth + from address |
-| `MAIL_PASSWORD` | SMTP auth (Gmail app password) |
+| `MAIL_PASSWORD` | SMTP auth password/app password |
+| `MAIL_HOST` | Optional provider-neutral auth SMTP host |
+| `MAIL_PORT` | Optional provider-neutral auth SMTP port |
+| `MAIL_SECURE` | Optional provider-neutral auth SMTP TLS flag |
+| `MAIL_FROM` | Optional provider-neutral auth mail From header |
 | `ADMIN_EMAIL` | Admin notification recipients |
 | `SUPPORT_EMAIL` | Order mail support line fallback |
 | `APP_NAME` | Order phase subject branding |
@@ -123,8 +129,8 @@ Application ID and support contact are included. Approve/reject/badge templates 
 | `initiateOrder` emails | N/A (no gate) | Log `err.message` | **201** — order + PI created |
 | Post-payment webhook emails | N/A | Log `mailErr.message` | **200** — webhook ack |
 | Order accept/reject/ship/deliver | N/A | Log message | **200** — order updated |
-| Register OTP | N/A | Log; registration succeeds | **200/201** |
-| Forgot password OTP | N/A | Log; returns error | **500** — intentional contract |
+| Register OTP | N/A | Log sanitized code; account preserved | **502** `OTP_DELIVERY_FAILED` |
+| Forgot password OTP | N/A | Log sanitized code; generic response | **200** — anti-enumeration |
 
 ---
 
@@ -132,7 +138,7 @@ Application ID and support contact are included. Approve/reject/badge templates 
 
 - [`vendorOnboardingEmailDelivery.js`](../utils/vendorOnboardingEmailDelivery.js): logs label + `err.message` only; never OTP, credentials, or full payloads
 - Order email catch blocks (#33): log `err?.message` / `mailErr?.message` only
-- `mailer.js`: OTP values are not logged (verified by automated source audit)
+- Auth OTP delivery logs sanitized code/type details only; no raw provider payloads, OTP values, or credentials (verified by automated source audit)
 
 ---
 

--- a/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
+++ b/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
@@ -101,7 +101,27 @@ Invoke-RestMethod https://api.mosaicbizhub.com/api/ready
 
 ## Email delivery status
 
-**Still blocked** on production (`90d7292`). Register and resend return **502** `OTP_DELIVERY_FAILED`. Inbox delivery not confirmed.
+**Still blocked** on production after deploy `a461b15` (2026-06-29).
+
+| Signal | Result |
+| --- | --- |
+| `GET /api/ready` `authEmail.configured` | **true** — `MAIL_USER` and `MAIL_PASSWORD` are present in EB process env |
+| Register / resend OTP | **502** `OTP_DELIVERY_FAILED` |
+| Known customer/vendor forgot-password | **500** `Failed to send reset OTP` |
+| Unknown forgot-password | **200** (anti-enumeration OK) |
+
+**Revised root cause:** Not missing env vars. SMTP credentials are set but **Gmail delivery is failing** at send time — likely invalid/expired App Password, revoked credentials (`EAUTH` / `535`), or outbound SMTP connectivity from EB. Operator: rotate Google App Password on the `MAIL_USER` account, update `MAIL_PASSWORD` on EB, restart environment, grep CloudWatch for `Auth OTP email delivery failed` and Nodemailer auth errors.
+
+## Production deploy (2026-06-29)
+
+| Item | Value |
+| --- | --- |
+| PR | [#164](https://github.com/Techware-Hut/mosaic-backend/pull/164) `staging` → `main` |
+| Deployed commit | `a461b151127054ad1b31f14122f9291a8d40d4a3` |
+| GHA deploy run | Success (Deploy to Elastic Beanstalk #119) |
+| `authEmail.configured` on `/api/ready` | **true** |
+
+Post-deploy auth-email smoke (MBH_TEST_* emails from session `.env.local`, status codes only): PASS 3 / FAIL 5 / SKIP 0.
 
 ## Code changes in this branch (operability, no auth behavior change)
 

--- a/docs/backend/BACKEND_ARCHITECTURE_AS_BUILT.md
+++ b/docs/backend/BACKEND_ARCHITECTURE_AS_BUILT.md
@@ -154,7 +154,7 @@ Order in [`app.js`](../../app.js):
 | MongoDB Atlas | Primary database | `MONGODB_URI` |
 | Stripe | Orders, Connect, subscriptions, vendor verification | `STRIPE_SECRET_KEY`, 5× webhook secrets |
 | AWS S3 | Product images, vendor documents | `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_BUCKET` |
-| Gmail SMTP | Transactional email | `MAIL_USER`, `MAIL_PASSWORD`, `ADMIN_EMAIL` |
+| SMTP email | Auth OTP provider-neutral SMTP + legacy transactional mail | `MAIL_USER`, `MAIL_PASSWORD`, optional `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, `MAIL_FROM`, `ADMIN_EMAIL` |
 | Google OAuth | Social login | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `API_BASE_URL` |
 | Google Geocoding | Address/geo | `GOOGLE_GEOCODING_API_KEY` |
 | Cloudinary | Legacy image URLs | `CLOUDINARY_*` |

--- a/docs/production-env-checklist.md
+++ b/docs/production-env-checklist.md
@@ -68,8 +68,12 @@ Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-regist
 
 | Variable | Required for |
 |----------|--------------|
-| `MAIL_USER` | OTP, order, onboarding mail (Gmail address; also used as From header) |
-| `MAIL_PASSWORD` | SMTP auth — must be a **Google App Password**, not the account login password |
+| `MAIL_USER` | OTP, order, onboarding mail SMTP login; auth mail From fallback |
+| `MAIL_PASSWORD` | SMTP auth password/app password |
+| `MAIL_HOST` | Optional provider-neutral auth SMTP host; leave unset for Gmail fallback |
+| `MAIL_PORT` | Optional provider-neutral auth SMTP port |
+| `MAIL_SECURE` | Optional provider-neutral auth SMTP TLS flag |
+| `MAIL_FROM` | Optional provider-neutral auth mail From header |
 | `ADMIN_EMAIL` | Admin notifications (vendor onboarding, contact form) — **not** required for auth OTP |
 | `SUPPORT_EMAIL` | Optional; email templates |
 | `APP_NAME` | Optional branding |
@@ -81,13 +85,13 @@ Webhook URL registration: [stripe-webhook-registration.md](stripe-webhook-regist
 
 ### Auth OTP email (registration / resend / unverified login)
 
-OTP is sent **by email only** via Nodemailer + Gmail (`utils/mailer.js`). There is no SMS/mobile OTP channel.
+OTP is sent **by email only** via Nodemailer SMTP (`utils/mailer.js` + `utils/smtpTransport.js`). There is no SMS/mobile OTP channel.
 
-**Auth OTP requires only `MAIL_USER` and `MAIL_PASSWORD`.** `ADMIN_EMAIL` does not gate registration or forgot-password OTP delivery.
+**Auth OTP requires `MAIL_USER` and `MAIL_PASSWORD`.** `ADMIN_EMAIL` does not gate registration or forgot-password OTP delivery. Set `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, and `MAIL_FROM` for provider-neutral SMTP; leave `MAIL_HOST` unset to keep Gmail fallback.
 
 **Production inbox smoke (disposable test account only):**
 
-1. Set `MAIL_USER` and `MAIL_PASSWORD` (App Password) on Elastic Beanstalk; **restart** the environment.
+1. Set the auth SMTP `MAIL_*` env names on Elastic Beanstalk; **restart** the environment.
 2. Run spaced probes (≥30s apart to avoid 429 rate limits): `./scripts/auth-email-smoke.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -DisposableDomain <your-disposable-domain>`
 3. Optional known-account forgot-password: set session-only `SMOKE_TEST_CUSTOMER_EMAIL` and `SMOKE_TEST_VENDOR_EMAIL` before running the script.
 4. `POST /api/users/register` with a disposable email you control — expect **201** and inbox delivery within ~2 minutes.
@@ -97,8 +101,8 @@ OTP is sent **by email only** via Nodemailer + Gmail (`utils/mailer.js`). There 
 
 | Probe | Route | Expected on success | Mail failure |
 | --- | --- | ---: | ---: |
-| Customer forgot-password | `POST /api/users/forgot-password` | 200 | 500 |
-| Vendor forgot-password | `POST /api/users/forgot-password` | 200 | 500 |
+| Customer forgot-password | `POST /api/users/forgot-password` | 200 | 200 generic; verify inbox/logs |
+| Vendor forgot-password | `POST /api/users/forgot-password` | 200 | 200 generic; verify inbox/logs |
 | Customer register | `POST /api/users/register` | 201 | 502 `OTP_DELIVERY_FAILED` |
 | Vendor register | `POST /api/users/register` (`role: business_owner`) | 201 | 502 |
 | Resend OTP | `POST /api/users/resend-otp` | 200 | 502 |
@@ -106,17 +110,17 @@ OTP is sent **by email only** via Nodemailer + Gmail (`utils/mailer.js`). There 
 
 Wait **≥15 minutes** after a burst of failed probes that returned **429** before re-running auth email smoke from the same IP.
 
-**When SMTP delivery fails**, auth endpoints return **502** with `code: OTP_DELIVERY_FAILED` (account may still be saved; user can retry via `POST /api/users/resend-otp` after mail recovery).
+**When SMTP delivery fails**, registration/resend/unverified-login OTP endpoints return **502** with `code: OTP_DELIVERY_FAILED` (account may still be saved; user can retry via `POST /api/users/resend-otp` after mail recovery). Forgot-password remains generic **200** to avoid account enumeration.
 
 **Log signatures for SMTP auth failure (grep EB logs — never log secrets):**
 
 | Signature | Meaning |
 |-----------|---------|
-| `Failed to send OTP email:` | Application caught a registration/resend/login OTP send failure |
+| `Auth OTP email delivery failed` | Application caught an auth OTP/password-reset send failure |
 | `Resend OTP error:` | Unexpected error in resend handler (non-delivery paths) |
 | `Login error:` | Unexpected error in login handler (non-delivery paths) |
-| Nodemailer `code: 'EAUTH'` | SMTP authentication rejected |
-| Response contains `535` / `Invalid login` / `Username and Password not accepted` | Gmail rejected credentials — rotate App Password |
+| `code=EAUTH` | SMTP authentication rejected |
+| `responseCode=535` | SMTP provider rejected auth; inspect provider settings without logging secrets |
 
 Confirm no 6-digit OTP values and no `MAIL_PASSWORD` appear in log lines after auth smoke.
 

--- a/scripts/auth-email-smoke.ps1
+++ b/scripts/auth-email-smoke.ps1
@@ -130,7 +130,7 @@ $registerBody = @{
     role     = 'customer'
 } | ConvertTo-Json -Compress
 $code = Get-StatusCode "$Base/api/users/register" -Method POST -Body $registerBody
-if ($code -eq 201) { Write-ProbePass "A5 POST register customer ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A5 POST register customer ($code, OTP delivery failed - check MAIL_USER/MAIL_PASSWORD on EB)" } else { Write-ProbeFail "A5 POST register customer ($code, expected 201)" }
+if ($code -eq 201) { Write-ProbePass "A5 POST register customer ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A5 POST register customer ($code, OTP delivery failed - check auth SMTP MAIL_* env names on EB)" } else { Write-ProbeFail "A5 POST register customer ($code, expected 201)" }
 
 Wait-ProbeDelay
 
@@ -145,7 +145,7 @@ $registerBody = @{
     role     = 'business_owner'
 } | ConvertTo-Json -Compress
 $code = Get-StatusCode "$Base/api/users/register" -Method POST -Body $registerBody
-if ($code -eq 201) { Write-ProbePass "A6 POST register vendor ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A6 POST register vendor ($code, OTP delivery failed - check MAIL_USER/MAIL_PASSWORD on EB)" } else { Write-ProbeFail "A6 POST register vendor ($code, expected 201)" }
+if ($code -eq 201) { Write-ProbePass "A6 POST register vendor ($code)" } elseif ($code -eq 502) { Write-ProbeFail "A6 POST register vendor ($code, OTP delivery failed - check auth SMTP MAIL_* env names on EB)" } else { Write-ProbeFail "A6 POST register vendor ($code, expected 201)" }
 
 Wait-ProbeDelay
 

--- a/tests/auth/otp-email-delivery.test.js
+++ b/tests/auth/otp-email-delivery.test.js
@@ -113,6 +113,11 @@ function assertNoOtpInBody(body) {
   assert.ok(!/\b\d{6}\b/.test(serialized), 'response must not contain a 6-digit OTP');
 }
 
+function assertNoProviderLeakInBody(body) {
+  const serialized = JSON.stringify(body);
+  assert.doesNotMatch(serialized, /EAUTH|535|api[_-]?key|smtp-password|credential/i);
+}
+
 class RegisterMockUser {
   constructor(data) {
     Object.assign(this, data);
@@ -161,7 +166,9 @@ test('registerUser returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async 
     ...buildControllerMocks({
       mailer: {
         sendOtpEmail: async () => {
-          throw new Error('SMTP connection failed');
+          const err = new Error('EAUTH 535 smtp-password rejected');
+          err.code = 'EAUTH';
+          throw err;
         },
       },
     }).mocks,
@@ -182,6 +189,7 @@ test('registerUser returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async 
   assert.equal(res.cookies.otpPending, 'true');
   assert.ok(savedUser && savedUser.saveCalled, 'unverified account should be preserved');
   assertNoOtpInBody(res.body);
+  assertNoProviderLeakInBody(res.body);
 });
 
 test('resendOtp returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () => {
@@ -196,7 +204,9 @@ test('resendOtp returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () 
     },
     mailer: {
       sendOtpEmail: async () => {
-        throw new Error('SMTP auth failed');
+        const err = new Error('EAUTH 535 smtp-password rejected');
+        err.code = 'EAUTH';
+        throw err;
       },
     },
   }).mocks);
@@ -213,6 +223,7 @@ test('resendOtp returns OTP_DELIVERY_FAILED when sendOtpEmail throws', async () 
   assert.equal(res.body.user.role, unverifiedUser.role);
   assert.equal(res.cookies.otpPending, undefined);
   assertNoOtpInBody(res.body);
+  assertNoProviderLeakInBody(res.body);
 });
 
 test('resendOtp returns 200 when sendOtpEmail succeeds', async () => {
@@ -248,7 +259,9 @@ test('loginUser returns OTP_DELIVERY_FAILED for unverified user when sendOtpEmai
     },
     mailer: {
       sendOtpEmail: async () => {
-        throw new Error('EAUTH invalid credentials');
+        const err = new Error('EAUTH 535 smtp-password rejected');
+        err.code = 'EAUTH';
+        throw err;
       },
     },
   });
@@ -275,6 +288,7 @@ test('loginUser returns OTP_DELIVERY_FAILED for unverified user when sendOtpEmai
   assert.equal(res.authCookies, null);
   assert.equal(getSetAuthCookiesCalled(), false);
   assertNoOtpInBody(res.body);
+  assertNoProviderLeakInBody(res.body);
 });
 
 test('auth OTP rate limits remain unchanged in userRoutes', () => {

--- a/tests/auth/password-reset-abuse-protection.test.js
+++ b/tests/auth/password-reset-abuse-protection.test.js
@@ -39,6 +39,12 @@ function createResponse() {
   };
 }
 
+function assertNoOtpOrProviderLeakInBody(body) {
+  const serialized = JSON.stringify(body);
+  assert.doesNotMatch(serialized, /\b\d{6}\b/);
+  assert.doesNotMatch(serialized, /EAUTH|535|api[_-]?key|smtp-password|credential/i);
+}
+
 test('forgotPassword returns a generic success response for unknown emails', async () => {
   const userController = withMocks(userControllerPath, {
     '../models/User': {
@@ -72,6 +78,58 @@ test('forgotPassword returns a generic success response for unknown emails', asy
     success: true,
     message: 'If an account with that email exists, a password reset OTP will be sent.',
   });
+});
+
+test('forgotPassword returns a generic safe response when reset OTP email fails', async () => {
+  const user = {
+    email: 'vendor@example.com',
+    passwordHash: 'hashed-password',
+    isDeleted: false,
+    isBlocked: false,
+    saveCalls: 0,
+    async save() {
+      this.saveCalls += 1;
+    },
+  };
+
+  const userController = withMocks(userControllerPath, {
+    '../models/User': {
+      findOne: async () => user,
+    },
+    bcryptjs: {
+      hash: async (value) => `hashed:${value}`,
+      compare: async () => false,
+    },
+    'express-validator': {
+      validationResult: () => ({ isEmpty: () => true, array: () => [] }),
+    },
+    '../utils/mailer': {
+      sendOtpEmail: async () => {},
+      sendWelcomeEmail: async () => {},
+      sendPasswordResetOtpEmail: async () => {
+        const err = new Error('EAUTH 535 smtp-password rejected');
+        err.code = 'EAUTH';
+        throw err;
+      },
+    },
+    '../utils/cookieHelper': {
+      getCookieOptions: () => ({}),
+      clearCookie: () => {},
+      setAuthCookies: () => {},
+      clearAuthCookies: () => {},
+    },
+  });
+
+  const res = createResponse();
+  await userController.forgotPassword({ body: { email: user.email } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    success: true,
+    message: 'If an account with that email exists, a password reset OTP will be sent.',
+  });
+  assert.equal(user.saveCalls, 1);
+  assertNoOtpOrProviderLeakInBody(res.body);
 });
 
 test('resetPassword invalidates the reset OTP after the maximum failed attempts', async () => {

--- a/tests/email/auth-mailer-smtp.test.js
+++ b/tests/email/auth-mailer-smtp.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const mailerPath = path.resolve(__dirname, '../../utils/mailer.js');
+
+const ENV_KEYS = [
+  'MAIL_HOST',
+  'MAIL_PORT',
+  'MAIL_SECURE',
+  'MAIL_USER',
+  'MAIL_PASSWORD',
+  'MAIL_FROM',
+];
+
+function snapshotEnv() {
+  const saved = {};
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+  }
+  return saved;
+}
+
+function restoreEnv(saved) {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
+  }
+}
+
+function loadMailerWithNodemailer(nodemailerMock) {
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'nodemailer') {
+      return nodemailerMock;
+    }
+
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[mailerPath];
+  const mailer = require(mailerPath);
+  Module._load = originalLoad;
+  return mailer;
+}
+
+test('sendOtpEmail uses provider-neutral SMTP config and MAIL_FROM for auth mail', async () => {
+  const savedEnv = snapshotEnv();
+  process.env.MAIL_HOST = 'smtp.resend.com';
+  process.env.MAIL_PORT = '465';
+  process.env.MAIL_SECURE = 'true';
+  process.env.MAIL_USER = 'resend';
+  process.env.MAIL_PASSWORD = 'smtp-password';
+  process.env.MAIL_FROM = 'Mosaic Biz Hub <hello@mosaicbizhub.com>';
+
+  const createdConfigs = [];
+  const sentMessages = [];
+  const nodemailerMock = {
+    createTransport(config) {
+      createdConfigs.push(config);
+      return {
+        verify: async () => {},
+        sendMail: async (message) => {
+          sentMessages.push(message);
+        },
+      };
+    },
+  };
+
+  const mailer = loadMailerWithNodemailer(nodemailerMock);
+
+  try {
+    await mailer.sendOtpEmail('recipient@example.com', '123456', 'register');
+  } finally {
+    restoreEnv(savedEnv);
+    delete require.cache[mailerPath];
+  }
+
+  assert.equal(createdConfigs.length, 1);
+  assert.deepEqual(createdConfigs[0], {
+    host: 'smtp.resend.com',
+    port: 465,
+    secure: true,
+    auth: {
+      user: 'resend',
+      pass: 'smtp-password',
+    },
+  });
+  assert.equal(sentMessages.length, 1);
+  assert.equal(sentMessages[0].from, 'Mosaic Biz Hub <hello@mosaicbizhub.com>');
+  assert.equal(sentMessages[0].to, 'recipient@example.com');
+});

--- a/tests/utils/auth-email-delivery.test.js
+++ b/tests/utils/auth-email-delivery.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const {
   isAuthEmailConfigured,
   deliverAuthOtpEmail,
+  getSafeAuthEmailError,
 } = require('../../utils/authEmailDelivery');
 
 const deliveryPath = path.resolve(__dirname, '../../utils/authEmailDelivery.js');
@@ -84,7 +85,7 @@ test('deliverAuthOtpEmail returns sent on success', async () => {
   assert.equal(result.skipped, false);
 });
 
-test('deliverAuthOtpEmail logs message only on failure', async () => {
+test('deliverAuthOtpEmail logs sanitized provider details only on failure', async () => {
   process.env.MAIL_USER = 'mail@example.com';
   process.env.MAIL_PASSWORD = 'app-password';
 
@@ -95,7 +96,10 @@ test('deliverAuthOtpEmail logs message only on failure', async () => {
   const result = await deliverAuthOtpEmail({
     context: 'unverifiedLogin',
     send: async () => {
-      throw new Error('EAUTH invalid credentials');
+      const err = new Error('SMTP password leaked in provider message');
+      err.code = 'EAUTH';
+      err.responseCode = 535;
+      throw err;
     },
   });
 
@@ -104,14 +108,23 @@ test('deliverAuthOtpEmail logs message only on failure', async () => {
 
   assert.equal(result.sent, false);
   assert.equal(result.skipped, false);
-  assert.equal(result.error, 'EAUTH invalid credentials');
+  assert.equal(result.error, 'code=EAUTH responseCode=535');
   assert.ok(errorLogs.some((line) => line.includes('unverifiedLogin')));
   assert.ok(!errorLogs.some((line) => line.includes('app-password')));
+  assert.ok(!errorLogs.some((line) => line.includes('SMTP password leaked')));
+});
+
+test('getSafeAuthEmailError does not return raw provider messages', () => {
+  const err = new Error('535 credentials rejected for smtp-password');
+  err.code = 'EAUTH';
+  err.responseCode = 535;
+
+  assert.equal(getSafeAuthEmailError(err), 'code=EAUTH responseCode=535');
 });
 
 test('authEmailDelivery source avoids logging credential values', () => {
   const source = fs.readFileSync(deliveryPath, 'utf8');
-  assert.ok(source.includes('err.message'));
+  assert.ok(source.includes('getSafeAuthEmailError'));
   assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_PASSWORD/));
   assert.ok(!source.match(/console\.(log|error|warn)\([^)]*MAIL_USER/));
 });

--- a/tests/utils/smtp-transport.test.js
+++ b/tests/utils/smtp-transport.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildSmtpTransportConfig,
+  formatMosaicFromHeader,
+  getMailFromAddress,
+  parseMailPort,
+  parseMailSecure,
+} = require('../../utils/smtpTransport');
+
+test('buildSmtpTransportConfig keeps Gmail fallback when MAIL_HOST is unset', () => {
+  const config = buildSmtpTransportConfig({
+    MAIL_USER: 'mail@example.com',
+    MAIL_PASSWORD: 'app-password',
+  });
+
+  assert.deepEqual(config, {
+    service: 'gmail',
+    auth: {
+      user: 'mail@example.com',
+      pass: 'app-password',
+    },
+  });
+});
+
+test('buildSmtpTransportConfig uses provider-neutral SMTP when MAIL_HOST is set', () => {
+  const config = buildSmtpTransportConfig({
+    MAIL_HOST: 'smtp.resend.com',
+    MAIL_PORT: '465',
+    MAIL_SECURE: 'true',
+    MAIL_USER: 'resend',
+    MAIL_PASSWORD: 'smtp-password',
+  });
+
+  assert.equal(config.host, 'smtp.resend.com');
+  assert.equal(config.port, 465);
+  assert.equal(config.secure, true);
+  assert.deepEqual(config.auth, {
+    user: 'resend',
+    pass: 'smtp-password',
+  });
+});
+
+test('parseMailPort parses MAIL_PORT=465 as a number', () => {
+  assert.equal(parseMailPort('465'), 465);
+});
+
+test('parseMailSecure parses MAIL_SECURE=true as boolean true', () => {
+  assert.equal(parseMailSecure('true'), true);
+  assert.equal(parseMailSecure('TRUE'), true);
+  assert.equal(parseMailSecure('false'), false);
+});
+
+test('MAIL_FROM is preferred over MAIL_USER for the From header', () => {
+  const env = {
+    MAIL_FROM: 'Mosaic Biz Hub <hello@mosaicbizhub.com>',
+    MAIL_USER: 'smtp-login@example.com',
+  };
+
+  assert.equal(getMailFromAddress(env), 'Mosaic Biz Hub <hello@mosaicbizhub.com>');
+  assert.equal(formatMosaicFromHeader(env), 'Mosaic Biz Hub <hello@mosaicbizhub.com>');
+});
+
+test('MAIL_FROM falls back to MAIL_USER for Gmail compatibility', () => {
+  const env = {
+    MAIL_USER: 'mail@example.com',
+  };
+
+  assert.equal(getMailFromAddress(env), 'mail@example.com');
+  assert.equal(formatMosaicFromHeader(env), '"Mosaic Biz Hub" <mail@example.com>');
+});

--- a/utils/authEmailDelivery.js
+++ b/utils/authEmailDelivery.js
@@ -10,6 +10,25 @@ function isAuthEmailConfigured() {
   );
 }
 
+function getSafeAuthEmailError(err) {
+  if (!err) {
+    return 'unknown';
+  }
+
+  const parts = [];
+  if (err.code) {
+    parts.push(`code=${String(err.code)}`);
+  }
+  if (err.responseCode) {
+    parts.push(`responseCode=${String(err.responseCode)}`);
+  }
+  if (!parts.length && err.name) {
+    parts.push(`type=${String(err.name)}`);
+  }
+
+  return parts.length ? parts.join(' ') : 'delivery_failed';
+}
+
 /**
  * @param {{ context: string, send: () => Promise<void> }} options
  * @returns {Promise<{ sent: boolean, skipped?: boolean, reason?: string, error?: string }>}
@@ -24,13 +43,14 @@ async function deliverAuthOtpEmail({ context, send }) {
     await send();
     return { sent: true, skipped: false };
   } catch (err) {
-    const message = err && err.message ? String(err.message) : 'Unknown email error';
-    console.error(`Auth OTP email delivery failed (${context}):`, message);
-    return { sent: false, skipped: false, error: message };
+    const safeError = getSafeAuthEmailError(err);
+    console.error(`Auth OTP email delivery failed (${context}):`, safeError);
+    return { sent: false, skipped: false, error: safeError };
   }
 }
 
 module.exports = {
   isAuthEmailConfigured,
   deliverAuthOtpEmail,
+  getSafeAuthEmailError,
 };

--- a/utils/mailer.js
+++ b/utils/mailer.js
@@ -1,9 +1,14 @@
 const nodemailer = require('nodemailer');
 const { buildFrontendUrl } = require('./frontendUrl');
 const { deliverAuthOtpEmail } = require('./authEmailDelivery');
+const {
+  buildSmtpTransportConfig,
+  formatMosaicFromHeader,
+} = require('./smtpTransport');
 
 let transporter = null;
-let verifyPromise = null;
+let authTransporter = null;
+let authVerifyPromise = null;
 
 function getTransporter() {
   if (!transporter) {
@@ -18,22 +23,29 @@ function getTransporter() {
   return transporter;
 }
 
-function verifyTransporterOnce() {
-  if (!verifyPromise) {
-    verifyPromise = getTransporter().verify().catch((err) => {
-      verifyPromise = null;
+function getAuthTransporter() {
+  if (!authTransporter) {
+    authTransporter = nodemailer.createTransport(buildSmtpTransportConfig());
+  }
+  return authTransporter;
+}
+
+function verifyAuthTransporterOnce() {
+  if (!authVerifyPromise) {
+    authVerifyPromise = getAuthTransporter().verify().catch((err) => {
+      authVerifyPromise = null;
       throw err;
     });
   }
-  return verifyPromise;
+  return authVerifyPromise;
 }
 
 async function sendMailWithAuthDelivery(context, mailOptions) {
   const delivery = await deliverAuthOtpEmail({
     context,
     send: async () => {
-      await verifyTransporterOnce();
-      await getTransporter().sendMail(mailOptions);
+      await verifyAuthTransporterOnce();
+      await getAuthTransporter().sendMail(mailOptions);
     },
   });
 
@@ -52,7 +64,7 @@ async function sendMailWithAuthDelivery(context, mailOptions) {
 
 exports.sendOtpEmail = async (to, otp, context = 'register') => {
   const mailOptions = {
-    from: `"Mosaic Biz Hub" <${process.env.MAIL_USER}>`,
+    from: formatMosaicFromHeader(),
     to,
     subject: 'Your OTP Code',
     text: `Your OTP is ${otp}. It will expire in 10 minutes.`,
@@ -63,7 +75,7 @@ exports.sendOtpEmail = async (to, otp, context = 'register') => {
 
 exports.sendPasswordResetOtpEmail = async (to, otp) => {
   const mailOptions = {
-    from: `"Mosaic Biz Hub" <${process.env.MAIL_USER}>`,
+    from: formatMosaicFromHeader(),
     to,
     subject: 'Password Reset OTP',
     text: `Your password reset OTP is ${otp}. It will expire in 10 minutes.`,

--- a/utils/smtpTransport.js
+++ b/utils/smtpTransport.js
@@ -1,0 +1,65 @@
+function getTrimmedEnv(env, name) {
+  const value = env[name];
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+function parseMailPort(value) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseMailSecure(value) {
+  return String(value).trim().toLowerCase() === 'true';
+}
+
+function buildSmtpTransportConfig(env = process.env) {
+  const host = getTrimmedEnv(env, 'MAIL_HOST');
+  const user = getTrimmedEnv(env, 'MAIL_USER');
+  const pass = getTrimmedEnv(env, 'MAIL_PASSWORD');
+
+  if (!host) {
+    return {
+      service: 'gmail',
+      auth: { user, pass },
+    };
+  }
+
+  const config = {
+    host,
+    secure: parseMailSecure(env.MAIL_SECURE),
+    auth: { user, pass },
+  };
+
+  const port = parseMailPort(env.MAIL_PORT);
+  if (port !== undefined) {
+    config.port = port;
+  }
+
+  return config;
+}
+
+function getMailFromAddress(env = process.env) {
+  return getTrimmedEnv(env, 'MAIL_FROM') || getTrimmedEnv(env, 'MAIL_USER');
+}
+
+function formatMosaicFromHeader(env = process.env) {
+  const mailFrom = getTrimmedEnv(env, 'MAIL_FROM');
+  if (mailFrom) {
+    return mailFrom;
+  }
+
+  const fromAddress = getTrimmedEnv(env, 'MAIL_USER');
+  return fromAddress ? `"Mosaic Biz Hub" <${fromAddress}>` : '"Mosaic Biz Hub"';
+}
+
+module.exports = {
+  buildSmtpTransportConfig,
+  formatMosaicFromHeader,
+  getMailFromAddress,
+  parseMailPort,
+  parseMailSecure,
+};


### PR DESCRIPTION
﻿## Summary

Promotes current `staging` to `main` for production deployment.

Included changes:

- Provider-neutral auth SMTP support for OTP/password-reset mail with Gmail fallback preserved.
- Auth email failure responses/logging remain generic and sanitized.
- Current docs/env inventory/smoke guidance aligned with auth SMTP behavior.
- Existing staging auth email proof documentation update.

## Validation before promotion

- Backend PR #165 CI: `Test` passed, `build` passed.
- Local backend checks before PR #165 merge:
  - `npm test` — 448 tests passed.
  - `node --test tests/integration/auth.integration.test.js` — 8 tests passed.
  - Focused SMTP/auth/email/health tests passed.

## Safety

- No env values, OTPs, cookies, tokens, SMTP passwords, API keys, or provider secrets committed.
- No Stripe/payment/webhook code changes in PR #165.
- No `app.js` or middleware order changes in PR #165.
- Canonical `GET /api/featured-products` preserved.

## Post-merge

Push to `main` should trigger `deploy-eb-production.yml`, then production health/readiness/build-info and auth email smoke should be run.
