### PR TITLE
[release] Promote vendor upload proxy backend fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 | `AWS_ACCESS_KEY_ID` | Yes for uploads | AWS access key for S3 access |
 | `AWS_SECRET_ACCESS_KEY` | Yes for uploads | AWS secret key for S3 access |
 | `AWS_S3_BUCKET` | Yes for uploads | S3 bucket name for product, service, food, and onboarding uploads |
+| `S3_UPLOAD_CORS_ORIGINS` | Optional for S3 CORS apply script | Comma-separated browser origins allowed to direct-upload with presigned S3 URLs. Falls back to `CORS_ORIGINS`/`FRONTEND_URL` plus approved app/local origins. |
+
+Vendor PDF uploads use presigned S3 `PUT` URLs. If the API returns an upload URL but the browser `OPTIONS` request to S3 returns `403`, apply the bucket CORS rule in [docs/VENDOR_PDF_UPLOAD_CORS.md](docs/VENDOR_PDF_UPLOAD_CORS.md).
 
 ### Email and notifications
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 | `AWS_S3_BUCKET` | Yes for uploads | S3 bucket name for product, service, food, and onboarding uploads |
 | `S3_UPLOAD_CORS_ORIGINS` | Optional for S3 CORS apply script | Comma-separated browser origins allowed to direct-upload with presigned S3 URLs. Falls back to `CORS_ORIGINS`/`FRONTEND_URL` plus approved app/local origins. |
 
-Vendor PDF uploads use presigned S3 `PUT` URLs. If the API returns an upload URL but the browser `OPTIONS` request to S3 returns `403`, apply the bucket CORS rule in [docs/VENDOR_PDF_UPLOAD_CORS.md](docs/VENDOR_PDF_UPLOAD_CORS.md).
+Vendor PDF uploads from `/partners/business-profile` use the authenticated API proxy route `POST /api/vendor-onboarding/stage1/upload-file`, which writes to the same vendor-scoped S3 path without requiring browser-to-S3 CORS. The legacy/direct presigned `PUT` route remains available; if that path is used and browser `OPTIONS` to S3 returns `403`, apply the bucket CORS rule in [docs/VENDOR_PDF_UPLOAD_CORS.md](docs/VENDOR_PDF_UPLOAD_CORS.md).
 
 ### Email and notifications
 

--- a/controllers/vendorOnboardingUpload.controller.js
+++ b/controllers/vendorOnboardingUpload.controller.js
@@ -16,121 +16,137 @@ const s3Client = new S3Client({
   },
 });
 
