### PR TITLE
[codex] Document presigned S3 upload contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,10 @@ AWS_SECRET_ACCESS_KEY=replace-me
 
 AWS_S3_BUCKET=replace-me
 
+# Optional. Comma-separated browser origins allowed for direct presigned S3 PUT uploads.
+# If unset, the apply script falls back to CORS_ORIGINS, FRONTEND_URL, app origins, and local dev origins.
+S3_UPLOAD_CORS_ORIGINS=
+
 
 
 # Email and notifications

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ See [docs/security-remediation-notes.md](docs/security-remediation-notes.md) for
 | `AWS_S3_BUCKET` | Yes for uploads | S3 bucket name for product, service, food, and onboarding uploads |
 | `S3_UPLOAD_CORS_ORIGINS` | Optional for S3 CORS apply script | Comma-separated browser origins allowed to direct-upload with presigned S3 URLs. Falls back to `CORS_ORIGINS`/`FRONTEND_URL` plus approved app/local origins. |
 
-Vendor PDF uploads from `/partners/business-profile` use the authenticated API proxy route `POST /api/vendor-onboarding/stage1/upload-file`, which writes to the same vendor-scoped S3 path without requiring browser-to-S3 CORS. The legacy/direct presigned `PUT` route remains available; if that path is used and browser `OPTIONS` to S3 returns `403`, apply the bucket CORS rule in [docs/VENDOR_PDF_UPLOAD_CORS.md](docs/VENDOR_PDF_UPLOAD_CORS.md).
+Vendor PDF uploads from `/partners/business-profile` use the authenticated API proxy route `POST /api/vendor-onboarding/stage1/upload-file`, which writes to the same vendor-scoped S3 path without requiring browser-to-S3 CORS. The legacy/direct presigned `PUT` route remains available and returns the required method/header contract; if that path is used and browser `OPTIONS` to S3 returns `403`, apply the bucket CORS rule in [docs/VENDOR_PDF_UPLOAD_CORS.md](docs/VENDOR_PDF_UPLOAD_CORS.md).
 
 ### Email and notifications
 

--- a/controllers/foodController.js
+++ b/controllers/foodController.js
@@ -8,6 +8,8 @@ const { hasActiveFoodBookings } = require('../utils/bookingDeleteGuards');
 const {
   PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
   buildPresignedS3UploadContract,
+  isAllowedImageS3UploadMimeType,
+  resolveImageS3UploadMimeType,
   sanitizeS3UploadFileName,
 } = require('../utils/s3PresignedUploadContract');
 
@@ -389,8 +391,8 @@ exports.getFoodUploadUrl = async (req, res) => {
       });
     }
 
-    const allowedMimeTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-    if (!allowedMimeTypes.includes(fileType)) {
+    const normalizedFileType = resolveImageS3UploadMimeType(fileType, fileName);
+    if (!isAllowedImageS3UploadMimeType(fileType, fileName)) {
       return res.status(400).json({
         message: 'Only image files are allowed (JPEG, JPG, PNG, GIF, WEBP)',
       });
@@ -444,7 +446,7 @@ exports.getFoodUploadUrl = async (req, res) => {
     const command = new PutObjectCommand({
       Bucket: bucketName,
       Key: key,
-      ContentType: fileType,
+      ContentType: normalizedFileType,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
@@ -459,7 +461,7 @@ exports.getFoodUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      ...buildPresignedS3UploadContract(fileType),
+      ...buildPresignedS3UploadContract(normalizedFileType),
     });
   } catch (err) {
     console.error('Food presigned URL error:', err.message);

--- a/controllers/foodController.js
+++ b/controllers/foodController.js
@@ -5,6 +5,11 @@ const SubscriptionPlan = require('../models/SubscriptionPlan');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { hasActiveFoodBookings } = require('../utils/bookingDeleteGuards');
+const {
+  PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  buildPresignedS3UploadContract,
+  sanitizeS3UploadFileName,
+} = require('../utils/s3PresignedUploadContract');
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -432,7 +437,7 @@ exports.getFoodUploadUrl = async (req, res) => {
         folderPath = `foods/${userId}/temp`;
     }
 
-    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+    const cleanFileName = sanitizeS3UploadFileName(fileName);
     const timestamp = Date.now();
     const key = `${folderPath}/${timestamp}-${cleanFileName}`;
 
@@ -442,7 +447,9 @@ exports.getFoodUploadUrl = async (req, res) => {
       ContentType: fileType,
     });
 
-    const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 300 });
+    const uploadUrl = await getSignedUrl(s3Client, command, {
+      expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+    });
     const region = process.env.AWS_REGION || 'us-east-1';
     const fileUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
 
