### PR TITLE
[codex] Document auth email production smoke

### DIFF
--- a/docs/BACKEND_SOFT_LAUNCH_SMOKE_PROOF_2026_06_29.md
+++ b/docs/BACKEND_SOFT_LAUNCH_SMOKE_PROOF_2026_06_29.md
@@ -9,6 +9,29 @@ Related issues:
 
 Read-only launch-readiness verification of existing Mosaic Biz Hub backend behavior against production API. No payment flows executed, no secrets exposed, no code or deploy changes made.
 
+## 2026-06-30 Auth Email Addendum
+
+Production has advanced since the original 2026-06-29 smoke proof.
+
+| Item | Value |
+| --- | --- |
+| Production API tested | `https://api.mosaicbizhub.com` |
+| Production live commit | `a5a4e54` |
+| Production deploy workflow | `deploy-eb-production.yml` run `28459250020` - success |
+| Auth SMTP change | Provider-neutral auth SMTP support using `MAIL_HOST`, `MAIL_PORT`, `MAIL_SECURE`, `MAIL_USER`, `MAIL_PASSWORD`, and `MAIL_FROM`; Gmail fallback remains when `MAIL_HOST` is unset |
+
+Post-deploy checks on 2026-06-30:
+
+| Check | Result |
+| --- | --- |
+| `GET /api/health` | Pass - 200, `status: ok`, release commit `a5a4e54` |
+| `GET /api/ready` | Pass - 200, `status: ready`, `database: connected`, `authEmail.configured: true`, release commit `a5a4e54` |
+| `GET /api/build-info` | Pass - 200, release commit `a5a4e54` |
+| Auth email smoke script | Pass - 6 pass, 0 fail, 2 skip (known-account env names absent locally) |
+| Production frontend browser auth/email smoke | Pass - customer/vendor signup reached OTP, signup/resend/forgot-password emails arrived, unknown forgot-password stayed generic with no mailbox delivery |
+
+No Stripe/payment, webhook, `app.js` middleware/CORS, or featured-product route changes were made for this auth email deployment. The canonical `GET /api/featured-products` contract was preserved; `/api/products/featured` remains absent.
+
 ## Commit Identity (Important)
 
 | Item | Value |

--- a/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
+++ b/docs/PRODUCTION_AUTH_EMAIL_DELIVERY_PROOF_2026_06_29.md
@@ -4,6 +4,50 @@
 
 OTP registration, forgot-password, and resend-otp mail delivery on production API. No deploy performed. No secrets, OTPs, or credentials printed or committed.
 
+## 2026-06-30 Resolved Status
+
+Auth email delivery is now **passing** in production after deploying provider-neutral SMTP support for the Resend-backed `MAIL_*` configuration.
+
+| Item | Value |
+| --- | --- |
+| Backend feature branch | `fix/auth-email-resend-smtp` |
+| Implementation commit | `75209f7` |
+| Production merge commit | `a5a4e54` |
+| Production deploy workflow | `deploy-eb-production.yml` run `28459250020` - success |
+| Production API | `https://api.mosaicbizhub.com` |
+| Production frontend smoke target | `https://mosaicbizhub.com` |
+
+Current auth SMTP env contract:
+
+| Variable | Purpose |
+| --- | --- |
+| `MAIL_HOST` | Provider-neutral SMTP host for auth OTP/password-reset mail. When unset, the Gmail fallback remains available. |
+| `MAIL_PORT` | SMTP port, parsed as a number. |
+| `MAIL_SECURE` | SMTP secure flag, parsed as a boolean. |
+| `MAIL_USER` | SMTP login identity. |
+| `MAIL_PASSWORD` | SMTP password/API key. |
+| `MAIL_FROM` | From header for auth mail. Falls back to `"Mosaic Biz Hub" <MAIL_USER>`. |
+
+Production checks on 2026-06-30:
+
+| Probe | Result |
+| --- | --- |
+| `GET /api/health` | 200, `status: ok`, release commit `a5a4e54` |
+| `GET /api/ready` | 200, `status: ready`, `database: connected`, `authEmail.configured: true`, release commit `a5a4e54` |
+| `GET /api/build-info` | 200, release commit `a5a4e54` |
+| `./scripts/auth-email-smoke.ps1 -ApiBaseUrl https://api.mosaicbizhub.com -ProbeDelaySeconds 30` | PASS 6, FAIL 0, SKIP 2 |
+| Customer registration OTP delivery | Passed with disposable inbox; email arrived |
+| Vendor registration OTP delivery | Passed with disposable inbox; email arrived |
+| Customer resend OTP delivery | Passed with disposable inbox; email arrived |
+| Vendor resend OTP delivery | Passed through production frontend browser smoke; email arrived |
+| Customer forgot-password OTP delivery | Passed with disposable inbox; email arrived |
+| Vendor forgot-password OTP delivery | Passed with disposable inbox; email arrived |
+| Unknown forgot-password anti-enumeration | 200 generic response; no mailbox delivery observed |
+
+Frontend production browser smoke on 2026-06-30 also confirmed customer and vendor signup pages reached `/verify-otp`, resend calls returned 200, forgot-password pages advanced to the reset step, and all related mailbox delivery checks passed. The smoke output recorded only statuses and booleans; no email addresses, OTPs, tokens, cookies, credentials, env values, or email bodies were printed.
+
+The sections below are retained as historical failure analysis from 2026-06-29.
+
 ## Branch and commit
 
 | Item | Value |