-/**
- * Generate presigned URL for Vendor Onboarding Stage-1 documents
- */
+const ALLOWED_VENDOR_ONBOARDING_DOCUMENT_TYPES = [
+  "minority-proof",
+  "tax-doc",
+  "business-license",
+  "business-profile",
+  "feature-banner",
+  "refund-policy",
+  "terms-service",
+];
+
+function getVendorOnboardingFolderPath(userId, documentType) {
+  switch (documentType) {
+    case "minority-proof":
+      return `vendor-onboarding/stage1/${userId}/minority-proof`;
+    case "tax-doc":
+      return `vendor-onboarding/stage1/${userId}/tax-doc`;
+    case "business-license":
+      return `vendor-onboarding/stage1/${userId}/business-license`;
+    case "business-profile":
+      return `vendor-onboarding/business-profile/${userId}/logo`;
+    case "feature-banner":
+      return `vendor-onboarding/business-profile/${userId}/feature-banner`;
+    case "refund-policy":
+      return `vendor-onboarding/business-profile/${userId}/refund-policy`;
+    case "terms-service":
+      return `vendor-onboarding/business-profile/${userId}/terms-service`;
+    default:
+      return `vendor-onboarding/other/${userId}/${documentType}`;
+  }
+}
+
+function buildVendorOnboardingUploadTarget({
+  userId,
+  fileName,
+  fileType,
+  fileSize,
+  documentType,
+}) {
+  if (!fileName || !documentType) {
+    return {
+      status: 400,
+      body: { message: "fileName and documentType are required" },
+    };
+  }
+
+  if (!ALLOWED_VENDOR_ONBOARDING_DOCUMENT_TYPES.includes(documentType)) {
+    return {
+      status: 400,
+      body: { message: "Invalid document type" },
+    };
+  }
+
+  const normalizedFileType = resolveVendorOnboardingMimeType(fileType, fileName);
+  if (!isAllowedVendorOnboardingMime(fileType, fileName)) {
+    return {
+      status: 400,
+      body: {
+        message: `Invalid file type. Allowed types: ${ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.join(", ")}`,
+      },
+    };
+  }
+
+  const uploadSizeBytes = parseUploadSizeBytes(fileSize);
+  if (Number.isNaN(uploadSizeBytes)) {
+    return {
+      status: 400,
+      body: { message: "Invalid file size" },
+    };
+  }
+
+  if (uploadSizeBytes !== null && uploadSizeBytes > MAX_VENDOR_ONBOARDING_UPLOAD_BYTES) {
+    return {
+      status: 400,
+      body: {
+        message: `File must be under ${Math.round(
+          MAX_VENDOR_ONBOARDING_UPLOAD_BYTES / (1024 * 1024)
+        )}MB`,
+      },
+    };
+  }
+
+  const bucketName = process.env.AWS_S3_BUCKET;
+  const folderPath = getVendorOnboardingFolderPath(userId, documentType);
+  const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, "_");
+  const timestamp = Date.now();
+  const key = `${folderPath}/${timestamp}-${cleanFileName}`;
+  const region = process.env.AWS_REGION || "us-east-1";
+  const fileUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
+
+  return {
+    bucketName,
+    documentType,
+    fileUrl,
+    key,
+    normalizedFileType,
+  };
+}
+
 exports.getStage1UploadUrl = async (req, res) => {
   try {
     const userId = req.user._id;
     const { fileName, fileType, documentType, fileSize } = req.query;
 
-    if (!fileName || !documentType) {
-      return res.status(400).json({
-        message: "fileName and documentType are required",
-      });
+    const target = buildVendorOnboardingUploadTarget({
+      userId,
+      fileName,
+      fileType,
+      fileSize,
+      documentType,
+    });
+    if (target.status) {
+      return res.status(target.status).json(target.body);
     }
-
-    // ✅ ALLOWED DOCUMENT TYPES - INCLUDING BUSINESS PROFILE DOCUMENTS
-    const allowedDocTypes = [
-      // Stage 1 Documents
-      "minority-proof",
-      "tax-doc", 
-      "business-license",
-      
-      // Business Profile Documents
-      "business-profile",  // For logo/business profile image
-      "feature-banner",    // For business profile feature banner image
-      "refund-policy",     // For refund & return policy
-      "terms-service"      // For terms & conditions / service agreement
-    ];
-
-    if (!allowedDocTypes.includes(documentType)) {
-      return res.status(400).json({
-        message: "Invalid document type",
-      });
-    }
-
-    const normalizedFileType = resolveVendorOnboardingMimeType(fileType, fileName);
-
-    if (!isAllowedVendorOnboardingMime(fileType, fileName)) {
-      return res.status(400).json({
-        message: `Invalid file type. Allowed types: ${ALLOWED_VENDOR_ONBOARDING_MIME_TYPES.join(", ")}`,
-      });
-    }
-
-    const uploadSizeBytes = parseUploadSizeBytes(fileSize);
-    if (Number.isNaN(uploadSizeBytes)) {
-      return res.status(400).json({
-        message: "Invalid file size",
-      });
-    }
-
-    if (uploadSizeBytes !== null && uploadSizeBytes > MAX_VENDOR_ONBOARDING_UPLOAD_BYTES) {
-      return res.status(400).json({
-        message: `File must be under ${Math.round(MAX_VENDOR_ONBOARDING_UPLOAD_BYTES / (1024 * 1024))}MB`,
-      });
-    }
-
-    const bucketName = process.env.AWS_S3_BUCKET;
-
-    // ✅ ORGANIZED FOLDER STRUCTURE
-    let folderPath;
-    switch (documentType) {
-      // Stage 1 Documents
-      case "minority-proof":
-        folderPath = `vendor-onboarding/stage1/${userId}/minority-proof`;
-        break;
-      case "tax-doc":
-        folderPath = `vendor-onboarding/stage1/${userId}/tax-doc`;
-        break;
-      case "business-license":
-        folderPath = `vendor-onboarding/stage1/${userId}/business-license`;
-        break;
-      
-      // Business Profile Documents  
-      case "business-profile":
-        folderPath = `vendor-onboarding/business-profile/${userId}/logo`;
-        break;
-      case "feature-banner":
-        folderPath = `vendor-onboarding/business-profile/${userId}/feature-banner`;
-        break;
-      case "refund-policy":
-        folderPath = `vendor-onboarding/business-profile/${userId}/refund-policy`;
-        break;
-      case "terms-service":
-        folderPath = `vendor-onboarding/business-profile/${userId}/terms-service`;
-        break;
-      default:
-        folderPath = `vendor-onboarding/other/${userId}/${documentType}`;
-    }
-
-    // Clean filename - remove special characters, spaces
-    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
-    const timestamp = Date.now();
-    const key = `${folderPath}/${timestamp}-${cleanFileName}`;
 
     const command = new PutObjectCommand({
-      Bucket: bucketName,
-      Key: key,
-      ContentType: normalizedFileType,
+      Bucket: target.bucketName,
+      Key: target.key,
+      ContentType: target.normalizedFileType,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 300, // 5 minutes
+      expiresIn: 300,
     });
-
-    // ✅ CONSTRUCT PUBLIC URL
-    const region = process.env.AWS_REGION || 'us-east-1';
-    const fileUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
 
     return res.json({
       success: true,
       uploadUrl,
-      fileUrl,
-      documentType,
-      key
+      fileUrl: target.fileUrl,
+      documentType: target.documentType,
+      key: target.key,
     });
-
   } catch (error) {
     console.error("Presigned URL error:", error);
     return res.status(500).json({
@@ -140,53 +156,54 @@ exports.getStage1UploadUrl = async (req, res) => {
   }
 };
 
-// exports.getStage1UploadUrl = async (req, res) => {
-//   try {
-//     const userId = req.user._id;
-//     const { fileName, fileType, documentType } = req.query;
+exports.uploadStage1File = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { documentType } = req.body;
+    const file = req.file;
 
-//     if (!fileName || !fileType || !documentType) {
-//       return res.status(400).json({
-//         message: "fileName, fileType, and documentType are required",
-//       });
-//     }
+    if (!file) {
+      return res.status(400).json({
+        success: false,
+        message: "File is required",
+      });
+    }
 
-//     const allowedDocTypes = [
-//       "minority-proof",
-//       "tax-doc",
-//       "business-license",
-//     ];
+    const target = buildVendorOnboardingUploadTarget({
+      userId,
+      fileName: file.originalname,
+      fileType: file.mimetype,
+      fileSize: file.size,
+      documentType,
+    });
+    if (target.status) {
+      return res.status(target.status).json(target.body);
+    }
 
-//     if (!allowedDocTypes.includes(documentType)) {
-//       return res.status(400).json({
-//         message: "Invalid document type",
-//       });
-//     }
+    const command = new PutObjectCommand({
+      Bucket: target.bucketName,
+      Key: target.key,
+      Body: file.buffer,
+      ContentType: target.normalizedFileType,
+    });
 
-//     const bucketName = process.env.AWS_S3_BUCKET;
+    await s3Client.send(command);
 
-//     const key = `vendor-onboarding/stage1/${userId}/${documentType}/${Date.now()}-${fileName}`;
-
-//     const command = new PutObjectCommand({
-//       Bucket: bucketName,
-//       Key: key,
-//       ContentType: fileType,
-//     });
-
-//     const uploadUrl = await getSignedUrl(s3Client, command, {
-//       expiresIn: 300, // 5 minutes
-//     });
-
-//     const fileUrl = `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
-
-//     return res.json({
-//       uploadUrl,
-//       fileUrl,
-//     });
-//   } catch (error) {
-//     console.error("Presigned URL error:", error);
-//     return res.status(500).json({
-//       message: "Failed to generate upload URL",
-//     });
-//   }
-// };
+    return res.json({
+      success: true,
+      uploadMethod: "api-proxy",
+      fileUrl: target.fileUrl,
+      documentType: target.documentType,
+      key: target.key,
+    });
+  } catch (error) {
+    console.error("Vendor onboarding upload error:", {
+      message: error.message,
+      name: error.name,
+    });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to upload file",
+    });
+  }
+};

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -82,6 +82,7 @@ Mounts: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (same
 | PATCH | `.../business-profile` | same | `patchBusinessProfile` | vendor + Stage-1 `verified` | Partial profile update | 🟡 |
 | GET | `.../status/:applicationId` | — | `getStatusByApplicationId` | ⚪ **Public** | Application status poll | 🟢 — exposes progress by ID |
 | GET | `.../applicationId` | `authenticate` | `getApplicationId` | Authenticated | Get own application ID | 🟡 |
+| POST | `.../stage1/upload-file` | `authenticate`, `requireVerifiedVendor` | `uploadStage1File` | vendor verified | API-proxied S3 document upload | 🟡 P2.6 |
 | GET | `.../stage1/upload-url` | `authenticate`, `requireVerifiedVendor` | `getStage1UploadUrl` | vendor verified | S3 presigned upload URL | 🟡 P2.6 |
 | POST | `.../stage1/create-payment` | same | `createVerificationPayment` | vendor verified | Create $24.99 Stripe PI | 🔴 P2.2 — real/test charge |
 | GET | `.../stage1/payment-status` | same | `getPaymentStatus` | vendor verified | Verification payment status | 🟡 P2.4 |

--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -178,7 +178,8 @@ Mount: `/api/vendor-onboarding` → [`routes/vendorOnboarding.routes.js`](../rou
 | `/api/vendor-onboarding/submit` | POST | Yes | verified vendor | Submit application | **valid** | |
 | `/api/vendor-onboarding/business-profile` | PUT | Yes | stage-1 verified vendor | Business profile update | **valid** | Full replace |
 | `/api/vendor-onboarding/business-profile` | PATCH | Yes | stage-1 verified vendor | Business profile patch | **valid** | Partial update |
-| `/api/vendor-onboarding/stage1/upload-url` | GET | Yes | verified vendor | Doc upload | **valid** | |
+| `/api/vendor-onboarding/stage1/upload-file` | POST | Yes | verified vendor | Doc upload proxy | **valid** | Business-profile PDF UI path |
+| `/api/vendor-onboarding/stage1/upload-url` | GET | Yes | verified vendor | Presigned doc upload | **valid** | Legacy/direct S3 path |
 | `/api/vendor-onboarding/stage1/create-payment` | POST | Yes | verified vendor | Verification fee | **valid** | Stripe Checkout path |
 | `/api/vendor-onboarding/stage1/payment-status` | GET | Yes | verified vendor | Payment poll | **valid** | |
 | `/api/vendor-onboarding/status/:applicationId` | GET | No | Public | Application status page | **valid** | |

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -283,15 +283,19 @@ After `verified`, the handler guides stages:
 
 ## Document upload behavior
 
-**Route:** `GET /api/vendor-onboarding/stage1/upload-url` → `getStage1UploadUrl`  
+**UI route:** `POST /api/vendor-onboarding/stage1/upload-file` → `uploadStage1File`
+**Legacy/direct route:** `GET /api/vendor-onboarding/stage1/upload-url` → `getStage1UploadUrl`
 **Middleware:** `authenticate` → `requireVerifiedVendor`
 
 ### Flow
 
-1. Client passes query params: `fileName`, `fileType`, `documentType`, and optional `fileSize`.
-2. Server validates `documentType`, resolved MIME type, and file size.
-3. Returns S3 presigned PUT URL (5 min expiry) + public `fileUrl`.
-4. Client uploads directly to S3, then saves URL in draft via `saveDraft`.
+1. Business-profile UI sends `multipart/form-data` to `POST /stage1/upload-file` with `file` and `documentType`.
+2. Server verifies the vendor session, validates `documentType`, resolved MIME type, and file size.
+3. Server writes the object to S3 under the authenticated vendor user path.
+4. API returns `fileUrl`, `documentType`, and object `key`.
+5. Client saves URL in draft via `saveDraft`.
+
+The presigned `GET /stage1/upload-url` path is retained for direct S3 uploads, but browser direct-upload requires S3 bucket CORS. The intended business-profile PDF path uses the API proxy to avoid S3 browser preflight failures.
 
 ### Allowed `documentType` values
 
@@ -322,7 +326,7 @@ From [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingU
 - Vendor onboarding uploads are limited to 5 MB when the client sends `fileSize`.
 - Rejected types return `400` with allowed list in message.
 - Filename sanitized: non-alphanumeric → `_`; timestamp prefixed in S3 key.
-- Direct S3 browser uploads require bucket CORS for the frontend origin, `PUT`, and the `Content-Type` header. See [`docs/VENDOR_PDF_UPLOAD_CORS.md`](VENDOR_PDF_UPLOAD_CORS.md).
+- API proxy uploads require backend `CORS_ORIGINS` for the frontend origin and do not require browser-to-S3 CORS. Direct S3 browser uploads require bucket CORS for the frontend origin, `PUT`, and the `Content-Type` header. See [`docs/VENDOR_PDF_UPLOAD_CORS.md`](VENDOR_PDF_UPLOAD_CORS.md).
 
 **Tests:** [`tests/vendor/vendor-onboarding-upload-mime.test.js`](../tests/vendor/vendor-onboarding-upload-mime.test.js)
 
@@ -410,6 +414,7 @@ flowchart TD
 | `POST /draft` | Yes — `requireVerifiedVendor` | No |
 | `GET /draft`, `GET /onboarding-data` | Yes | No |
 | `POST /submit` | Yes | No |
+| `POST /stage1/upload-file` | Yes | No |
 | `GET /stage1/upload-url` | Yes | No |
 | `POST /stage1/create-payment` | Yes | No |
 | `GET /stage1/payment-status` | Yes | No |
@@ -515,6 +520,7 @@ npm test   # includes tests/vendor/*
 | GET | `/draft` | `getDraft` | Vendor verified |
 | POST | `/submit` | `submitForReview` | Vendor verified |
 | GET | `/onboarding-data` | `getOnboardingData` | Vendor verified |
+| POST | `/stage1/upload-file` | `uploadStage1File` | Vendor verified |
 | GET | `/stage1/upload-url` | `getStage1UploadUrl` | Vendor verified |
 | POST | `/stage1/create-payment` | `createVerificationPayment` | Vendor verified |
 | GET | `/stage1/payment-status` | `getPaymentStatus` | Vendor verified |

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -322,6 +322,7 @@ From [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingU
 - Vendor onboarding uploads are limited to 5 MB when the client sends `fileSize`.
 - Rejected types return `400` with allowed list in message.
 - Filename sanitized: non-alphanumeric → `_`; timestamp prefixed in S3 key.
+- Direct S3 browser uploads require bucket CORS for the frontend origin, `PUT`, and the `Content-Type` header. See [`docs/VENDOR_PDF_UPLOAD_CORS.md`](VENDOR_PDF_UPLOAD_CORS.md).
 
 **Tests:** [`tests/vendor/vendor-onboarding-upload-mime.test.js`](../tests/vendor/vendor-onboarding-upload-mime.test.js)
 

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -1,21 +1,26 @@
 # Vendor PDF Upload CORS Runbook
 
-This app uses AWS S3 presigned URLs for vendor onboarding document uploads. Supabase Storage is not part of the current vendor PDF upload path.
+This app stores vendor onboarding documents in AWS S3. Supabase Storage is not part of the current vendor PDF upload path.
+
+The intended `/partners/business-profile` UI path now uses an authenticated backend upload proxy so the browser uploads to the Mosaic API, not directly to S3. The presigned S3 route remains available for direct-upload flows and diagnostics.
 
 ## Request Flow
 
 1. Vendor opens `/partners/business-profile`.
-2. Frontend calls the authenticated API route:
-   `GET /api/vendor-onboarding/stage1/upload-url`.
-3. Backend verifies the session and `business_owner` vendor permissions, validates the document type, MIME type, and size, then returns a presigned S3 `PUT` URL.
-4. Frontend uploads the PDF directly to the presigned S3 URL with:
-   - method: `PUT`
-   - header: `Content-Type: application/pdf`
-   - credentials: omitted
-   - no `Authorization`, `x-upsert`, cache-control, or app custom headers
-5. Frontend saves the returned `fileUrl` in the vendor onboarding draft.
+2. Frontend posts `multipart/form-data` to:
+   `POST /api/vendor-onboarding/stage1/upload-file`.
+3. Backend verifies the session and `business_owner` vendor permissions, validates the document type, MIME type, and size, then writes the file to S3 under the authenticated vendor user path.
+4. Frontend saves the returned `fileUrl` in the vendor onboarding draft.
 
-The API CORS policy and the S3 bucket CORS policy are separate. A successful `upload-url` response proves API auth/CORS is working, but the browser still preflights the direct S3 `PUT`.
+The API proxy path uses normal backend CORS (`CORS_ORIGINS`) and does not require browser-to-S3 preflight. A successful proxy upload proves API auth/CORS and server-side S3 write behavior are working.
+
+Legacy/direct S3 flow:
+
+1. Frontend calls `GET /api/vendor-onboarding/stage1/upload-url`.
+2. Backend returns a presigned S3 `PUT` URL.
+3. Browser uploads directly to S3 with only `Content-Type` and the raw file body.
+
+For this direct path, the API CORS policy and S3 bucket CORS policy are separate. A successful `upload-url` response proves API auth/CORS is working, but the browser still preflights the direct S3 `PUT`.
 
 ## Required Environment
 
@@ -33,7 +38,7 @@ If `S3_UPLOAD_CORS_ORIGINS` is not set, the helper falls back to `CORS_ORIGINS`,
 
 ## S3 Bucket CORS
 
-The S3 bucket must allow browser preflight for the frontend origin and the signed `PUT` request. AWS S3 CORS rules do not list `OPTIONS` as an allowed method; S3 answers `OPTIONS` when the requested method, origin, and headers match a rule.
+The API proxy path does not require S3 bucket CORS. If using the legacy/direct presigned path, the S3 bucket must allow browser preflight for the frontend origin and the signed `PUT` request. AWS S3 CORS rules do not list `OPTIONS` as an allowed method; S3 answers `OPTIONS` when the requested method, origin, and headers match a rule.
 
 Required rule shape:
 
@@ -84,9 +89,9 @@ Use a safe dummy PDF, not a real vendor document.
 1. Log in as a verified vendor/business owner.
 2. Open `/partners/business-profile`.
 3. Upload a PDF for refund policy or terms/service agreement.
-4. Confirm `GET /api/vendor-onboarding/stage1/upload-url` returns `200`.
-5. Confirm the S3 `OPTIONS` preflight does not return `403`.
-6. Confirm the S3 `PUT` returns a success status.
+4. Confirm `POST /api/vendor-onboarding/stage1/upload-file` returns `200`.
+5. Confirm the upload request does not show a browser CORS failure.
+6. Confirm no browser request is made directly to S3 for the business-profile PDF path.
 7. Confirm the resulting object key is under the authenticated vendor path:
    `vendor-onboarding/business-profile/{vendorUserId}/...`.
 8. Confirm a customer or unauthenticated session cannot get a signed upload URL.
@@ -95,6 +100,8 @@ Use a safe dummy PDF, not a real vendor document.
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
+| `POST /stage1/upload-file` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification |
+| `POST /stage1/upload-file` fails API CORS | Backend `CORS_ORIGINS` missing frontend origin | Add the frontend origin to backend CORS env |
 | `upload-url` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification, not S3 CORS |
 | `upload-url` returns `200`, then S3 `OPTIONS` returns `403` | Bucket CORS missing origin, `PUT`, or `Content-Type` | Apply this S3 CORS rule |
 | S3 `OPTIONS` passes, but `PUT` fails signature error | Frontend changed signed headers or upload method | Use direct `PUT` with the resolved content type only |

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -1,0 +1,101 @@
+# Vendor PDF Upload CORS Runbook
+
+This app uses AWS S3 presigned URLs for vendor onboarding document uploads. Supabase Storage is not part of the current vendor PDF upload path.
+
+## Request Flow
+
+1. Vendor opens `/partners/business-profile`.
+2. Frontend calls the authenticated API route:
+   `GET /api/vendor-onboarding/stage1/upload-url`.
+3. Backend verifies the session and `business_owner` vendor permissions, validates the document type, MIME type, and size, then returns a presigned S3 `PUT` URL.
+4. Frontend uploads the PDF directly to the presigned S3 URL with:
+   - method: `PUT`
+   - header: `Content-Type: application/pdf`
+   - credentials: omitted
+   - no `Authorization`, `x-upsert`, cache-control, or app custom headers
+5. Frontend saves the returned `fileUrl` in the vendor onboarding draft.
+
+The API CORS policy and the S3 bucket CORS policy are separate. A successful `upload-url` response proves API auth/CORS is working, but the browser still preflights the direct S3 `PUT`.
+
+## Required Environment
+
+Backend runtime:
+
+| Variable | Purpose |
+| --- | --- |
+| `AWS_REGION` | S3 client region |
+| `AWS_ACCESS_KEY_ID` | Server-side S3 signing/apply credentials |
+| `AWS_SECRET_ACCESS_KEY` | Server-side S3 signing/apply credentials |
+| `AWS_S3_BUCKET` | Upload bucket name |
+| `S3_UPLOAD_CORS_ORIGINS` | Optional comma-separated browser origins for S3 upload CORS |
+
+If `S3_UPLOAD_CORS_ORIGINS` is not set, the helper falls back to `CORS_ORIGINS`, `FRONTEND_URL`, the production app origins, and local dev origins.
+
+## S3 Bucket CORS
+
+The S3 bucket must allow browser preflight for the frontend origin and the signed `PUT` request. AWS S3 CORS rules do not list `OPTIONS` as an allowed method; S3 answers `OPTIONS` when the requested method, origin, and headers match a rule.
+
+Required rule shape:
+
+```json
+{
+  "CORSRules": [
+    {
+      "ID": "MosaicVendorPresignedUploads",
+      "AllowedOrigins": [
+        "https://mosaicbizhub.com",
+        "https://www.mosaicbizhub.com",
+        "https://app.mosaicbizhub.com",
+        "https://mosaic-biz-frontend-launch.vercel.app",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000"
+      ],
+      "AllowedMethods": ["PUT", "GET", "HEAD"],
+      "AllowedHeaders": ["Content-Type"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+```
+
+For Vercel preview deployments, either add the exact preview origin to `S3_UPLOAD_CORS_ORIGINS` before applying the rule, or explicitly approve a wildcard preview origin such as `https://*.vercel.app`.
+
+## Apply The Rule
+
+Dry run:
+
+```bash
+npm run s3:cors:vendor-upload
+```
+
+Apply:
+
+```bash
+npm run s3:cors:vendor-upload -- --apply
+```
+
+The apply command writes only S3 bucket CORS. It preserves existing CORS rules and replaces only the `MosaicVendorPresignedUploads` managed rule. It does not change bucket policy, object ACLs, IAM permissions, or make files globally writable.
+
+## Browser Test Checklist
+
+Use a safe dummy PDF, not a real vendor document.
+
+1. Log in as a verified vendor/business owner.
+2. Open `/partners/business-profile`.
+3. Upload a PDF for refund policy or terms/service agreement.
+4. Confirm `GET /api/vendor-onboarding/stage1/upload-url` returns `200`.
+5. Confirm the S3 `OPTIONS` preflight does not return `403`.
+6. Confirm the S3 `PUT` returns a success status.
+7. Confirm the resulting object key is under the authenticated vendor path:
+   `vendor-onboarding/business-profile/{vendorUserId}/...`.
+8. Confirm a customer or unauthenticated session cannot get a signed upload URL.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `upload-url` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification, not S3 CORS |
+| `upload-url` returns `200`, then S3 `OPTIONS` returns `403` | Bucket CORS missing origin, `PUT`, or `Content-Type` | Apply this S3 CORS rule |
+| S3 `OPTIONS` passes, but `PUT` fails signature error | Frontend changed signed headers or upload method | Use direct `PUT` with the resolved content type only |
+| Local dev upload fails | Localhost origin missing from bucket CORS | Add local origin and reapply |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -450,6 +450,7 @@ This is the strictest vendor guard — it ensures only fully email-verified vend
 | GET    | `/api/vendor-onboarding/onboarding-data`    | ✅ `authenticate` | `requireVerifiedVendor`    |
 | PUT    | `/api/vendor-onboarding/business-profile`   | ✅ `authenticate` | `requireStage1Verified` (via `requireVerifiedVendor.create`) |
 | PATCH  | `/api/vendor-onboarding/business-profile`   | ✅ `authenticate` | `requireStage1Verified` (via `requireVerifiedVendor.create`) |
+| POST   | `/api/vendor-onboarding/stage1/upload-file` | ✅ `authenticate` | `requireVerifiedVendor`    |
 | GET    | `/api/vendor-onboarding/stage1/upload-url`  | ✅ `authenticate` | `requireVerifiedVendor`    |
 | POST   | `/api/vendor-onboarding/stage1/create-payment` | ✅ `authenticate` | `requireVerifiedVendor` |
 

--- a/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
+++ b/docs/backend/BACKEND_ENVIRONMENT_VARIABLES_NAMES_ONLY.md
@@ -92,6 +92,7 @@
 | `AWS_ACCESS_KEY_ID` | required-prod |
 | `AWS_SECRET_ACCESS_KEY` | required-prod |
 | `AWS_S3_BUCKET` | required-prod |
+| `S3_UPLOAD_CORS_ORIGINS` | optional-prod |
 | `STORAGE_PROVIDER` | optional (`aws`) |
 
 ---

--- a/middlewares/vendorOnboardingFileUpload.js
+++ b/middlewares/vendorOnboardingFileUpload.js
@@ -1,0 +1,36 @@
+const multer = require("multer");
+const {
+  MAX_VENDOR_ONBOARDING_UPLOAD_BYTES,
+} = require("../utils/vendorOnboardingUploadMimeAllowlist");
+
+const vendorOnboardingFileUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_VENDOR_ONBOARDING_UPLOAD_BYTES,
+    files: 1,
+  },
+}).single("file");
+
+function handleVendorOnboardingFileUpload(req, res, next) {
+  vendorOnboardingFileUpload(req, res, (error) => {
+    if (!error) {
+      return next();
+    }
+
+    if (error.code === "LIMIT_FILE_SIZE") {
+      return res.status(400).json({
+        success: false,
+        message: `File must be under ${Math.round(
+          MAX_VENDOR_ONBOARDING_UPLOAD_BYTES / (1024 * 1024)
+        )}MB`,
+      });
+    }
+
+    return res.status(400).json({
+      success: false,
+      message: "Invalid upload request",
+    });
+  });
+}
+
+module.exports = handleVendorOnboardingFileUpload;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:contract": "node --test tests/launch/backend-launch-contract.test.js",
     "test:integration": "node scripts/run-integration-tests.js",
     "smoke:backend": "node scripts/run-smoke-backend.js",
+    "s3:cors:vendor-upload": "node scripts/apply-s3-upload-cors.js",
     "dev": "nodemon index.js",
     "start": "node index.js"
   },

