### PR TITLE
[codex] Document canonical vendor upload flow

### DIFF
--- a/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
+++ b/docs/BACKEND_FRONTEND_ROUTE_CONTRACT.md
@@ -178,8 +178,8 @@ Mount: `/api/vendor-onboarding` → [`routes/vendorOnboarding.routes.js`](../rou
 | `/api/vendor-onboarding/submit` | POST | Yes | verified vendor | Submit application | **valid** | |
 | `/api/vendor-onboarding/business-profile` | PUT | Yes | stage-1 verified vendor | Business profile update | **valid** | Full replace |
 | `/api/vendor-onboarding/business-profile` | PATCH | Yes | stage-1 verified vendor | Business profile patch | **valid** | Partial update |
-| `/api/vendor-onboarding/stage1/upload-file` | POST | Yes | verified vendor | Doc upload proxy | **valid** | Business-profile PDF UI path |
-| `/api/vendor-onboarding/stage1/upload-url` | GET | Yes | verified vendor | Presigned doc upload | **valid** | Legacy/direct S3 path |
+| `/api/vendor-onboarding/stage1/upload-file` | POST | Yes | verified vendor | Doc upload proxy | **valid** | Canonical `/partners/business/new` and `/partners/business-profile` document UI path |
+| `/api/vendor-onboarding/stage1/upload-url` | GET | Yes | verified vendor | Presigned doc upload | **valid** | Direct S3 diagnostic path; not used by those UI routes |
 | `/api/vendor-onboarding/stage1/create-payment` | POST | Yes | verified vendor | Verification fee | **valid** | Stripe Checkout path |
 | `/api/vendor-onboarding/stage1/payment-status` | GET | Yes | verified vendor | Payment poll | **valid** | |
 | `/api/vendor-onboarding/status/:applicationId` | GET | No | Public | Application status page | **valid** | |

--- a/docs/S3_UPLOAD_CORS.md
+++ b/docs/S3_UPLOAD_CORS.md
@@ -110,9 +110,11 @@ Observed on launch origin (sanitized): `Access-Control-Allow-Methods` includes P
 
 ---
 
-## Frontend upload contract
+## Direct S3 diagnostic upload contract
 
-1. `GET /api/vendor-onboarding/stage1/upload-url?fileName=...&fileType={file.type}&documentType=...` with vendor cookies.
+The active `/partners/business/new` and `/partners/business-profile` UI routes should use `POST /api/vendor-onboarding/stage1/upload-file`, not this direct browser-to-S3 path. Use this contract only when deliberately testing the retained presigned upload diagnostic path.
+
+1. `GET /api/vendor-onboarding/stage1/upload-url?fileName=...&fileType={resolvedMimeType}&documentType=...` with vendor cookies.
 2. `PUT` to `uploadUrl` with body = raw file bytes (not `multipart/form-data`).
 3. Header `Content-Type` must **exactly** match `requiredHeaders["Content-Type"]` from the API response.
 4. Persist **`fileUrl`** from the API response for draft/submit payloads.

--- a/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
+++ b/docs/UPLOAD_STORAGE_LIFECYCLE_AUDIT_2026_06_28.md
@@ -13,7 +13,7 @@ Mosaic backend uses a mix of S3 presigned PUT URLs, API-proxied S3 uploads, dire
 
 | Surface | Route/file | Auth | File/type behavior | Lifecycle |
 | --- | --- | --- | --- | --- |
-| Vendor onboarding docs | `GET /api/vendor-onboarding/stage1/upload-url`, `POST /api/vendor-onboarding/stage1/upload-file`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | Stage 1 direct path client PUTs to S3; business-profile refund/terms path uses API proxy; both save returned `fileUrl` |
+| Vendor onboarding docs | `POST /api/vendor-onboarding/stage1/upload-file`, diagnostic `GET /api/vendor-onboarding/stage1/upload-url`, `controllers/vendorOnboardingUpload.controller.js` | Authenticated verified vendor | Allowed doc types; JPEG/PNG/WebP/PDF allowlist via `utils/vendorOnboardingUploadMimeAllowlist.js`; filename sanitized | `/partners/business/new` and `/partners/business-profile` use the API proxy and save returned `fileUrl`; direct presign remains diagnostic only |
 | Product images | `GET /api/product/upload-url`, `GET /api/product/variant-upload-url` | Authenticated business owner | Product doc type allowlist; image MIME normalization/allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
 | Service images | `GET /api/service/upload-url` | Authenticated business owner | Service doc type allowlist; image MIME normalization/allowlist; gallery quota check for gallery images; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
 | Food images | `GET /api/food/upload-url` | Authenticated business owner | Food doc type allowlist, image MIME normalization/allowlist, gallery quota check, sanitized filenames; response includes upload method/header contract | Client PUTs to S3 and stores returned URL |
@@ -24,6 +24,7 @@ Mosaic backend uses a mix of S3 presigned PUT URLs, API-proxied S3 uploads, dire
 ## Confirmed Controls
 
 - Vendor onboarding MIME allowlist: `image/jpeg`, `image/png`, `image/webp`, `application/pdf`.
+- Vendor/business document UI routes share the API-proxied `POST /stage1/upload-file` flow, so browser uploads go to the Mosaic API instead of directly to S3.
 - Product/service/food presigned uploads normalize safe image MIME types, including extension fallback when browsers report generic file types.
 - Presigned URLs expire after 300 seconds.
 - Filenames are sanitized in vendor onboarding, product, service, food, and generic presign controllers.

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -323,7 +323,7 @@ From [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingU
 - `normalizeMimeType` strips parameters (e.g. `image/jpeg; charset=binary`).
 - Common browser PDF alias `application/x-pdf` resolves to `application/pdf`.
 - Empty or generic browser MIME values can fall back to a safe file extension allowlist (`.jpg`, `.jpeg`, `.png`, `.webp`, `.pdf`).
-- Vendor onboarding uploads are limited to 5 MB when the client sends `fileSize`.
+- API proxy uploads are limited to 5 MB from the server-observed uploaded file size; the direct presigned diagnostic route validates the client-provided `fileSize` query when present.
 - Rejected types return `400` with allowed list in message.
 - Filename sanitized: non-alphanumeric → `_`; timestamp prefixed in S3 key.
 - API proxy uploads require backend `CORS_ORIGINS` for the frontend origin and do not require browser-to-S3 CORS. Direct S3 browser uploads require bucket CORS for the frontend origin, `PUT`, and the `Content-Type` header. See [`docs/VENDOR_PDF_UPLOAD_CORS.md`](VENDOR_PDF_UPLOAD_CORS.md).

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -289,13 +289,13 @@ After `verified`, the handler guides stages:
 
 ### Flow
 
-1. Business-profile UI sends `multipart/form-data` to `POST /stage1/upload-file` with `file` and `documentType`.
+1. `/partners/business/new` and `/partners/business-profile` send `multipart/form-data` to `POST /stage1/upload-file` with `file` and `documentType`.
 2. Server verifies the vendor session, validates `documentType`, resolved MIME type, and file size.
 3. Server writes the object to S3 under the authenticated vendor user path.
 4. API returns `fileUrl`, `documentType`, and object `key`.
-5. Client saves URL in draft via `saveDraft`.
+5. Client saves URL in the Stage-1 draft or business profile payload.
 
-The presigned `GET /stage1/upload-url` path is retained for direct S3 uploads, but browser direct-upload requires S3 bucket CORS. The intended business-profile PDF path uses the API proxy to avoid S3 browser preflight failures.
+The presigned `GET /stage1/upload-url` path is retained for direct S3 diagnostics, but browser direct-upload requires S3 bucket CORS. The intended vendor/business document UI paths use the API proxy to avoid S3 browser preflight failures. Do not regress `/partners/business/new` back to `GET /stage1/upload-url`; it must share the same upload helper as `/partners/business-profile`.
 
 ### Allowed `documentType` values
 

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -24,6 +24,12 @@ For this direct path, the API CORS policy and S3 bucket CORS policy are separate
 
 ## Required Environment
 
+Frontend runtime:
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | Backend API origin used by `uploadVendorOnboardingFile` for `POST /api/vendor-onboarding/stage1/upload-file` |
+
 Backend runtime:
 
 | Variable | Purpose |
@@ -32,9 +38,9 @@ Backend runtime:
 | `AWS_ACCESS_KEY_ID` | Server-side S3 signing/apply credentials |
 | `AWS_SECRET_ACCESS_KEY` | Server-side S3 signing/apply credentials |
 | `AWS_S3_BUCKET` | Upload bucket name |
-| `S3_UPLOAD_CORS_ORIGINS` | Optional comma-separated browser origins for S3 upload CORS |
+| `S3_UPLOAD_CORS_ORIGINS` | Optional comma-separated browser origins for the direct S3 diagnostic upload path |
 
-If `S3_UPLOAD_CORS_ORIGINS` is not set, the helper falls back to `CORS_ORIGINS`, `FRONTEND_URL`, the production app origins, and local dev origins.
+If `S3_UPLOAD_CORS_ORIGINS` is not set, the helper falls back to `CORS_ORIGINS`, `FRONTEND_URL`, the production app origins, and local dev origins. The canonical `/partners/business/new` and `/partners/business-profile` UI upload path does not need this variable because the browser posts to the backend API proxy.
 
 ## S3 Bucket CORS
 

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -2,15 +2,15 @@
 
 This app stores vendor onboarding documents in AWS S3. Supabase Storage is not part of the current vendor PDF upload path.
 
-The intended `/partners/business-profile` UI path now uses an authenticated backend upload proxy so the browser uploads to the Mosaic API, not directly to S3. The presigned S3 route remains available for direct-upload flows and diagnostics.
+The intended vendor/business document UI paths now use one authenticated backend upload proxy so the browser uploads to the Mosaic API, not directly to S3. This applies to both `/partners/business/new` and `/partners/business-profile`. The presigned S3 route remains available for direct-upload diagnostics, but these two UI routes should not use it.
 
 ## Request Flow
 
-1. Vendor opens `/partners/business-profile`.
+1. Vendor opens `/partners/business/new` or `/partners/business-profile`.
 2. Frontend posts `multipart/form-data` to:
    `POST /api/vendor-onboarding/stage1/upload-file`.
 3. Backend verifies the session and `business_owner` vendor permissions, validates the document type, MIME type, and size, then writes the file to S3 under the authenticated vendor user path.
-4. Frontend saves the returned `fileUrl` in the vendor onboarding draft.
+4. Frontend saves the returned `fileUrl` in the vendor onboarding draft or business profile payload.
 
 The API proxy path uses normal backend CORS (`CORS_ORIGINS`) and does not require browser-to-S3 preflight. A successful proxy upload proves API auth/CORS and server-side S3 write behavior are working.
 
@@ -87,14 +87,18 @@ The apply command writes only S3 bucket CORS. It preserves existing CORS rules a
 Use a safe dummy PDF, not a real vendor document.
 
 1. Log in as a verified vendor/business owner.
-2. Open `/partners/business-profile`.
-3. Upload a PDF for refund policy or terms/service agreement.
+2. Open `/partners/business/new`.
+3. Upload a safe dummy PDF or allowed image for minority proof, tax document, or business license.
 4. Confirm `POST /api/vendor-onboarding/stage1/upload-file` returns `200`.
 5. Confirm the upload request does not show a browser CORS failure.
-6. Confirm no browser request is made directly to S3 for the business-profile PDF path.
+6. Confirm no browser request is made directly to S3 for the vendor/business document path.
 7. Confirm the resulting object key is under the authenticated vendor path:
    `vendor-onboarding/business-profile/{vendorUserId}/...`.
-8. Confirm a customer or unauthenticated session cannot get a signed upload URL.
+8. Save/continue, refresh the page, and confirm the uploaded metadata remains visible in the draft.
+9. Open `/partners/business-profile`.
+10. Upload or replace a safe dummy PDF for refund policy or terms/service agreement.
+11. Confirm `POST /api/vendor-onboarding/stage1/upload-file` returns `200` and no direct S3 browser request is made.
+12. Confirm a customer or unauthenticated session cannot use `POST /stage1/upload-file`.
 
 ## Direct S3 Preflight Regression Check
 
@@ -114,6 +118,7 @@ Run this only for the legacy/direct presigned path. Do not paste signed URLs, co
 | --- | --- | --- |
 | `POST /stage1/upload-file` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification |
 | `POST /stage1/upload-file` fails API CORS | Backend `CORS_ORIGINS` missing frontend origin | Add the frontend origin to backend CORS env |
+| `/partners/business-profile` uploads work but `/partners/business/new` fails | Frontend route is using stale direct presign/S3 flow instead of `uploadVendorOnboardingFile` | Point both routes at the shared API-proxy helper |
 | `upload-url` fails `401`/`403` | User session or vendor role check failed | Fix login/vendor verification, not S3 CORS |
 | `upload-url` returns `200`, then S3 `OPTIONS` returns `403` | Bucket CORS missing origin, `PUT`, or `Content-Type` | Apply this S3 CORS rule |
 | S3 `OPTIONS` passes, but `PUT` fails signature error | Frontend changed signed headers or upload method | Use direct `PUT` with `requiredHeaders["Content-Type"]` only |

--- a/docs/backend/BACKEND_ROUTE_REGISTRATION.md
+++ b/docs/backend/BACKEND_ROUTE_REGISTRATION.md
@@ -103,7 +103,8 @@ Mounts: `/api/vendor-onboarding` **and** `/admin/vendor-onboard-verify-stage1` (
 | PUT/PATCH | `/business-profile` | update/patch profile | JWT | stage-1 verified | verified |
 | GET | `/status/:applicationId` | `getStatusByApplicationId` | **Public** | — | verified |
 | GET | `/applicationId` | `getApplicationId` | JWT | — | verified |
-| GET | `/stage1/upload-url` | `getStage1UploadUrl` | JWT | verified vendor | verified |
+| POST | `/stage1/upload-file` | `uploadStage1File` | JWT | verified vendor | verified |
+| GET | `/stage1/upload-url` | `getStage1UploadUrl` | JWT | verified vendor | verified direct S3 diagnostic |
 | POST | `/stage1/create-payment` | `createVerificationPayment` | JWT | verified vendor | verified |
 | GET | `/stage1/payment-status` | `getPaymentStatus` | JWT | verified vendor | verified |
 | GET | `/pending` | `getPendingApplications` | JWT | admin | verified |


### PR DESCRIPTION
## Summary
Documents the canonical vendor/business document upload flow now shared by `/partners/business/new` and `/partners/business-profile`.

## What changed
- Updated the vendor PDF upload runbook to cover both UI routes.
- Documented the production failure mode where one route used the API proxy while another used stale direct presign/S3 upload logic.
- Updated lifecycle/storage docs to say the UI routes use `POST /api/vendor-onboarding/stage1/upload-file`; direct presign remains diagnostic only.

## Validation
- Targeted vendor upload backend tests passed.
- Full backend `npm test` passed.
- `git diff --check` passed.