--- a/docs/qa/REGRESSION_CLAIM_LEDGER.md
+++ b/docs/qa/REGRESSION_CLAIM_LEDGER.md
@@ -1,6 +1,6 @@
 # Regression Claim Ledger
 
-Date: 2026-06-24
+Date: 2026-06-30
 Repository: `Techware-Hut/mosaic-backend`
 Backend branch: `codex/backend-final-preprod-audit`
 Starting staging SHA: `28f9be37c6ae168605ad1d978d32fb013ddfe3af`
@@ -12,9 +12,9 @@ Rule for this ledger: "not tested" is not treated as a failure. A claim is only 
 
 | Classification | Count | Meaning |
 | --- | ---: | --- |
-| Confirmed and fixed | 2 | Current pass or recent integrated work closed the exact issue with tests/evidence |
+| Confirmed and fixed | 4 | Current pass or recent integrated work closed the exact issue with tests/evidence |
 | Stale/already fixed | 13 | Report no longer matches current staging/frontend code |
-| Runtime evidence required | 9 | Code/tests align, but live final-domain proof is still needed |
+| Runtime evidence required | 7 | Code/tests align, but live final-domain proof is still needed |
 | Frontend-owned | 2 | Backend route is correct; issue was or is in frontend caller/UX/doc surface |
 | Product decision required | 5 | Behavior may be intentional and needs owner decision |
 | Partially confirmed | 2 | A mismatch/risk exists, but safe correction requires clearer consumer semantics |
@@ -25,8 +25,8 @@ Rule for this ledger: "not tested" is not treated as a failure. A claim is only 
 
 | Report item | Classification | Evidence | Owner/action |
 | --- | --- | --- | --- |
-| Vendor registration/OTP blocked | Runtime evidence required | Backend OTP tests pass and failure paths are structured; live SMTP/final-domain browser proof not run | QA with fresh vendor account |
-| Customer registration/OTP blocked | Runtime evidence required | Same auth/OTP coverage as vendor registration | QA with fresh customer account |
+| Vendor registration/OTP blocked | Confirmed and fixed | Production 2026-06-30 final-domain browser smoke reached OTP page, returned 201, and mailbox delivery arrived after backend `a5a4e54` auth SMTP deploy | No backend action; keep no-OTP-recording policy for any valid-code walkthrough |
+| Customer registration/OTP blocked | Confirmed and fixed | Production 2026-06-30 final-domain browser smoke reached OTP page, returned 201, and mailbox delivery arrived after backend `a5a4e54` auth SMTP deploy | No backend action; keep no-OTP-recording policy for any valid-code walkthrough |
 | Registration copy says OTP sent to mobile while backend emails OTP | Frontend-owned | Backend OTP behavior is email-based; frontend copy must remain email-aligned | Keep frontend copy aligned |
 | OTP delivery failure creates unsafe/ambiguous state | Stale/already fixed | `tests/auth/otp-email-delivery.test.js` passes for register/resend/login mail failure | No backend change |
 | Login response leaks unsafe user fields | Stale/already fixed | Login/session tests cover `toPublicAuthUser` safe serialization | No backend change |


### PR DESCRIPTION
## Summary
- Records the 2026-06-30 provider-neutral auth SMTP production deploy and live smoke evidence.
- Updates backend soft-launch and regression evidence so auth email no longer appears as an open runtime blocker.
- Keeps historical 2026-06-29 SMTP failure analysis intact as a superseded snapshot.

## Validation
- git diff --check
- Production smoke already completed: backend health/ready/build-info 200, authEmail.configured true, customer/vendor signup/resend/forgot-password mailbox delivery passed, unknown forgot-password generic/no delivery.

## Safety
- Docs only.
- No env values, OTPs, tokens, cookies, credentials, email addresses, or message bodies recorded.