### PR TITLE
Promote vendor PDF upload fix to production

### DIFF
--- a/controllers/vendorOnboardingUpload.controller.js
+++ b/controllers/vendorOnboardingUpload.controller.js
@@ -2,8 +2,10 @@ const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const {
   ALLOWED_VENDOR_ONBOARDING_MIME_TYPES,
+  MAX_VENDOR_ONBOARDING_UPLOAD_BYTES,
   isAllowedVendorOnboardingMime,
-  normalizeMimeType,
+  parseUploadSizeBytes,
+  resolveVendorOnboardingMimeType,
 } = require("../utils/vendorOnboardingUploadMimeAllowlist");
 
 const s3Client = new S3Client({
@@ -20,11 +22,11 @@ const s3Client = new S3Client({
 exports.getStage1UploadUrl = async (req, res) => {
   try {
     const userId = req.user._id;
-    const { fileName, fileType, documentType } = req.query;
+    const { fileName, fileType, documentType, fileSize } = req.query;
 
-    if (!fileName || !fileType || !documentType) {
+    if (!fileName || !documentType) {
       return res.status(400).json({
-        message: "fileName, fileType, and documentType are required",
+        message: "fileName and documentType are required",
       });
     }
 
@@ -48,13 +50,27 @@ exports.getStage1UploadUrl = async (req, res) => {
       });
     }
 
-    if (!isAllowedVendorOnboardingMime(fileType)) {
+    const normalizedFileType = resolveVendorOnboardingMimeType(fileType, fileName);
+
+    if (!isAllowedVendorOnboardingMime(fileType, fileName)) {
       return res.status(400).json({
         message: `Invalid file type. Allowed types: ${ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.join(", ")}`,
       });
     }
 
-    const normalizedFileType = normalizeMimeType(fileType);
+    const uploadSizeBytes = parseUploadSizeBytes(fileSize);
+    if (Number.isNaN(uploadSizeBytes)) {
+      return res.status(400).json({
+        message: "Invalid file size",
+      });
+    }
+
+    if (uploadSizeBytes !== null && uploadSizeBytes > MAX_VENDOR_ONBOARDING_UPLOAD_BYTES) {
+      return res.status(400).json({
+        message: `File must be under ${Math.round(MAX_VENDOR_ONBOARDING_UPLOAD_BYTES / (1024 * 1024))}MB`,
+      });
+    }
+
     const bucketName = process.env.AWS_S3_BUCKET;
 
     // ✅ ORGANIZED FOLDER STRUCTURE

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -288,8 +288,8 @@ After `verified`, the handler guides stages:
 
 ### Flow
 
-1. Client passes query params: `fileName`, `fileType`, `documentType`.
-2. Server validates `documentType` and MIME type.
+1. Client passes query params: `fileName`, `fileType`, `documentType`, and optional `fileSize`.
+2. Server validates `documentType`, resolved MIME type, and file size.
 3. Returns S3 presigned PUT URL (5 min expiry) + public `fileUrl`.
 4. Client uploads directly to S3, then saves URL in draft via `saveDraft`.
 
@@ -317,6 +317,9 @@ From [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingU
 | `application/pdf` | .pdf |
 
 - `normalizeMimeType` strips parameters (e.g. `image/jpeg; charset=binary`).
+- Common browser PDF alias `application/x-pdf` resolves to `application/pdf`.
+- Empty or generic browser MIME values can fall back to a safe file extension allowlist (`.jpg`, `.jpeg`, `.png`, `.webp`, `.pdf`).
+- Vendor onboarding uploads are limited to 5 MB when the client sends `fileSize`.
 - Rejected types return `400` with allowed list in message.
 - Filename sanitized: non-alphanumeric → `_`; timestamp prefixed in S3 key.
 

--- a/tests/vendor/vendor-onboarding-upload-mime.test.js
+++ b/tests/vendor/vendor-onboarding-upload-mime.test.js
@@ -75,6 +75,7 @@ test('vendor onboarding MIME allowlist accepts expected safe types', () => {
     ALLOWED_VENDOR_ONBOARDING_MIME_TYPES,
     isAllowedVendorOnboardingMime,
     normalizeMimeType,
+    resolveVendorOnboardingMimeType,
   } = require(allowlistPath);
 
   assert.deepEqual(ALLOWED_VENDOR_ONBOARDING_MIME_TYPES, ALLOWED);
@@ -82,7 +83,11 @@ test('vendor onboarding MIME allowlist accepts expected safe types', () => {
   assert.equal(isAllowedVendorOnboardingMime('image/png'), true);
   assert.equal(isAllowedVendorOnboardingMime('image/webp'), true);
   assert.equal(isAllowedVendorOnboardingMime('application/pdf'), true);
+  assert.equal(isAllowedVendorOnboardingMime('', 'policy.PDF'), true);
+  assert.equal(isAllowedVendorOnboardingMime('application/octet-stream', 'policy.pdf'), true);
   assert.equal(normalizeMimeType(' image/PNG ; charset=binary '), 'image/png');
+  assert.equal(normalizeMimeType('application/x-pdf'), 'application/pdf');
+  assert.equal(resolveVendorOnboardingMimeType('', 'policy.PDF'), 'application/pdf');
   assert.equal(isAllowedVendorOnboardingMime('application/javascript'), false);
   assert.equal(isAllowedVendorOnboardingMime('text/html'), false);
   assert.equal(isAllowedVendorOnboardingMime('application/x-msdownload'), false);
@@ -115,6 +120,71 @@ test('getStage1UploadUrl allows image and PDF MIME types', async () => {
     assert.match(res.body.uploadUrl, /^https:\/\/signed\.example\.com\//);
     assert.equal(res.body.documentType, documentType);
   }
+});
+
+test('getStage1UploadUrl allows PDF when browser omits MIME type but filename is safe', async () => {
+  const { getStage1UploadUrl } = loadUploadController();
+  const res = mockResponse();
+
+  await getStage1UploadUrl(
+    {
+      user: { _id: '507f1f77bcf86cd799439011' },
+      query: {
+        fileName: 'refund-policy.PDF',
+        fileType: '',
+        fileSize: String(1024),
+        documentType: 'refund-policy',
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.match(res.body.uploadUrl, /refund-policy\.PDF/);
+});
+
+test('getStage1UploadUrl rejects unsupported documents even when extension is present', async () => {
+  const { getStage1UploadUrl } = loadUploadController();
+  const res = mockResponse();
+
+  await getStage1UploadUrl(
+    {
+      user: { _id: '507f1f77bcf86cd799439011' },
+      query: {
+        fileName: 'terms.docx',
+        fileType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        fileSize: String(1024),
+        documentType: 'terms-service',
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Invalid file type/);
+  assert.match(res.body.message, /application\/pdf/);
+});
+
+test('getStage1UploadUrl rejects files over the documented upload size', async () => {
+  const { getStage1UploadUrl } = loadUploadController();
+  const res = mockResponse();
+
+  await getStage1UploadUrl(
+    {
+      user: { _id: '507f1f77bcf86cd799439011' },
+      query: {
+        fileName: 'large-policy.pdf',
+        fileType: 'application/pdf',
+        fileSize: String(5 * 1024 * 1024 + 1),
+        documentType: 'terms-service',
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'File must be under 5MB');
 });
 
 test('getStage1UploadUrl rejects unsafe MIME types with 400', async () => {

--- a/utils/vendorOnboardingUploadMimeAllowlist.js
+++ b/utils/vendorOnboardingUploadMimeAllowlist.js
@@ -5,20 +5,89 @@ const ALLOWED_VENDOR_ONBOARDING_MIME_TYPES = [
   'application/pdf',
 ];
 
+const VENDOR_ONBOARDING_MIME_ALIASES = {
+  'image/jpg': 'image/jpeg',
+  'application/x-pdf': 'application/pdf',
+};
+
+const VENDOR_ONBOARDING_EXTENSION_MIME_TYPES = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+};
+
+const GENERIC_UPLOAD_MIME_TYPES = new Set([
+  '',
+  'application/octet-stream',
+  'binary/octet-stream',
+]);
+
+const MAX_VENDOR_ONBOARDING_UPLOAD_BYTES = 5 * 1024 * 1024;
+
 function normalizeMimeType(mimeType) {
   if (typeof mimeType !== 'string') {
     return '';
   }
 
-  return mimeType.split(';')[0].trim().toLowerCase();
+  const normalized = mimeType.split(';')[0].trim().toLowerCase();
+  return VENDOR_ONBOARDING_MIME_ALIASES[normalized] || normalized;
 }
 
-function isAllowedVendorOnboardingMime(mimeType) {
-  return ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.includes(normalizeMimeType(mimeType));
+function getFileExtension(fileName) {
+  if (typeof fileName !== 'string') {
+    return '';
+  }
+
+  const normalized = fileName.trim().toLowerCase();
+  const lastDot = normalized.lastIndexOf('.');
+  if (lastDot < 0) {
+    return '';
+  }
+
+  return normalized.slice(lastDot);
+}
+
+function resolveVendorOnboardingMimeType(mimeType, fileName) {
+  const normalized = normalizeMimeType(mimeType);
+  if (ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.includes(normalized)) {
+    return normalized;
+  }
+
+  if (!GENERIC_UPLOAD_MIME_TYPES.has(normalized)) {
+    return normalized;
+  }
+
+  return VENDOR_ONBOARDING_EXTENSION_MIME_TYPES[getFileExtension(fileName)] || normalized;
+}
+
+function isAllowedVendorOnboardingMime(mimeType, fileName) {
+  return ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.includes(
+    resolveVendorOnboardingMimeType(mimeType, fileName)
+  );
+}
+
+function parseUploadSizeBytes(fileSize) {
+  if (fileSize === undefined || fileSize === null || fileSize === '') {
+    return null;
+  }
+
+  const parsed = Number(fileSize);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return Number.NaN;
+  }
+
+  return parsed;
 }
 
 module.exports = {
   ALLOWED_VENDOR_ONBOARDING_MIME_TYPES,
-  normalizeMimeType,
+  MAX_VENDOR_ONBOARDING_UPLOAD_BYTES,
+  VENDOR_ONBOARDING_EXTENSION_MIME_TYPES,
+  getFileExtension,
   isAllowedVendorOnboardingMime,
+  normalizeMimeType,
+  parseUploadSizeBytes,
+  resolveVendorOnboardingMimeType,
 };


### PR DESCRIPTION
## Summary
- Promote the vendor onboarding PDF upload presign validation fix from staging to production.
- Allows safe PDF MIME aliases and generic/empty browser MIME values when the filename is a PDF.
- Preserves the presigned S3 upload architecture and 5 MB upload validation.

## Validation
- Backend PR #170 merged into staging.
- Backend unit suite passed before merge: 451 tests.
- Focused vendor upload tests passed.

## Production QA Needed
- After merge/deploy, test with a safe dummy PDF using an authenticated vendor account.