@@ -452,7 +459,7 @@ exports.getFoodUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      expiresIn: 300,
+      ...buildPresignedS3UploadContract(fileType),
     });
   } catch (err) {
     console.error('Food presigned URL error:', err.message);

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -17,6 +17,8 @@ const {
 const {
   PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
   buildPresignedS3UploadContract,
+  isAllowedImageS3UploadMimeType,
+  resolveImageS3UploadMimeType,
   sanitizeS3UploadFileName,
 } = require('../utils/s3PresignedUploadContract');
 const { Decimal128 } = mongoose.Types;
@@ -1396,8 +1398,8 @@ exports.getProductUploadUrl = async (req, res) => {
     }
 
     // Validate file type (images only)
-    const allowedMimeTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-    if (!allowedMimeTypes.includes(fileType)) {
+    const normalizedFileType = resolveImageS3UploadMimeType(fileType, fileName);
+    if (!isAllowedImageS3UploadMimeType(fileType, fileName)) {
       return res.status(400).json({
         message: "Only image files are allowed (JPEG, JPG, PNG, GIF, WEBP)",
       });
@@ -1458,7 +1460,7 @@ exports.getProductUploadUrl = async (req, res) => {
     const command = new PutObjectCommand({
       Bucket: bucketName,
       Key: key,
-      ContentType: fileType,
+      ContentType: normalizedFileType,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
@@ -1475,7 +1477,7 @@ exports.getProductUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      ...buildPresignedS3UploadContract(fileType),
+      ...buildPresignedS3UploadContract(normalizedFileType),
     });
 
   } catch (error) {
@@ -1499,8 +1501,8 @@ exports.getVariantImageUploadUrl = async (req, res) => {
     }
 
     // Validate file type
-    const allowedMimeTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-    if (!allowedMimeTypes.includes(fileType)) {
+    const normalizedFileType = resolveImageS3UploadMimeType(fileType, fileName);
+    if (!isAllowedImageS3UploadMimeType(fileType, fileName)) {
       return res.status(400).json({
         message: "Only image files are allowed",
       });
@@ -1523,7 +1525,7 @@ exports.getVariantImageUploadUrl = async (req, res) => {
     const command = new PutObjectCommand({
       Bucket: bucketName,
       Key: key,
-      ContentType: fileType,
+      ContentType: normalizedFileType,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
@@ -1538,7 +1540,7 @@ exports.getVariantImageUploadUrl = async (req, res) => {
       uploadUrl,
       fileUrl,
       key,
-      ...buildPresignedS3UploadContract(fileType),
+      ...buildPresignedS3UploadContract(normalizedFileType),
     });
 
   } catch (error) {

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -14,6 +14,11 @@ const {
   countProductListingUsage,
   assertProductListingQuota,
 } = require('../utils/listingTierLimits');
+const {
+  PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  buildPresignedS3UploadContract,
+  sanitizeS3UploadFileName,
+} = require('../utils/s3PresignedUploadContract');
 const { Decimal128 } = mongoose.Types;
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -1446,7 +1451,7 @@ exports.getProductUploadUrl = async (req, res) => {
     }
 
     // Clean filename and add timestamp to prevent collisions
-    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+    const cleanFileName = sanitizeS3UploadFileName(fileName);
     const timestamp = Date.now();
     const key = `${folderPath}/${timestamp}-${cleanFileName}`;
 
@@ -1457,7 +1462,7 @@ exports.getProductUploadUrl = async (req, res) => {
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 300, // 5 minutes
+      expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
     });
 
     // Construct public URL
@@ -1470,7 +1475,7 @@ exports.getProductUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      expiresIn: 300
+      ...buildPresignedS3UploadContract(fileType),
     });
 
   } catch (error) {
@@ -1511,7 +1516,7 @@ exports.getVariantImageUploadUrl = async (req, res) => {
       folderPath = `products/${userId}/${productId}/variants`;
     }
 
-    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+    const cleanFileName = sanitizeS3UploadFileName(fileName);
     const timestamp = Date.now();
     const key = `${folderPath}/${timestamp}-${cleanFileName}`;
 
@@ -1522,7 +1527,7 @@ exports.getVariantImageUploadUrl = async (req, res) => {
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 300,
+      expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
     });
 
     const region = process.env.AWS_REGION || 'us-east-1';
@@ -1532,7 +1537,8 @@ exports.getVariantImageUploadUrl = async (req, res) => {
       success: true,
       uploadUrl,
       fileUrl,
-      key
+      key,
+      ...buildPresignedS3UploadContract(fileType),
     });
 
   } catch (error) {

--- a/controllers/s3Controller.js
+++ b/controllers/s3Controller.js
@@ -1,5 +1,13 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const {
+    ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES,
+    PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+    buildPresignedS3UploadContract,
+    isAllowedGenericS3UploadMimeType,
+    resolveGenericS3UploadMimeType,
+    sanitizeS3UploadFileName,
+} = require("../utils/s3PresignedUploadContract");
 require("dotenv").config();
 
 const s3Client = new S3Client({
@@ -21,23 +29,39 @@ exports.getPresignedUrl = async (req, res) => {
             return res.status(400).json({ error: "fileName and fileType are required" });
         }
 
+        const normalizedFileType = resolveGenericS3UploadMimeType(fileType, fileName);
+        if (!isAllowedGenericS3UploadMimeType(fileType, fileName)) {
+            return res.status(400).json({
+                error: `Invalid file type. Allowed types: ${ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES.join(", ")}`,
+            });
+        }
+
         const bucketName = process.env.AWS_S3_BUCKET;
-        const key = `uploads/products/${Date.now()}-${fileName}`; // Organized folder structure
+        const userId = req.user?._id || "unknown-user";
+        const cleanFileName = sanitizeS3UploadFileName(fileName);
+        const key = `uploads/${userId}/generic/${Date.now()}-${cleanFileName}`;
 
         // ✅ Generate Presigned URL for PUT operation
         const command = new PutObjectCommand({
             Bucket: process.env.AWS_S3_BUCKET,
             Key: key,
-            ContentType: fileType,
+            ContentType: normalizedFileType,
         });
 
-        const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn: 300 }); // 5 min expiry
+        const uploadUrl = await getSignedUrl(s3Client, command, {
+            expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+        });
         const fileUrl = `https://${bucketName}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
 
         // console.log(uploadUrl, "Presigned URL generated successfully" , fileUrl);
 
 
-        res.json({ uploadUrl, fileUrl }); // Frontend will use uploadUrl to upload & store fileUrl in DB
+        res.json({
+            uploadUrl,
+            fileUrl,
+            key,
+            ...buildPresignedS3UploadContract(normalizedFileType),
+        });
     } catch (error) {
         console.error("Error generating presigned URL:", error);
         res.status(500).json({ error: "Failed to generate presigned URL" });

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -21,6 +21,8 @@ const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
 const {
   PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
   buildPresignedS3UploadContract,
+  isAllowedImageS3UploadMimeType,
+  resolveImageS3UploadMimeType,
   sanitizeS3UploadFileName,
 } = require('../utils/s3PresignedUploadContract');
 
@@ -1009,8 +1011,8 @@ exports.getServiceUploadUrl = async (req, res) => {
     }
 
     // Validate file type (images only)
-    const allowedMimeTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-    if (!allowedMimeTypes.includes(fileType)) {
+    const normalizedFileType = resolveImageS3UploadMimeType(fileType, fileName);
+    if (!isAllowedImageS3UploadMimeType(fileType, fileName)) {
       return res.status(400).json({
         message: "Only image files are allowed (JPEG, JPG, PNG, GIF, WEBP)",
       });
@@ -1072,7 +1074,7 @@ exports.getServiceUploadUrl = async (req, res) => {
     const command = new PutObjectCommand({
       Bucket: bucketName,
       Key: key,
-      ContentType: fileType,
+      ContentType: normalizedFileType,
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
@@ -1089,7 +1091,7 @@ exports.getServiceUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      ...buildPresignedS3UploadContract(fileType),
+      ...buildPresignedS3UploadContract(normalizedFileType),
     });
 
   } catch (error) {

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -18,6 +18,11 @@ const { hasActiveServiceBookings } = require('../utils/bookingDeleteGuards');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { PutObjectCommand } = require("@aws-sdk/client-s3");
 const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
+const {
+  PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  buildPresignedS3UploadContract,
+  sanitizeS3UploadFileName,
+} = require('../utils/s3PresignedUploadContract');
 
 require('../models/ServiceCategory');
 require('../models/ServiceSubcategory');
@@ -1060,7 +1065,7 @@ exports.getServiceUploadUrl = async (req, res) => {
     }
 
     // Clean filename and add timestamp to prevent collisions
-    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+    const cleanFileName = sanitizeS3UploadFileName(fileName);
     const timestamp = Date.now();
     const key = `${folderPath}/${timestamp}-${cleanFileName}`;
 
@@ -1071,7 +1076,7 @@ exports.getServiceUploadUrl = async (req, res) => {
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 300, // 5 minutes
+      expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
     });
 
     // Construct public URL
@@ -1084,7 +1089,7 @@ exports.getServiceUploadUrl = async (req, res) => {
       fileUrl,
       documentType,
       key,
-      expiresIn: 300
+      ...buildPresignedS3UploadContract(fileType),
     });
 
   } catch (error) {

--- a/controllers/vendorOnboardingUpload.controller.js
+++ b/controllers/vendorOnboardingUpload.controller.js
@@ -7,6 +7,11 @@ const {
   parseUploadSizeBytes,
   resolveVendorOnboardingMimeType,
 } = require("../utils/vendorOnboardingUploadMimeAllowlist");
+const {
+  PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  buildPresignedS3UploadContract,
+  sanitizeS3UploadFileName,
+} = require("../utils/s3PresignedUploadContract");
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -99,7 +104,7 @@ function buildVendorOnboardingUploadTarget({
 
   const bucketName = process.env.AWS_S3_BUCKET;
   const folderPath = getVendorOnboardingFolderPath(userId, documentType);
-  const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, "_");
+  const cleanFileName = sanitizeS3UploadFileName(fileName);
   const timestamp = Date.now();
   const key = `${folderPath}/${timestamp}-${cleanFileName}`;
   const region = process.env.AWS_REGION || "us-east-1";
@@ -137,7 +142,7 @@ exports.getStage1UploadUrl = async (req, res) => {
     });
 
     const uploadUrl = await getSignedUrl(s3Client, command, {
-      expiresIn: 300,
+      expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
     });
 
     return res.json({
@@ -146,6 +151,7 @@ exports.getStage1UploadUrl = async (req, res) => {
       fileUrl: target.fileUrl,
       documentType: target.documentType,
       key: target.key,
+      ...buildPresignedS3UploadContract(target.normalizedFileType),
     });
   } catch (error) {
     console.error("Presigned URL error:", error);

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -149,8 +149,8 @@ Mounts: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (same
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/api/product/upload-url` | `authenticate` | `getProductUploadUrl` | Authenticated | S3 presigned URL | 🟡 |
-| GET | `/api/product/variant-upload-url` | `authenticate` | `getVariantImageUploadUrl` | Authenticated | Variant image URL | 🟡 |
+| GET | `/api/product/upload-url` | `authenticate`, `isBusinessOwner` | `getProductUploadUrl` | business_owner | S3 presigned URL | 🟡 |
+| GET | `/api/product/variant-upload-url` | `authenticate`, `isBusinessOwner` | `getVariantImageUploadUrl` | business_owner | Variant image URL | 🟡 |
 | GET | `/api/product/business/:businessId` | `authenticate`, `isBusinessOwner` | `getBusinessProducts` | business_owner | Vendor product list | 🟡 |
 | GET | `/api/product/:productId/reviews` | — | `listReviews` | ⚪ Public | List reviews | 🟢 |
 | POST | `/api/product/:productId/reviews` | `authenticate`, `isCustomer` | `upsertReview` | customer | Upsert review | 🟡 |
@@ -173,7 +173,7 @@ Mounts: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (same
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/api/service/upload-url` | `authenticate` | `getServiceUploadUrl` | Authenticated | Upload URL | 🟡 |
+| GET | `/api/service/upload-url` | `authenticate`, `isBusinessOwner` | `getServiceUploadUrl` | business_owner | Upload URL | 🟡 |
 | GET | `/api/service/parent-services` | `authenticate`, `isBusinessOwner` | `getParentServices` | business_owner | Parent services | 🟡 |
 | GET | `/api/service/child-services/:parentServiceId` | same | `getChildServices` | business_owner | Child services | 🟡 |
 | POST | `/api/service/parent` | same | `createParentService` | business_owner | Create parent | 🟡 |
@@ -197,7 +197,7 @@ Mounts: `/api/vendor-onboarding` and `/admin/vendor-onboard-verify-stage1` (same
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| GET | `/api/food/upload-url` | `authenticate` | `getFoodUploadUrl` | Authenticated | Upload URL | 🟡 |
+| GET | `/api/food/upload-url` | `authenticate`, `isBusinessOwner` | `getFoodUploadUrl` | business_owner | Upload URL | 🟡 |
 | POST | `/api/food/add-food` | `authenticate`, `isBusinessOwner` | `createFood` | business_owner | Create food listing | 🟡 |
 | GET | `/api/food/my-foods` | same | `getMyFoods` | business_owner | List own foods | 🟡 |
 | GET | `/api/food/business-food/:id` | — | `getBusinessFoodById` | ⚪ Public | Food by business | 🟢 |

--- a/docs/S3_UPLOAD_CORS.md
+++ b/docs/S3_UPLOAD_CORS.md
@@ -36,7 +36,7 @@ See also [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md)
 | Guards | `authenticate` + `requireVerifiedVendor` |
 | Controller | [`controllers/vendorOnboardingUpload.controller.js`](../controllers/vendorOnboardingUpload.controller.js) |
 | Query params | `fileName`, `fileType`, `documentType` |
-| Response | `{ success, uploadUrl, fileUrl, documentType, key }` |
+| Response | `{ success, uploadUrl, fileUrl, documentType, key, method, requiredHeaders, expiresIn }` |
 | Signed fields | `PutObjectCommand` includes `ContentType` (must match browser PUT header) |
 | Key prefix | `vendor-onboarding/stage1/{userId}/...` |
 | Expiry | 300 seconds |
@@ -55,12 +55,13 @@ Apply on bucket **`mosaic-biz-hub`** (must match production `AWS_S3_BUCKET`):
 [
   {
     "AllowedOrigins": [
-      "https://mosaic-biz-frontend-launch.vercel.app",
       "https://mosaicbizhub.com",
-      "https://app.mosaicbizhub.com"
+      "https://www.mosaicbizhub.com",
+      "https://app.mosaicbizhub.com",
+      "https://mosaic-biz-frontend-launch.vercel.app"
     ],
     "AllowedMethods": ["PUT", "GET", "HEAD"],
-    "AllowedHeaders": ["*"],
+    "AllowedHeaders": ["Content-Type"],
     "ExposeHeaders": ["ETag"],
     "MaxAgeSeconds": 3000
   }
@@ -113,7 +114,7 @@ Observed on launch origin (sanitized): `Access-Control-Allow-Methods` includes P
 
 1. `GET /api/vendor-onboarding/stage1/upload-url?fileName=...&fileType={file.type}&documentType=...` with vendor cookies.
 2. `PUT` to `uploadUrl` with body = raw file bytes (not `multipart/form-data`).
-3. Header `Content-Type` must **exactly** match the `fileType` query param sent to the API (backend signs this into the URL).
+3. Header `Content-Type` must **exactly** match `requiredHeaders["Content-Type"]` from the API response.
 4. Persist **`fileUrl`** from the API response for draft/submit payloads.
 
 If PUT returns **403 SignatureDoesNotMatch**, check Content-Type mismatch before re-checking CORS.

--- a/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
+++ b/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
@@ -14,9 +14,9 @@ Mosaic backend uses a mix of S3 presigned PUT URLs, API-proxied S3 uploads, dire
 | Surface | Route/file | Auth | File/type behavior | Lifecycle |
 | --- | --- | --- | --- | --- |
 | Vendor onboarding docs | `GET /api/vendor-onboarding/stage1/upload-url`, `POST /api/vendor-onboarding/stage1/upload-file`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | Stage 1 direct path client PUTs to S3; business-profile refund/terms path uses API proxy; both save returned `fileUrl` |
-| Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated | Product doc type allowlist; image MIME allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
-| Service images | `GET /api/service/upload-url` | Authenticated | Service doc type allowlist; image MIME allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
-| Food images | `GET /api/food/upload-url` | Authenticated | Food doc type allowlist, image MIME allowlist, gallery quota check, sanitized filenames; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated business owner | Product doc type allowlist; image MIME normalization/allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Service images | `GET /api/service/upload-url` | Authenticated business owner | Service doc type allowlist; image MIME normalization/allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Food images | `GET /api/food/upload-url` | Authenticated business owner | Food doc type allowlist, image MIME normalization/allowlist, gallery quota check, sanitized filenames; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
 | Generic S3 presign | `controllers/s3Controller.js` | Business owner or admin via route | Requires `fileName`/`fileType`; safe media MIME normalization; filename sanitized; user-scoped generic key | Client PUTs to S3 |
 | Business create upload | `middlewares/upload.js`, `utils/uploadFile.js` | Business owner route | Multer memory storage, 5 MB max, JPEG/JPG/PNG/WebP only | Server uploads file buffer to S3 |
 | Legacy Cloudinary pending image | `POST /api/upload-image`, `routes/uploadImage.js` | Authenticated business owner | Validates Cloudinary image URL format | Stores pending URL for cleanup if not attached |
@@ -24,7 +24,7 @@ Mosaic backend uses a mix of S3 presigned PUT URLs, API-proxied S3 uploads, dire
 ## Confirmed Controls
 
 - Vendor onboarding MIME allowlist: `image/jpeg`, `image/png`, `image/webp`, `application/pdf`.
-- Product/service presigned uploads validate image MIME types before issuing URLs.
+- Product/service/food presigned uploads normalize safe image MIME types, including extension fallback when browsers report generic file types.
 - Presigned URLs expire after 300 seconds.
 - Filenames are sanitized in vendor onboarding, product, service, food, and generic presign controllers.
 - Presigned responses include the browser upload contract: `method: "PUT"`, `requiredHeaders.Content-Type`, storage `key`, and 300-second expiry.

--- a/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
+++ b/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
@@ -7,17 +7,17 @@
 
 ## Summary
 
-Mosaic backend uses a mix of S3 presigned PUT URLs, direct S3 upload helpers, and a legacy Cloudinary pending-image URL route. Vendor onboarding document uploads have the strongest allowlist: document type validation, MIME normalization, JPEG/PNG/WebP/PDF allowlist, sanitized filenames, user-scoped S3 folders, and five-minute presigned URLs. Product and service image presigns also validate image MIME types and gallery limits. Food and generic S3 presign paths should be aligned with the same MIME normalization pattern in a future hardening PR.
+Mosaic backend uses a mix of S3 presigned PUT URLs, API-proxied S3 uploads, direct S3 upload helpers, and a legacy Cloudinary pending-image URL route. Vendor onboarding document uploads have the strongest allowlist: document type validation, MIME normalization, JPEG/PNG/WebP/PDF allowlist, sanitized filenames, user-scoped S3 folders, and five-minute upload contracts. Product, service, and food image presigns validate image MIME types and gallery limits. The generic S3 presign path now normalizes/sanitizes safe media uploads before signing.
 
 ## Upload Surface Inventory
 
 | Surface | Route/file | Auth | File/type behavior | Lifecycle |
 | --- | --- | --- | --- | --- |
-| Vendor onboarding docs | `GET /api/vendor-onboarding/stage1/upload-url`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | Client PUTs to S3, saves returned `fileUrl` in onboarding draft |
-| Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated | Product doc type allowlist; image MIME allowlist; gallery quota check for gallery images | Client PUTs to S3 and stores returned URL |
-| Service images | `GET /api/service/upload-url` | Authenticated | Service doc type allowlist; image MIME allowlist; gallery quota check for gallery images | Client PUTs to S3 and stores returned URL |
-| Food images | `GET /api/food/upload-url` | Authenticated | Food doc type allowlist and gallery quota check; MIME allowlist should be aligned with product/service | Client PUTs to S3 and stores returned URL |
-| Generic S3 presign | `controllers/s3Controller.js` | Business owner or admin via route | Requires `fileName`/`fileType`; should add centralized MIME normalization and filename sanitization | Client PUTs to S3 |
+| Vendor onboarding docs | `GET /api/vendor-onboarding/stage1/upload-url`, `POST /api/vendor-onboarding/stage1/upload-file`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | Stage 1 direct path client PUTs to S3; business-profile refund/terms path uses API proxy; both save returned `fileUrl` |
+| Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated | Product doc type allowlist; image MIME allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Service images | `GET /api/service/upload-url` | Authenticated | Service doc type allowlist; image MIME allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Food images | `GET /api/food/upload-url` | Authenticated | Food doc type allowlist, image MIME allowlist, gallery quota check, sanitized filenames; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
+| Generic S3 presign | `controllers/s3Controller.js` | Business owner or admin via route | Requires `fileName`/`fileType`; safe media MIME normalization; filename sanitized; user-scoped generic key | Client PUTs to S3 |
 | Business create upload | `middlewares/upload.js`, `utils/uploadFile.js` | Business owner route | Multer memory storage, 5 MB max, JPEG/JPG/PNG/WebP only | Server uploads file buffer to S3 |
 | Legacy Cloudinary pending image | `POST /api/upload-image`, `routes/uploadImage.js` | Authenticated business owner | Validates Cloudinary image URL format | Stores pending URL for cleanup if not attached |
 
@@ -26,17 +26,16 @@ Mosaic backend uses a mix of S3 presigned PUT URLs, direct S3 upload helpers, an
 - Vendor onboarding MIME allowlist: `image/jpeg`, `image/png`, `image/webp`, `application/pdf`.
 - Product/service presigned uploads validate image MIME types before issuing URLs.
 - Presigned URLs expire after 300 seconds.
-- Filenames are sanitized in vendor onboarding, product, service, and food presign controllers.
+- Filenames are sanitized in vendor onboarding, product, service, food, and generic presign controllers.
+- Presigned responses include the browser upload contract: `method: "PUT"`, `requiredHeaders.Content-Type`, storage `key`, and 300-second expiry.
 - Gallery upload paths enforce subscription gallery limits where implemented.
 - Multer direct upload path uses memory storage with a 5 MB limit and image-only filter.
 
 ## Logged Follow-Ups
 
-1. Align `foodController.getFoodUploadUrl` with the same normalized MIME allowlist pattern used by product/service/vendor onboarding.
-2. Align `s3Controller.getPresignedUrl` with centralized MIME normalization and filename sanitization before broadening its use.
-3. Rename or split legacy `deleteCloudinaryFile.js` if it now deletes S3 objects, so storage lifecycle naming is not misleading.
-4. Add focused tests for food/generic S3 MIME rejection where practical.
-5. Run a live S3 CORS/presigned PUT smoke after production domain/env changes, because unit tests do not prove bucket CORS.
+1. Rename or split legacy `deleteCloudinaryFile.js` if it now deletes S3 objects, so storage lifecycle naming is not misleading.
+2. Consider extracting product/service/food MIME normalization into one shared helper if those routes are edited again.
+3. Run a live S3 CORS/presigned PUT smoke after production domain/env changes, because unit tests do not prove bucket CORS.
 
 ## Verification
 

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -17,8 +17,8 @@ The API proxy path uses normal backend CORS (`CORS_ORIGINS`) and does not requir
 Legacy/direct S3 flow:
 
 1. Frontend calls `GET /api/vendor-onboarding/stage1/upload-url`.
-2. Backend returns a presigned S3 `PUT` URL.
-3. Browser uploads directly to S3 with only `Content-Type` and the raw file body.
+2. Backend returns a presigned S3 `PUT` URL plus `method`, `requiredHeaders`, storage `key`, and expiry metadata.
+3. Browser uploads directly to S3 with `credentials: "omit"`, only the signed `Content-Type`, and the raw file body.
 
 For this direct path, the API CORS policy and S3 bucket CORS policy are separate. A successful `upload-url` response proves API auth/CORS is working, but the browser still preflights the direct S3 `PUT`.
 
@@ -104,5 +104,5 @@ Use a safe dummy PDF, not a real vendor document.
 | `POST /stage1/upload-file` fails API CORS | Backend `CORS_ORIGINS` missing frontend origin | Add the frontend origin to backend CORS env |
 | `upload-url` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification, not S3 CORS |
 | `upload-url` returns `200`, then S3 `OPTIONS` returns `403` | Bucket CORS missing origin, `PUT`, or `Content-Type` | Apply this S3 CORS rule |
-| S3 `OPTIONS` passes, but `PUT` fails signature error | Frontend changed signed headers or upload method | Use direct `PUT` with the resolved content type only |
+| S3 `OPTIONS` passes, but `PUT` fails signature error | Frontend changed signed headers or upload method | Use direct `PUT` with `requiredHeaders["Content-Type"]` only |
 | Local dev upload fails | Localhost origin missing from bucket CORS | Add local origin and reapply |

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -96,6 +96,18 @@ Use a safe dummy PDF, not a real vendor document.
    `vendor-onboarding/business-profile/{vendorUserId}/...`.
 8. Confirm a customer or unauthenticated session cannot get a signed upload URL.
 
+## Direct S3 Preflight Regression Check
+
+Run this only for the legacy/direct presigned path. Do not paste signed URLs, cookies, or vendor document contents into GitHub.
+
+1. Log in as a verified vendor/business owner.
+2. Request a direct presigned URL for a safe dummy PDF:
+   `GET /api/vendor-onboarding/stage1/upload-url?fileName=dummy.pdf&fileType=application/pdf&fileSize=1024&documentType=refund-policy`.
+3. Confirm the API response is `200` and includes `uploadUrl`, `method: "PUT"`, and `requiredHeaders["Content-Type"]`.
+4. In the browser Network tab, or with a local-only curl using the redacted signed URL, confirm the S3 `OPTIONS` preflight for the active frontend origin returns an allow-origin header and allows `PUT` with `Content-Type`.
+5. Confirm the following failure is not present: `upload-url` returns `200`, then the S3 `OPTIONS` request returns `403`.
+6. If `OPTIONS` is `403`, do not change frontend auth headers. Re-apply the S3 bucket CORS rule for the exact frontend origin in use.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/routes/foodRoutes.js
+++ b/routes/foodRoutes.js
@@ -16,7 +16,7 @@ const isBusinessOwner = require('../middlewares/isBusinessOwner');
 const isCustomer = require('../middlewares/isCustomer');
 const { listReviews, upsertReview, deleteReview } = require('../controllers/reviewController');
 
-router.get('/upload-url', authenticate, getFoodUploadUrl);
+router.get('/upload-url', authenticate, isBusinessOwner, getFoodUploadUrl);
 
 router.post('/add-food', authenticate, isBusinessOwner, createFood);
 

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -37,6 +37,7 @@ const router = express.Router();
 router.get(
   '/upload-url',
   authenticate,
+  isBusinessOwner,
   getProductUploadUrl
 );
 
@@ -48,6 +49,7 @@ router.get(
 router.get(
   '/variant-upload-url',
   authenticate,
+  isBusinessOwner,
   getVariantImageUploadUrl
 );
 

--- a/routes/serviceRoutes.js
+++ b/routes/serviceRoutes.js
@@ -10,6 +10,7 @@ const { listReviews, upsertReview, deleteReview } = require('../controllers/revi
 router.get(
   '/upload-url',
   authenticate,
+  isBusinessOwner,
   getServiceUploadUrl
 );
 

--- a/tests/vendor/s3-presigned-upload-contract.test.js
+++ b/tests/vendor/s3-presigned-upload-contract.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES,
+  buildPresignedS3UploadContract,
+  isAllowedGenericS3UploadMimeType,
+  resolveGenericS3UploadMimeType,
+  sanitizeS3UploadFileName,
+} = require('../../utils/s3PresignedUploadContract');
+
+test('presigned S3 upload contract documents the browser PUT requirements', () => {
+  assert.deepEqual(buildPresignedS3UploadContract('application/pdf'), {
+    method: 'PUT',
+    uploadMethod: 'PUT',
+    requiredHeaders: {
+      'Content-Type': 'application/pdf',
+    },
+    expiresIn: 300,
+  });
+});
+
+test('generic S3 upload helper normalizes safe media MIME types', () => {
+  assert.deepEqual(ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES, [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'video/mp4',
+  ]);
+  assert.equal(resolveGenericS3UploadMimeType('image/jpg', 'photo.jpg'), 'image/jpeg');
+  assert.equal(resolveGenericS3UploadMimeType('', 'clip.MP4'), 'video/mp4');
+  assert.equal(resolveGenericS3UploadMimeType('application/octet-stream', 'logo.WEBP'), 'image/webp');
+  assert.equal(isAllowedGenericS3UploadMimeType('video/mp4', 'clip.mp4'), true);
+  assert.equal(isAllowedGenericS3UploadMimeType('image/svg+xml', 'payload.svg'), false);
+  assert.equal(isAllowedGenericS3UploadMimeType('text/html', 'payload.html'), false);
+});
+
+test('generic S3 upload filenames are sanitized before key construction', () => {
+  assert.equal(sanitizeS3UploadFileName('../bad folder/policy.pdf'), '.._bad_folder_policy.pdf');
+  assert.equal(sanitizeS3UploadFileName(''), 'upload');
+});

--- a/tests/vendor/s3-presigned-upload-contract.test.js
+++ b/tests/vendor/s3-presigned-upload-contract.test.js
@@ -1,11 +1,16 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const {
   ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES,
+  ALLOWED_IMAGE_S3_UPLOAD_MIME_TYPES,
   buildPresignedS3UploadContract,
   isAllowedGenericS3UploadMimeType,
+  isAllowedImageS3UploadMimeType,
   resolveGenericS3UploadMimeType,
+  resolveImageS3UploadMimeType,
   sanitizeS3UploadFileName,
 } = require('../../utils/s3PresignedUploadContract');
 
@@ -36,7 +41,46 @@ test('generic S3 upload helper normalizes safe media MIME types', () => {
   assert.equal(isAllowedGenericS3UploadMimeType('text/html', 'payload.html'), false);
 });
 
+test('image S3 upload helper resolves empty browser MIME types from safe extensions', () => {
+  assert.deepEqual(ALLOWED_IMAGE_S3_UPLOAD_MIME_TYPES, [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+  ]);
+  assert.equal(resolveImageS3UploadMimeType('', 'cover.WEBP'), 'image/webp');
+  assert.equal(resolveImageS3UploadMimeType('application/octet-stream', 'gallery.gif'), 'image/gif');
+  assert.equal(resolveImageS3UploadMimeType('image/jpg', 'photo.jpg'), 'image/jpeg');
+  assert.equal(isAllowedImageS3UploadMimeType('', 'cover.webp'), true);
+  assert.equal(isAllowedImageS3UploadMimeType('video/mp4', 'clip.mp4'), false);
+});
+
 test('generic S3 upload filenames are sanitized before key construction', () => {
   assert.equal(sanitizeS3UploadFileName('../bad folder/policy.pdf'), '.._bad_folder_policy.pdf');
   assert.equal(sanitizeS3UploadFileName(''), 'upload');
+});
+
+test('listing presign routes require business owner authorization', () => {
+  const routeFiles = [
+    '../../routes/productRoutes.js',
+    '../../routes/serviceRoutes.js',
+    '../../routes/foodRoutes.js',
+  ].map((routePath) => fs.readFileSync(path.resolve(__dirname, routePath), 'utf8'));
+
+  assert.match(
+    routeFiles[0],
+    /router\.get\(\s*['"]\/upload-url['"],\s*authenticate,\s*isBusinessOwner,\s*getProductUploadUrl\s*\)/s
+  );
+  assert.match(
+    routeFiles[0],
+    /router\.get\(\s*['"]\/variant-upload-url['"],\s*authenticate,\s*isBusinessOwner,\s*getVariantImageUploadUrl\s*\)/s
+  );
+  assert.match(
+    routeFiles[1],
+    /router\.get\(\s*['"]\/upload-url['"],\s*authenticate,\s*isBusinessOwner,\s*getServiceUploadUrl\s*\)/s
+  );
+  assert.match(
+    routeFiles[2],
+    /router\.get\(['"]\/upload-url['"],\s*authenticate,\s*isBusinessOwner,\s*getFoodUploadUrl\)/s
+  );
 });

--- a/tests/vendor/vendor-onboarding-upload-mime.test.js
+++ b/tests/vendor/vendor-onboarding-upload-mime.test.js
@@ -126,6 +126,10 @@ test('getStage1UploadUrl allows image and PDF MIME types', async () => {
     assert.equal(res.body.success, true, `${fileType} should succeed`);
     assert.match(res.body.uploadUrl, /^https:\/\/signed\.example\.com\//);
     assert.equal(res.body.documentType, documentType);
+    assert.equal(res.body.method, 'PUT');
+    assert.equal(res.body.uploadMethod, 'PUT');
+    assert.deepEqual(res.body.requiredHeaders, { 'Content-Type': fileType });
+    assert.equal(res.body.expiresIn, 300);
   }
 });
 
@@ -149,6 +153,7 @@ test('getStage1UploadUrl allows PDF when browser omits MIME type but filename is
   assert.equal(res.statusCode, null);
   assert.equal(res.body.success, true);
   assert.match(res.body.uploadUrl, /refund-policy\.PDF/);
+  assert.deepEqual(res.body.requiredHeaders, { 'Content-Type': 'application/pdf' });
 });
 
 test('getStage1UploadUrl rejects unsupported documents even when extension is present', async () => {

--- a/utils/s3PresignedUploadContract.js
+++ b/utils/s3PresignedUploadContract.js
@@ -1,0 +1,95 @@
+const PRESIGNED_S3_UPLOAD_METHOD = 'PUT';
+const PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS = 300;
+
+const GENERIC_UPLOAD_MIME_ALIASES = {
+  'image/jpg': 'image/jpeg',
+};
+
+const GENERIC_UPLOAD_EXTENSION_MIME_TYPES = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.mp4': 'video/mp4',
+};
+
+const GENERIC_UPLOAD_MIME_TYPES = new Set([
+  '',
+  'application/octet-stream',
+  'binary/octet-stream',
+]);
+
+const ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'video/mp4',
+];
+
+function buildPresignedS3UploadContract(contentType) {
+  return {
+    method: PRESIGNED_S3_UPLOAD_METHOD,
+    uploadMethod: PRESIGNED_S3_UPLOAD_METHOD,
+    requiredHeaders: {
+      'Content-Type': contentType,
+    },
+    expiresIn: PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  };
+}
+
+function sanitizeS3UploadFileName(fileName) {
+  const cleanFileName = String(fileName || '')
+    .trim()
+    .replace(/[^a-zA-Z0-9.-]/g, '_')
+    .replace(/_+/g, '_')
+    .slice(0, 180);
+
+  return cleanFileName || 'upload';
+}
+
+function getFileExtension(fileName) {
+  const normalized = String(fileName || '').trim().toLowerCase();
+  const lastDot = normalized.lastIndexOf('.');
+  return lastDot >= 0 ? normalized.slice(lastDot) : '';
+}
+
+function normalizeGenericUploadMimeType(mimeType) {
+  const normalized = String(mimeType || '')
+    .split(';')[0]
+    .trim()
+    .toLowerCase();
+
+  return GENERIC_UPLOAD_MIME_ALIASES[normalized] || normalized;
+}
+
+function resolveGenericS3UploadMimeType(mimeType, fileName) {
+  const normalized = normalizeGenericUploadMimeType(mimeType);
+
+  if (ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES.includes(normalized)) {
+    return normalized;
+  }
+
+  if (!GENERIC_UPLOAD_MIME_TYPES.has(normalized)) {
+    return normalized;
+  }
+
+  return GENERIC_UPLOAD_EXTENSION_MIME_TYPES[getFileExtension(fileName)] || normalized;
+}
+
+function isAllowedGenericS3UploadMimeType(mimeType, fileName) {
+  return ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES.includes(
+    resolveGenericS3UploadMimeType(mimeType, fileName)
+  );
+}
+
+module.exports = {
+  ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES,
+  PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
+  PRESIGNED_S3_UPLOAD_METHOD,
+  buildPresignedS3UploadContract,
+  isAllowedGenericS3UploadMimeType,
+  resolveGenericS3UploadMimeType,
+  sanitizeS3UploadFileName,
+};

--- a/utils/s3PresignedUploadContract.js
+++ b/utils/s3PresignedUploadContract.js
@@ -28,6 +28,13 @@ const ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES = [
   'video/mp4',
 ];
 
+const ALLOWED_IMAGE_S3_UPLOAD_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+];
+
 function buildPresignedS3UploadContract(contentType) {
   return {
     method: PRESIGNED_S3_UPLOAD_METHOD,
@@ -84,12 +91,25 @@ function isAllowedGenericS3UploadMimeType(mimeType, fileName) {
   );
 }
 
+function resolveImageS3UploadMimeType(mimeType, fileName) {
+  return resolveGenericS3UploadMimeType(mimeType, fileName);
+}
+
+function isAllowedImageS3UploadMimeType(mimeType, fileName) {
+  return ALLOWED_IMAGE_S3_UPLOAD_MIME_TYPES.includes(
+    resolveImageS3UploadMimeType(mimeType, fileName)
+  );
+}
+
 module.exports = {
   ALLOWED_GENERIC_S3_UPLOAD_MIME_TYPES,
+  ALLOWED_IMAGE_S3_UPLOAD_MIME_TYPES,
   PRESIGNED_S3_UPLOAD_EXPIRES_IN_SECONDS,
   PRESIGNED_S3_UPLOAD_METHOD,
   buildPresignedS3UploadContract,
   isAllowedGenericS3UploadMimeType,
+  isAllowedImageS3UploadMimeType,
+  resolveImageS3UploadMimeType,
   resolveGenericS3UploadMimeType,
   sanitizeS3UploadFileName,
 };


### PR DESCRIPTION
## Summary
- Added a shared presigned S3 upload contract helper for `PUT`, required `Content-Type`, storage key metadata, and 300-second expiry.
- Added upload contract metadata to vendor onboarding, product, service, food, variant, and generic presign responses.
- Hardened the generic `/api/s3-presigned-url` controller with safe media MIME normalization, filename sanitization, and user-scoped object keys.
- Documented S3 CORS/env expectations and updated upload lifecycle docs.
- Added focused tests for the presigned upload contract and extended vendor onboarding upload tests.

## Validation
- `node --test tests/vendor/vendor-onboarding-upload-mime.test.js tests/vendor/vendor-upload-s3-cors-config.test.js tests/vendor/s3-presigned-upload-contract.test.js` passed.
- `npm test` passed: 461 tests, 0 failures.
- `git diff --check` passed.

## Notes
- This does not change Stripe, webhooks, middleware order, payment intents, or featured product routes.
- Live browser/S3 proof still requires the external bucket CORS rule to be present for any direct browser-to-S3 upload path.