--- a/routes/vendorOnboarding.routes.js
+++ b/routes/vendorOnboarding.routes.js
@@ -6,6 +6,7 @@ const requireVerifiedVendor = require("../middlewares/requireVerifiedVendor");
 const requireStage1VerifiedVendor = requireVerifiedVendor.create({
   requireStage1Verified: true,
 });
+const handleVendorOnboardingFileUpload = require("../middlewares/vendorOnboardingFileUpload");
 const authenticate = require('../middlewares/authenticate');
 const isAdmin = require('../middlewares/isAdmin');
 
@@ -24,6 +25,7 @@ const {
 
 const {
   getStage1UploadUrl,
+  uploadStage1File,
 } = require("../controllers/vendorOnboardingUpload.controller");
 
 const {
@@ -48,6 +50,13 @@ router.get('/status/:applicationId', getStatusByApplicationId);
 router.get('/applicationId',authMiddleware,getApplicationId);
 
 router.get("/stage1/upload-url", authMiddleware, requireVerifiedVendor, getStage1UploadUrl);
+router.post(
+  "/stage1/upload-file",
+  authMiddleware,
+  requireVerifiedVendor,
+  handleVendorOnboardingFileUpload,
+  uploadStage1File
+);
 router.post("/stage1/create-payment", authMiddleware, requireVerifiedVendor, createVerificationPayment);
 router.get("/stage1/payment-status", authMiddleware, requireVerifiedVendor, getPaymentStatus);
 

--- a/scripts/apply-s3-upload-cors.js
+++ b/scripts/apply-s3-upload-cors.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+require('dotenv').config();
+
+const {
+  GetBucketCorsCommand,
+  S3Client,
+  PutBucketCorsCommand,
+} = require('@aws-sdk/client-s3');
+const {
+  buildS3UploadCorsConfiguration,
+  S3_UPLOAD_CORS_RULE_ID,
+} = require('../utils/s3UploadCorsConfig');
+
+async function getExistingCorsRules(client, bucket) {
+  try {
+    const current = await client.send(
+      new GetBucketCorsCommand({
+        Bucket: bucket,
+      })
+    );
+
+    return current.CORSRules || [];
+  } catch (error) {
+    if (
+      error?.name === 'NoSuchCORSConfiguration' ||
+      error?.$metadata?.httpStatusCode === 404
+    ) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const corsConfiguration = buildS3UploadCorsConfiguration(process.env);
+
+  if (!apply) {
+    console.log(JSON.stringify(corsConfiguration, null, 2));
+    console.log(
+      'Dry run only. Re-run with --apply to write this CORS configuration to the S3 bucket.'
+    );
+    return;
+  }
+
+  if (!process.env.AWS_S3_BUCKET) {
+    throw new Error('AWS_S3_BUCKET is required');
+  }
+
+  const client = new S3Client({
+    region: process.env.AWS_REGION,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  });
+
+  const existingRules = await getExistingCorsRules(client, process.env.AWS_S3_BUCKET);
+  const managedRule = corsConfiguration.CORSRules[0];
+  const mergedConfiguration = {
+    CORSRules: [
+      ...existingRules.filter((rule) => rule.ID !== S3_UPLOAD_CORS_RULE_ID),
+      managedRule,
+    ],
+  };
+
+  await client.send(
+    new PutBucketCorsCommand({
+      Bucket: process.env.AWS_S3_BUCKET,
+      CORSConfiguration: mergedConfiguration,
+    })
+  );
+
+  console.log(
+    `Applied S3 upload CORS configuration with ${managedRule.AllowedOrigins.length} allowed browser origins.`
+  );
+}
+
+main().catch((error) => {
+  if (error.message === 'AWS_S3_BUCKET is required') {
+    console.error(error.message);
+  } else {
+    const status = error?.$metadata?.httpStatusCode
+      ? ` status=${error.$metadata.httpStatusCode}`
+      : '';
+    console.error(`Failed to apply S3 upload CORS: ${error.name || 'Error'}${status}`);
+  }
+  process.exit(1);
+});

--- a/tests/cors/cors-login-preflight.test.js
+++ b/tests/cors/cors-login-preflight.test.js
@@ -55,6 +55,9 @@ function createCorsProbeApp(envOverrides) {
   app.post('/api/users/login', (_req, res) => {
     res.sendStatus(200);
   });
+  app.post('/api/vendor-onboarding/stage1/upload-file', (_req, res) => {
+    res.sendStatus(200);
+  });
 
   return {
     app,
@@ -122,6 +125,28 @@ test('OPTIONS /api/users/login denies disallowed origin without server error', a
 
     assert.notEqual(res.status, 500);
     assert.equal(res.headers['access-control-allow-origin'], undefined);
+  } finally {
+    cleanup();
+  }
+});
+
+test('OPTIONS /api/vendor-onboarding/stage1/upload-file allows production apex origin with credentials', async () => {
+  const { app, cleanup } = createCorsProbeApp({
+    NODE_ENV: 'production',
+    CORS_ORIGINS:
+      'https://mosaicbizhub.com,https://app.mosaicbizhub.com,https://mosaic-biz-frontend-launch.vercel.app',
+  });
+
+  try {
+    const res = await supertest(app)
+      .options('/api/vendor-onboarding/stage1/upload-file')
+      .set('Origin', 'https://mosaicbizhub.com')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'content-type');
+
+    assert.equal(res.status, 204);
+    assert.equal(res.headers['access-control-allow-origin'], 'https://mosaicbizhub.com');
+    assert.equal(res.headers['access-control-allow-credentials'], 'true');
   } finally {
     cleanup();
   }

--- a/tests/vendor/vendor-onboarding-upload-mime.test.js
+++ b/tests/vendor/vendor-onboarding-upload-mime.test.js
@@ -26,10 +26,16 @@ function loadUploadController() {
   process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'test-secret';
 
   const originalLoad = Module._load;
+  const awsMockState = { sentCommands: [] };
   Module._load = function mockLoad(request, parent, isMain) {
     if (request === '@aws-sdk/client-s3') {
       return {
-        S3Client: class S3Client {},
+        S3Client: class S3Client {
+          async send(command) {
+            awsMockState.sentCommands.push(command);
+            return { ETag: '"test-etag"' };
+          }
+        },
         PutObjectCommand: class PutObjectCommand {
           constructor(input) {
             this.input = input;
@@ -52,6 +58,7 @@ function loadUploadController() {
   delete require.cache[uploadControllerPath];
   const loaded = require(uploadControllerPath);
   Module._load = originalLoad;
+  loaded.__awsMockState = awsMockState;
   return loaded;
 }
 
@@ -207,6 +214,81 @@ test('getStage1UploadUrl rejects unsafe MIME types with 400', async () => {
   assert.match(res.body.message, /Invalid file type/);
   assert.match(res.body.message, /image\/jpeg/);
   assert.match(res.body.message, /application\/pdf/);
+});
+
+test('uploadStage1File uploads PDF through authenticated API proxy under vendor path', async () => {
+  const controller = loadUploadController();
+  const res = mockResponse();
+  const vendorUserId = '507f1f77bcf86cd799439011';
+  const body = Buffer.from('%PDF-1.4 safe dummy');
+
+  await controller.uploadStage1File(
+    {
+      user: { _id: vendorUserId },
+      body: { documentType: 'refund-policy' },
+      file: {
+        originalname: 'refund policy.PDF',
+        mimetype: 'application/pdf',
+        size: body.length,
+        buffer: body,
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.uploadMethod, 'api-proxy');
+  assert.equal(res.body.documentType, 'refund-policy');
+  assert.match(
+    res.body.key,
+    new RegExp(`^vendor-onboarding/business-profile/${vendorUserId}/refund-policy/\\d+-refund_policy\\.PDF$`)
+  );
+  assert.equal(controller.__awsMockState.sentCommands.length, 1);
+  const commandInput = controller.__awsMockState.sentCommands[0].input;
+  assert.equal(commandInput.Bucket, 'test-bucket');
+  assert.equal(commandInput.Key, res.body.key);
+  assert.equal(commandInput.ContentType, 'application/pdf');
+  assert.equal(commandInput.Body, body);
+});
+
+test('uploadStage1File rejects missing file with safe validation error', async () => {
+  const { uploadStage1File } = loadUploadController();
+  const res = mockResponse();
+
+  await uploadStage1File(
+    {
+      user: { _id: '507f1f77bcf86cd799439011' },
+      body: { documentType: 'refund-policy' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(res.body.message, 'File is required');
+});
+
+test('uploadStage1File rejects unsafe proxy upload MIME types', async () => {
+  const { uploadStage1File } = loadUploadController();
+  const res = mockResponse();
+
+  await uploadStage1File(
+    {
+      user: { _id: '507f1f77bcf86cd799439011' },
+      body: { documentType: 'terms-service' },
+      file: {
+        originalname: 'payload.html',
+        mimetype: 'text/html',
+        size: 12,
+        buffer: Buffer.from('<script />'),
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Invalid file type/);
 });
 
 test('vendor onboarding upload route remains blocked without authentication', async () => {

--- a/tests/vendor/vendor-upload-s3-cors-config.test.js
+++ b/tests/vendor/vendor-upload-s3-cors-config.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildS3UploadCorsConfiguration,
+  getS3UploadCorsOrigins,
+  isSafeBrowserOrigin,
+} = require('../../utils/s3UploadCorsConfig');
+
+test('vendor upload S3 CORS origins include app and local browser origins', () => {
+  const origins = getS3UploadCorsOrigins({
+    S3_UPLOAD_CORS_ORIGINS:
+      'https://preview.example.vercel.app,https://api.mosaicbizhub.com,*',
+    FRONTEND_URL: 'https://mosaicbizhub.com',
+  });
+
+  assert.ok(origins.includes('https://preview.example.vercel.app'));
+  assert.ok(origins.includes('https://mosaicbizhub.com'));
+  assert.ok(origins.includes('https://www.mosaicbizhub.com'));
+  assert.ok(origins.includes('https://mosaic-biz-frontend-launch.vercel.app'));
+  assert.ok(origins.includes('http://localhost:3000'));
+  assert.ok(origins.includes('http://127.0.0.1:3000'));
+  assert.equal(origins.includes('https://api.mosaicbizhub.com'), false);
+  assert.equal(origins.includes('*'), false);
+});
+
+test('vendor upload S3 CORS rule allows presigned PUT with only required headers', () => {
+  const corsConfiguration = buildS3UploadCorsConfiguration({
+    S3_UPLOAD_CORS_ORIGINS: 'https://mosaicbizhub.com',
+  });
+  const [rule] = corsConfiguration.CORSRules;
+
+  assert.equal(rule.ID, 'MosaicVendorPresignedUploads');
+  assert.deepEqual(rule.AllowedMethods, ['PUT', 'GET', 'HEAD']);
+  assert.deepEqual(rule.AllowedHeaders, ['Content-Type']);
+  assert.deepEqual(rule.ExposeHeaders, ['ETag']);
+  assert.equal(rule.MaxAgeSeconds, 3000);
+  assert.equal(rule.AllowedMethods.includes('DELETE'), false);
+  assert.equal(rule.AllowedMethods.includes('OPTIONS'), false);
+});
+
+test('vendor upload S3 CORS origin validation rejects non-browser or wildcard origins', () => {
+  assert.equal(isSafeBrowserOrigin('https://*.vercel.app'), true);
+  assert.equal(isSafeBrowserOrigin('https://mosaicbizhub.com'), true);
+  assert.equal(isSafeBrowserOrigin('http://localhost:3000'), true);
+  assert.equal(isSafeBrowserOrigin('*'), false);
+  assert.equal(isSafeBrowserOrigin('https://api.mosaicbizhub.com'), false);
+  assert.equal(isSafeBrowserOrigin('https://mosaicbizhub.com/path'), false);
+  assert.equal(isSafeBrowserOrigin('not-a-url'), false);
+});

--- a/utils/s3UploadCorsConfig.js
+++ b/utils/s3UploadCorsConfig.js
@@ -1,0 +1,95 @@
+const DEFAULT_S3_UPLOAD_CORS_ORIGINS = [
+  'https://mosaicbizhub.com',
+  'https://www.mosaicbizhub.com',
+  'https://app.mosaicbizhub.com',
+  'https://mosaic-biz-frontend-launch.vercel.app',
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+];
+
+const S3_UPLOAD_CORS_ALLOWED_METHODS = ['PUT', 'GET', 'HEAD'];
+const S3_UPLOAD_CORS_ALLOWED_HEADERS = ['Content-Type'];
+const S3_UPLOAD_CORS_EXPOSE_HEADERS = ['ETag'];
+const S3_UPLOAD_CORS_MAX_AGE_SECONDS = 3000;
+const S3_UPLOAD_CORS_RULE_ID = 'MosaicVendorPresignedUploads';
+
+function parseOriginList(value) {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function isSafeBrowserOrigin(origin) {
+  if (origin === '*' || /\/\*$/.test(origin)) {
+    return false;
+  }
+
+  if (/^https:\/\/\*\.[a-z0-9.-]+$/i.test(origin)) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(origin);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return false;
+    }
+
+    if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+      return false;
+    }
+
+    return parsed.hostname !== 'api.mosaicbizhub.com';
+  } catch (_error) {
+    return false;
+  }
+}
+
+function dedupe(values) {
+  return [...new Set(values)];
+}
+
+function getS3UploadCorsOrigins(env = process.env) {
+  const configuredOrigins = parseOriginList(
+    env.S3_UPLOAD_CORS_ORIGINS || env.CORS_ORIGINS
+  );
+  const frontendUrlOrigins = parseOriginList(env.FRONTEND_URL);
+
+  return dedupe([
+    ...configuredOrigins,
+    ...frontendUrlOrigins,
+    ...DEFAULT_S3_UPLOAD_CORS_ORIGINS,
+  ]).filter(isSafeBrowserOrigin);
+}
+
+function buildS3UploadCorsConfiguration(env = process.env) {
+  return {
+    CORSRules: [
+      {
+        ID: S3_UPLOAD_CORS_RULE_ID,
+        AllowedOrigins: getS3UploadCorsOrigins(env),
+        AllowedMethods: S3_UPLOAD_CORS_ALLOWED_METHODS,
+        AllowedHeaders: S3_UPLOAD_CORS_ALLOWED_HEADERS,
+        ExposeHeaders: S3_UPLOAD_CORS_EXPOSE_HEADERS,
+        MaxAgeSeconds: S3_UPLOAD_CORS_MAX_AGE_SECONDS,
+      },
+    ],
+  };
+}
+
+module.exports = {
+  DEFAULT_S3_UPLOAD_CORS_ORIGINS,
+  S3_UPLOAD_CORS_ALLOWED_HEADERS,
+  S3_UPLOAD_CORS_ALLOWED_METHODS,
+  S3_UPLOAD_CORS_EXPOSE_HEADERS,
+  S3_UPLOAD_CORS_MAX_AGE_SECONDS,
+  S3_UPLOAD_CORS_RULE_ID,
+  buildS3UploadCorsConfiguration,
+  getS3UploadCorsOrigins,
+  isSafeBrowserOrigin,
+  parseOriginList,
+};


### PR DESCRIPTION
## Summary
- Promote the vendor onboarding upload proxy backend fix from `staging` to production.
- Adds authenticated `POST /api/vendor-onboarding/stage1/upload-file` for vendor document uploads.
- Keeps the presigned S3 upload route documented as a legacy/direct fallback.

## Validation
- `npm test`

## Related
- Integration PR: #172
- Supersedes direct feature-branch PR: #173