### PR TITLE
[codex] Add customer order lifecycle emails

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -98,7 +98,12 @@ const User = require("../models/User");
 const ProductVariant = require("../models/ProductVariant")  ;
 const Business = require("../models/Business");
 const { getBusinessCheckoutBlock } = require("../utils/checkoutGuards");
-const { sendOrderStatusEmail, sendOrderUpdateEmail } = require("../utils/orderPhase");
+const {
+  sendOrderStatusEmail,
+  sendOrderUpdateEmail,
+  sendOrderLifecycleEmail,
+} = require("../utils/orderPhase");
+const { sendCustomerOrderLifecycleEmail } = require("../utils/orderLifecycleEmailDelivery");
 const {
   calculateShippingForVendor,
   normalizeDeliverySpeed,
@@ -120,6 +125,13 @@ const toNum = (value) => {
 };
 
 const getAuthenticatedUserId = (req) => req.user?.id || req.user?._id;
+
+function serializeOrderForResponse(order) {
+  if (!order) return order;
+  const payload = typeof order.toObject === "function" ? order.toObject() : { ...order };
+  delete payload.lifecycleEmailLog;
+  return payload;
+}
 
 const ADMIN_PAYMENT_BUCKETS = ["pending", "paid", "failed", "refunded"];
 const ADMIN_STATUS_BUCKETS = [
@@ -1035,19 +1047,17 @@ exports.acceptOrder = async (req, res) => {
     order.statusHistory.push({ status: "accepted" });
     await order.save();
 
-    try {
-      const customerEmail = order.userId.email; // use whichever you store
-      if (customerEmail) {
-        await sendOrderStatusEmail(customerEmail, order._id.toString(), "accepted");
-      }
-    } catch (e) {
-      console.error("Failed to send acceptance email:", e?.message || e);
-    }
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_accepted",
+      send: (customerEmail) => sendOrderStatusEmail(customerEmail, order._id.toString(), "accepted"),
+    });
 
     res.json({
       success: true,
       message: "Order accepted and stock updated",
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error accepting order:", err);
@@ -1113,19 +1123,17 @@ exports.rejectOrder = async (req, res) => {
     }
 
     await order.save();
-    try {
-      const customerEmail = order.userId.email; // use whichever you store
-      if (customerEmail) {
-        await sendOrderStatusEmail(customerEmail, order._id.toString(), "rejected");
-      }
-    } catch (e) {
-      console.error("Failed to send rejection email:", e?.message || e);
-    }
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_rejected",
+      send: (customerEmail) => sendOrderStatusEmail(customerEmail, order._id.toString(), "rejected"),
+    });
 
     res.json({
       success: true,
       message: "Order rejected and refunded (if paid)",
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error rejecting order:", err);
@@ -1172,18 +1180,19 @@ exports.shipOrder = async (req, res) => {
     await order.save();
 
     // ✅ FIX EMAIL SENDING
-    const email = order.userId?.email;
-
-    if (email) {
-      await sendOrderUpdateEmail(email, "shipped", trackingUrl);
-    } else {
-      console.error("Missing user email for order:", order._id);
-    }
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_shipped",
+      fingerprintDetails: { trackingId, trackingUrl },
+      send: (customerEmail) =>
+        sendOrderUpdateEmail(customerEmail, "shipped", trackingUrl, { trackingId }),
+    });
 
     res.json({
       success: true,
       message: "Order marked as shipped",
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error in shipOrder:", err);
@@ -1219,18 +1228,17 @@ exports.deliverOrder = async (req, res) => {
     await order.save();
 
     // ✅ FIX EMAIL
-    const email = order.userId?.email;
-
-    if (email) {
-      await sendOrderUpdateEmail(email, "delivered");
-    } else {
-      console.error("Missing user email for order:", order._id);
-    }
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_delivered",
+      send: (customerEmail) => sendOrderUpdateEmail(customerEmail, "delivered"),
+    });
 
     res.json({
       success: true,
       message: "Order marked as delivered successfully",
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error delivering order:", err);
@@ -1243,7 +1251,8 @@ exports.initiateReturn = async (req, res) => {
     const userId = getAuthenticatedUserId(req);
     const orderId = req.params.orderId;
 
-    const order = await Order.findOne({ _id: orderId, userId });
+    const order = await Order.findOne({ _id: orderId, userId })
+      .populate("userId", "email name");
     if (!order) {
       return res.status(404).json({ success: false, message: "Order not found or unauthorized" });
     }
@@ -1261,10 +1270,17 @@ exports.initiateReturn = async (req, res) => {
 
     await order.save();  // Save the order after marking it as returned
 
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "return_initiated",
+      send: (customerEmail) => sendOrderLifecycleEmail(customerEmail, order, "return_initiated"),
+    });
+
     res.json({
       success: true,
       message: 'Return initiated successfully',
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error initiating return:", err);
@@ -1279,7 +1295,9 @@ exports.acceptReturn = async (req, res) => {
     const vendorId = req.user._id;
     const orderId = req.params.orderId;
 
-    const order = await Order.findOne({ _id: orderId, vendorId }).populate('businessId');
+    const order = await Order.findOne({ _id: orderId, vendorId })
+      .populate('businessId')
+      .populate('userId', 'email name');
     if (!order) {
       return res.status(404).json({ success: false, message: "Order not found or unauthorized" });
     }
@@ -1326,10 +1344,17 @@ exports.acceptReturn = async (req, res) => {
 
     await order.save();  // Save the updated order
 
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_refunded",
+      send: (customerEmail) => sendOrderLifecycleEmail(customerEmail, order, "order_refunded"),
+    });
+
     res.json({
       success: true,
       message: 'Return accepted and refund processed (if paid)',
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error accepting return:", err);
@@ -1501,7 +1526,8 @@ exports.cancelOrderByUser = async (req, res) => {
     const { orderId } = req.params;
 
     // Load the order for this user
-    const order = await Order.findOne({ _id: orderId, userId });
+    const order = await Order.findOne({ _id: orderId, userId })
+      .populate("userId", "email name");
     if (!order) {
       return res
         .status(404)
@@ -1573,10 +1599,17 @@ exports.cancelOrderByUser = async (req, res) => {
     order.statusHistory.push({ status: "cancelled" });
     await order.save();
 
+    const emailDelivery = await sendCustomerOrderLifecycleEmail({
+      order,
+      event: "order_cancelled",
+      send: (customerEmail) => sendOrderLifecycleEmail(customerEmail, order, "order_cancelled"),
+    });
+
     return res.json({
       success: true,
       message: "Order cancelled successfully",
-      order,
+      emailDelivery,
+      order: serializeOrderForResponse(order),
     });
   } catch (err) {
     console.error("Error cancelling order:", err);

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -2,6 +2,10 @@ const Stripe = require("stripe");
 const Order = require("../models/Order");
 const { sendOrderPaidEmails } = require("../utils/OrderMail");
 const {
+  appendOrderLifecycleEmailLog,
+  buildOrderLifecycleEmailFingerprint,
+} = require("../utils/orderLifecycleEmailDelivery");
+const {
   sanitizePaymentIntentForClient,
   sanitizeOrderForPaymentPoll,
 } = require("../utils/paymentIntentResponse");
@@ -101,6 +105,10 @@ exports.stripePaymentWebhook = async (req, res) => {
           order.businessId?.owner?.email,
         ].filter(Boolean);
         const uniqueVendorEmails = [...new Set(vendorEmails)];
+        const paidEmailFingerprint = buildOrderLifecycleEmailFingerprint(
+          order,
+          "order_paid_confirmation"
+        );
 
         // ✅ send emails (best-effort)
         try {
@@ -112,7 +120,20 @@ exports.stripePaymentWebhook = async (req, res) => {
           });
           order.paidConfirmationEmailSentAt = new Date();
           await order.save();
+          await appendOrderLifecycleEmailLog(order, {
+            event: "order_paid_confirmation",
+            fingerprint: paidEmailFingerprint,
+            deliveryStatus: "sent",
+            recipientRole: "customer",
+          });
         } catch (mailErr) {
+          await appendOrderLifecycleEmailLog(order, {
+            event: "order_paid_confirmation",
+            fingerprint: paidEmailFingerprint,
+            deliveryStatus: "failed",
+            recipientRole: "customer",
+            error: mailErr?.message || "Unknown email error",
+          });
           console.error("✉️ Failed to send order-paid emails:", mailErr?.message || mailErr);
         }
       }

--- a/docs/API_SURFACE.md
+++ b/docs/API_SURFACE.md
@@ -328,7 +328,7 @@ Router-level: `authenticate`, `isCustomer`.
 
 | Method | Route | Middleware | Controller | Auth/Role | Purpose | Smoke Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| POST | `/api/orders/initiate` | `authenticate` | `initiateOrder` | Authenticated customer | Create order + Stripe PI (Connect) | 🔴 **P5.2–P5.3** — real money; emails before pay |
+| POST | `/api/orders/initiate` | `authenticate` | `initiateOrder` | Authenticated customer | Create order + Stripe PI (Connect) | Real money; paid email is webhook-only |
 | GET | `/api/orders/retrieve-intent/:id` | `authenticate` | `retrieveIntent` | Authenticated | PI + orders lookup | 🟡 P5.4 |
 | GET | `/api/orders/user` | `authenticate` | `getUserOrders` | Authenticated | Customer orders | 🟡 |
 | GET | `/api/orders/:id/invoice.pdf` | `authenticate` | `getInvoicePdf` | Authenticated | Invoice PDF | 🟡 |
@@ -523,7 +523,7 @@ Routes that need extra care in production testing (from [launch-readiness-report
 | **Real money** | `POST /api/orders/initiate`, vendor `create-payment`, subscriptions | Stripe test mode + dedicated test accounts only |
 | **Public status leak** | `GET /api/vendor-onboarding/status/:applicationId` | Do not use real application IDs in public demos |
 | **Admin destructive** | `/admin/users/*`, finalize, business approve | Admin test account only |
-| **Pre-payment emails** | `POST /api/orders/initiate` | Known P0-6 — expect emails before pay succeeds |
+| **Order emails** | `POST /api/orders/initiate`, `/api/stripe/payment/webhook`, lifecycle routes | Paid confirmation is webhook-only; lifecycle emails are best-effort after state changes |
 
 ---
 

--- a/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
+++ b/docs/MVP_BACKEND_EMAIL_NOTIFICATIONS.md
@@ -21,6 +21,7 @@ Audit and document launch-safe backend email notification behavior for vendor on
 | Topic | Owner issue | #33 action |
 | --- | --- | --- |
 | Vendor onboarding emails (#30) | #30 | Preserve + test submit path |
+| Customer order lifecycle emails | #182 | Added best-effort customer emails for real order status changes with `lifecycleEmailLog` audit evidence |
 | Order confirmation **timing** (pre-payment vs post-payment) | #43 | **Resolved on `main`** — paid confirmation webhook-only via `paidConfirmationEmailSentAt` |
 | Webhook email dedup on retry | #43 | **Resolved on `main`** — dedup flag prevents resend on Stripe retry |
 | Post-purchase review follow-up | #35 | Document gap — not implemented |
@@ -39,7 +40,8 @@ Audit and document launch-safe backend email notification behavior for vendor on
 | [`utils/WellcomeMailer.js`](../utils/WellcomeMailer.js) | Onboarding submit/approve/reject/badge, admin alerts | Vendor onboarding |
 | [`utils/vendorOnboardingEmailDelivery.js`](../utils/vendorOnboardingEmailDelivery.js) | `deliverVendorOnboardingEmail(s)` | Graceful SMTP gate |
 | [`utils/OrderMail.js`](../utils/OrderMail.js) | `sendOrderPaidEmails` | Post-payment confirmation + PDF invoice |
-| [`utils/orderPhase.js`](../utils/orderPhase.js) | Placed, accept/reject, shipped, delivered | Order lifecycle |
+| [`utils/orderPhase.js`](../utils/orderPhase.js) | Accept/reject, shipped/delivered, cancel/return/refund templates | Order lifecycle |
+| [`utils/orderLifecycleEmailDelivery.js`](../utils/orderLifecycleEmailDelivery.js) | `sendCustomerOrderLifecycleEmail`, `lifecycleEmailLog` append/dedup helpers | Order lifecycle audit |
 | [`utils/approvalMail.js`](../utils/approvalMail.js) | Business approved/blocked/deactivated | Business admin |
 | [`utils/bookingMailer.js`](../utils/bookingMailer.js) | Service booking lifecycle | Bookings |
 | [`utils/BuisnessprofileMail.js`](../utils/BuisnessprofileMail.js) | Business profile admin review | Legacy profile flow |
@@ -50,7 +52,7 @@ Audit and document launch-safe backend email notification behavior for vendor on
 | --- | --- | --- |
 | [`vendorOnboarding.controller.js`](../controllers/vendorOnboarding.controller.js) | `POST /api/vendor-onboarding/submit` | Admin + vendor submission receipt |
 | [`admin/vendorOnboardVerifyStage1.js`](../controllers/admin/vendorOnboardVerifyStage1.js) | `POST /api/vendor-onboarding/:id/finalize` | Approve / reject / badge |
-| [`orderController.js`](../controllers/orderController.js) | `POST /api/orders/initiate`, accept/reject/ship/deliver | Order placed + lifecycle |
+| [`orderController.js`](../controllers/orderController.js) | accept/reject/ship/deliver/cancel/initiate-return/accept-return | Customer order lifecycle |
 | [`stripePaymentController.js`](../controllers/stripePaymentController.js) | `POST /api/stripe/payment/webhook` | Order paid + invoice |
 | [`userController.js`](../controllers/userController.js) | `POST /api/users/register`, `/resend-otp`, unverified `/login` | Registration / resend / login OTP |
 
@@ -94,11 +96,12 @@ Audit and document launch-safe backend email notification behavior for vendor on
 | Vendor approved | `finalizeVerification` | `sendVendorApprovedEmail` | Non-blocking; HTTP 200 |
 | Vendor rejected | `finalizeVerification` | `sendVendorRejectionEmail` | Non-blocking; HTTP 200 |
 | Trust badge assigned | `finalizeVerification` | `sendVendorTrustBadgeAssignedEmail` | Non-blocking; HTTP 200 |
-| Order placed (customer) | `initiateOrder` | `sendCustomerOrderPlacedEmail` | try/catch; order + PI still created |
-| Order placed (vendor) | `initiateOrder` | `sendVendorNewOrderEmail` | try/catch; order + PI still created |
+| Pre-payment order placed (customer) | `initiateOrder` | Legacy helper only; not called by active order controller | No email before payment succeeds |
+| Pre-payment order placed (vendor) | `initiateOrder` | Legacy helper only; not called by active order controller | No email before payment succeeds |
 | Order paid + invoice | `payment_intent.succeeded` webhook | `sendOrderPaidEmails` | try/catch per order; webhook 200 |
-| Order accepted/rejected | accept/reject handlers | `sendOrderStatusEmail` | try/catch; order update succeeds |
-| Order shipped/delivered | ship/deliver handlers | `sendOrderUpdateEmail` | try/catch; order update succeeds |
+| Order accepted/rejected | accept/reject handlers | `sendOrderStatusEmail` via lifecycle helper | Best-effort; state persists and attempt is logged |
+| Order shipped/delivered | ship/deliver handlers | `sendOrderUpdateEmail` via lifecycle helper | Best-effort; state persists and attempt is logged |
+| Order cancelled / return initiated / refunded | cancel/initiate-return/accept-return handlers | `sendOrderLifecycleEmail` via lifecycle helper | Best-effort; state persists and attempt is logged |
 
 ### Vendor submission receipt copy (#33)
 
@@ -114,7 +117,7 @@ Application ID and support contact are included. Approve/reject/badge templates 
 | --- | --- | --- |
 | Post-purchase review follow-up | **Not implemented** — Review CRUD exists (`reviewController.js`) but no mailer, scheduler, or post-order hook | #35 |
 | Move **paid** confirmation to post-payment only | **Done (#43)** — `sendOrderPaidEmails` webhook-only; dedup via `paidConfirmationEmailSentAt` | Closed |
-| Pre-payment "order placed" emails at `initiateOrder` | **Still active** — `sendCustomerOrderPlacedEmail` / `sendVendorNewOrderEmail` at order create | Documented P0-6 risk |
+| Pre-payment "order placed" emails at `initiateOrder` | **Disabled in active controller** - legacy helpers remain exported but are not called from `initiateOrder` | Closed by #43/#182 |
 | Webhook email dedup on retry | **Done (#43)** — skip when `paidConfirmationEmailSentAt` set | Closed |
 | Food booking emails | **Not implemented** | — |
 | Unified mail service / retry queue | **Not implemented** | — |
@@ -126,9 +129,9 @@ Application ID and support contact are included. Approve/reject/badge templates 
 | Flow | Missing SMTP | Send throws | HTTP outcome |
 | --- | --- | --- | --- |
 | Vendor submit / finalize | Skip + warn | Log message only | **200** — state persisted |
-| `initiateOrder` emails | N/A (no gate) | Log `err.message` | **201** — order + PI created |
+| `initiateOrder` pre-payment emails | Not sent | Not applicable | **201** - order + PI created; paid email waits for webhook |
 | Post-payment webhook emails | N/A | Log `mailErr.message` | **200** — webhook ack |
-| Order accept/reject/ship/deliver | N/A | Log message | **200** — order updated |
+| Order lifecycle handlers | N/A | Log message + append `lifecycleEmailLog` entry | **200** - order state persisted |
 | Register OTP | N/A | Log sanitized code; account preserved | **502** `OTP_DELIVERY_FAILED` |
 | Forgot password OTP | N/A | Log sanitized code; generic response | **200** — anti-enumeration |
 
@@ -150,9 +153,10 @@ Application ID and support contact are included. Approve/reject/badge templates 
 | [`tests/vendor/vendor-onboarding-submit-email.test.js`](../tests/vendor/vendor-onboarding-submit-email.test.js) | 4 | Submit email flags, skip, failure, idempotent |
 | [`tests/utils/vendor-onboarding-email-delivery.test.js`](../tests/utils/vendor-onboarding-email-delivery.test.js) | 6 | Delivery helper unit tests |
 | [`tests/email/email-notification-safety.test.js`](../tests/email/email-notification-safety.test.js) | 4 | Review gap audit, OTP/logging source checks |
-| [`tests/stripe/order-email-safety.test.js`](../tests/stripe/order-email-safety.test.js) | 3 | Post-payment email call + safe failure |
+| [`tests/stripe/order-email-safety.test.js`](../tests/stripe/order-email-safety.test.js) | 5 | Post-payment email call, duplicate guard, failed payment no-email, safe failure |
+| [`tests/orders/order-lifecycle-emails.test.js`](../tests/orders/order-lifecycle-emails.test.js) | 4 | Shipping/tracking email, SMTP failure logging, return initiation, refund email |
 
-**Suite total (Batch 3):** **190/190** (`npm test`) — includes #43 order-email-safety tests
+**Current verification:** run `npm test` before merge; targeted #182 tests cover webhook timing, tracking, cancellation, refund, and lifecycle failure logging.
 
 **Not proven by automation:** Live SMTP inbox delivery, template rendering in real clients, PDF invoice attachment in production.
 
@@ -168,7 +172,8 @@ Live SMTP inbox proof requires **disposable dedicated smoke accounts** — not a
 | C2 | Admin finalize approve | `SMOKE_TEST_ADMIN_*` + pending vendor app | Inbox: approval email; API `emailSent: true` |
 | C3 | Admin finalize reject | Same | Inbox: rejection email |
 | B1 | Checkout → order paid email | `SMOKE_TEST_CUSTOMER_*` + vendor listing | Inbox: payment confirmation + invoice PDF |
-| B2 | Order placed (pre-payment) | Same | Inbox: placed email (document P0-6 timing risk) |
+| B2 | Vendor ships order with tracking | Same | Inbox: shipping/tracking email; `lifecycleEmailLog` has one sent attempt |
+| B3 | Customer cancel / return accepted | Same | Inbox: cancel/refund lifecycle email; `lifecycleEmailLog` has one sent attempt |
 
 **Blockers:** `SMOKE_TEST_*` accounts not provisioned in repo — all live inbox proof **PENDING**.
 
@@ -178,7 +183,7 @@ Live SMTP inbox proof requires **disposable dedicated smoke accounts** — not a
 
 | Risk | Detail |
 | --- | --- |
-| Pre-payment order emails | Customer may receive "order placed" before payment succeeds — **not changed by #43** |
+| Pre-payment order helper drift | Legacy placed-email helpers remain exported but active `initiateOrder` does not call them |
 | Paid confirmation dedup | **Mitigated (#43)** — `paidConfirmationEmailSentAt` on webhook |
 | No review follow-up | Post-purchase review prompt not implemented — #35 |
 | Fragmented mailers | 8+ files each create own Nodemailer transport |

--- a/docs/STRIPE_WEBHOOKS.md
+++ b/docs/STRIPE_WEBHOOKS.md
@@ -128,7 +128,7 @@ Triggered by PaymentIntent from `POST /api/vendor-onboarding/stage1/create-payme
 
 | Event type | Action |
 |------------|--------|
-| `payment_intent.succeeded` | Find orders by `paymentId`; set `paid`/`ordered`; store `chargeId`, `transferId`, `applicationFeeId` on items; send order-paid emails |
+| `payment_intent.succeeded` | Find orders by `paymentId`; set `paid`/`ordered`; store `chargeId`, `transferId`, `applicationFeeId` on items; send order-paid emails; append lifecycle email attempt log |
 | Other | `200` ack only |
 
 ---

--- a/docs/audit/BACKEND_REFUND_RETURN_DISPUTE_AS_BUILT_AUDIT.md
+++ b/docs/audit/BACKEND_REFUND_RETURN_DISPUTE_AS_BUILT_AUDIT.md
@@ -107,7 +107,7 @@ sequenceDiagram
     API->>DB: status=cancelled only
   end
   API-->>C: 200 + order
-  Note over C,S: No customer email on cancel (reject/ship/deliver do email)
+  Note over C,S: Customer lifecycle email is attempted after state save; failure is logged without reversing state
 ```
 
 ### Vendor reject (paid order)
@@ -151,7 +151,7 @@ sequenceDiagram
     API->>S: refunds.create(full, reverse_transfer, refund_application_fee)
     API->>DB: paymentStatus=refunded, status=refunded
   end
-  Note over V,S: No email on initiateReturn or acceptReturn
+  Note over V,S: Customer lifecycle email is attempted for return initiated and refund processed after state save
 ```
 
 ### Webhook `charge.refunded` (as-built)
@@ -201,7 +201,7 @@ Classification key:
 | Connected-account transfer reversal | Implemented; runtime proof needed | `reverse_transfer: true` on all refund creates |
 | Application fee handling on refund | Implemented; runtime proof needed | `refund_application_fee: true` |
 | Status synchronization (inline + webhook) | **Confirmed bug** (partial) | Inline updates work; `charge.refunded` depends on charge metadata |
-| Notification on refund/cancel/return | **Client policy decision needed** | Reject/ship/deliver email; cancel/return paths silent |
+| Notification on refund/cancel/return | Implemented; runtime proof needed | Customer lifecycle email attempts logged in `lifecycleEmailLog`; targeted unit coverage added |
 | Reconciliation / audit trail | **Absent** (partial webhook) | No `Refund` records; item-level Stripe IDs not cleared on refund |
 | Stripe dispute webhooks | **Absent** | No `charge.dispute.*` handlers |
 | `Refund` model persistence | **Absent** | Orphan schema |
@@ -234,7 +234,7 @@ Classification key:
 | # | Question | Current behavior |
 |---|----------|------------------|
 | P1 | Should customer `initiateReturn` create a **pending** return vs immediately `returned`? | Immediate `returned`; vendor cannot reject return request |
-| P2 | Should cancel/acceptReturn/initiateReturn send **email notifications**? | Only reject/ship/deliver notify |
+| P2 | Should cancel/acceptReturn/initiateReturn send **email notifications**? | Yes - best-effort customer lifecycle email attempts are logged after state save |
 | P3 | Are **partial refunds** (damaged item, shipping only) required? | Not supported |
 | P4 | Who resolves **lost/damaged in transit** — vendor, platform, or insurer? | No workflow |
 | P5 | Should **admin** override refunds or mediate disputes? | No admin actions |

--- a/docs/backend/DATA_MODEL_DICTIONARY.md
+++ b/docs/backend/DATA_MODEL_DICTIONARY.md
@@ -169,6 +169,8 @@ Unique `{ customerId, productVariantId }`.
 | `status`, `statusHistory` | lifecycle |
 | `paymentStatus`, `paymentId`, `paymentMethod` | Stripe |
 | `chargeId`, `transferId` on items | post-webhook |
+| `paidConfirmationEmailSentAt` | post-payment email duplicate guard |
+| `lifecycleEmailLog` | customer order lifecycle email attempt audit |
 
 **Indexes:** `{ userId, vendorId, status }`, `{ groupOrderId }`
 

--- a/models/Order.js
+++ b/models/Order.js
@@ -177,6 +177,24 @@ const orderSchema = new Schema(
       type: Date,
       default: null,
     },
+    lifecycleEmailLog: [
+      {
+        event: String,
+        fingerprint: String,
+        orderStatus: String,
+        paymentStatus: String,
+        deliveryStatus: {
+          type: String,
+          enum: ["sent", "skipped", "failed"],
+        },
+        recipientRole: String,
+        attemptedAt: {
+          type: Date,
+          default: Date.now,
+        },
+        error: String,
+      },
+    ],
     stripeCustomerId: {
       type: String, // Optional: if using Stripe Customer objects
     },

--- a/tests/orders/customer-order-safety.test.js
+++ b/tests/orders/customer-order-safety.test.js
@@ -24,12 +24,13 @@ function makeOrder(overrides = {}) {
   let saveCalls = 0;
   return {
     _id: 'order-1',
-    userId: 'customer-1',
+    userId: { _id: 'customer-1', email: 'customer@example.com' },
     status: 'ordered',
     paymentStatus: 'pending',
     paymentId: null,
     items: [],
     statusHistory: [],
+    lifecycleEmailLog: [],
     async save() {
       saveCalls += 1;
     },
@@ -51,6 +52,7 @@ function loadOrderController({
     find: [],
     findOne: [],
     populate: [],
+    email: [],
     refundCreate: [],
     variantFindById: [],
     sequence: [],
@@ -93,7 +95,15 @@ function loadOrderController({
         },
         findOne(filter) {
           calls.findOne.push(filter);
-          return order;
+          return {
+            populate(field, select) {
+              calls.populate.push({ field, select });
+              return Promise.resolve(order);
+            },
+            then(resolve, reject) {
+              return Promise.resolve(order).then(resolve, reject);
+            },
+          };
         },
       };
     }
@@ -118,8 +128,9 @@ function loadOrderController({
 
     if (request.endsWith('utils/orderPhase')) {
       return {
-        sendOrderStatusEmail: async () => {},
-        sendOrderUpdateEmail: async () => {},
+        sendOrderStatusEmail: async (...args) => calls.email.push(['status', ...args]),
+        sendOrderUpdateEmail: async (...args) => calls.email.push(['update', ...args]),
+        sendOrderLifecycleEmail: async (...args) => calls.email.push(['lifecycle', ...args]),
         sendVendorNewOrderEmail: async () => {},
         sendCustomerOrderPlacedEmail: async () => {},
       };
@@ -218,6 +229,7 @@ test('cancelOrderByUser does not restore accepted-order stock when refund fails'
   assert.equal(order.status, 'accepted');
   assert.equal(order.paymentStatus, 'paid');
   assert.deepEqual(order.statusHistory, []);
+  assert.deepEqual(calls.email, []);
   assert.equal(order.getSaveCalls(), 0);
 });
 
@@ -264,5 +276,13 @@ test('cancelOrderByUser restores accepted-order stock after successful refund', 
   assert.equal(order.status, 'cancelled');
   assert.equal(order.paymentStatus, 'refunded');
   assert.deepEqual(order.statusHistory, [{ status: 'cancelled' }]);
-  assert.equal(order.getSaveCalls(), 1);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].event, 'order_cancelled');
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'sent');
+  assert.equal(res.body.order.lifecycleEmailLog, undefined);
+  assert.equal(calls.email.length, 1);
+  assert.equal(calls.email[0][0], 'lifecycle');
+  assert.equal(calls.email[0][1], 'customer@example.com');
+  assert.equal(calls.email[0][3], 'order_cancelled');
+  assert.equal(order.getSaveCalls(), 2);
 });

--- a/tests/orders/order-lifecycle-emails.test.js
+++ b/tests/orders/order-lifecycle-emails.test.js
@@ -1,0 +1,259 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const orderControllerPath = path.resolve(__dirname, '../../controllers/orderController.js');
+const lifecycleDeliveryPath = path.resolve(
+  __dirname,
+  '../../utils/orderLifecycleEmailDelivery.js'
+);
+
+function createResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOrder(overrides = {}) {
+  return {
+    _id: 'order-email-1',
+    groupOrderId: 'MBH-ORDER-EMAIL-001',
+    vendorId: 'vendor-1',
+    userId: { _id: 'customer-1', email: 'customer@example.com', name: 'Customer User' },
+    businessId: { stripeConnectAccountId: 'acct_test' },
+    status: 'accepted',
+    paymentStatus: 'paid',
+    paymentId: 'pi_test',
+    totalAmount: 42,
+    items: [],
+    statusHistory: [],
+    lifecycleEmailLog: [],
+    saveCount: 0,
+    async save() {
+      this.saveCount += 1;
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function buildOrderQuery(order, calls) {
+  return {
+    populate(field, select) {
+      calls.populate.push({ field, select });
+      return this;
+    },
+    then(resolve, reject) {
+      return Promise.resolve(order).then(resolve, reject);
+    },
+  };
+}
+
+function loadOrderController({
+  order,
+  sendOrderUpdateEmail,
+  sendOrderLifecycleEmail,
+} = {}) {
+  const calls = {
+    email: [],
+    populate: [],
+    refundCreate: [],
+  };
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return function Stripe() {
+        return {
+          refunds: {
+            create: async (payload) => {
+              calls.refundCreate.push(payload);
+              return { id: 're_test' };
+            },
+          },
+        };
+      };
+    }
+    if (request.endsWith('models/Order')) {
+      return {
+        findOne: () => buildOrderQuery(order, calls),
+        find: () => ({
+          sort: () => ({
+            populate: () => ({
+              populate: () => ({
+                populate: async () => [],
+              }),
+            }),
+          }),
+        }),
+      };
+    }
+    if (request.endsWith('models/ProductVariant')) {
+      return { findById: async () => null };
+    }
+    if (request.endsWith('models/User') || request.endsWith('models/Business') || request.endsWith('models/Cart')) {
+      return {};
+    }
+    if (request.endsWith('utils/checkoutGuards')) {
+      return { getBusinessCheckoutBlock: async () => null };
+    }
+    if (request.endsWith('utils/orderPhase')) {
+      return {
+        sendOrderStatusEmail: async (...args) => calls.email.push(['status', ...args]),
+        sendOrderUpdateEmail: sendOrderUpdateEmail || (async (...args) => {
+          calls.email.push(['update', ...args]);
+        }),
+        sendOrderLifecycleEmail: sendOrderLifecycleEmail || (async (...args) => {
+          calls.email.push(['lifecycle', ...args]);
+        }),
+        sendVendorNewOrderEmail: async () => {},
+        sendCustomerOrderPlacedEmail: async () => {},
+      };
+    }
+    if (request.endsWith('utils/vendorShipping')) {
+      return {
+        calculateShippingForVendor: () => 0,
+        normalizeDeliverySpeed: (value) => value,
+      };
+    }
+    if (request.endsWith('utils/vendorTax')) {
+      return {
+        getResolvedTaxCategory: () => null,
+        getTaxRateForCategory: () => 0,
+        buildTaxAwareAmounts: () => ({}),
+        extractTaxFromInclusiveAmount: () => 0,
+        roundCurrency: (value) => value,
+      };
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[orderControllerPath];
+  delete require.cache[lifecycleDeliveryPath];
+  const controller = require(orderControllerPath);
+  Module._load = originalLoad;
+
+  return { controller, calls };
+}
+
+test('shipOrder sends one tracking email after tracking is saved', async () => {
+  const order = buildOrder({ status: 'accepted' });
+  const { controller, calls } = loadOrderController({ order });
+  const res = createResponse();
+
+  await controller.shipOrder(
+    {
+      user: { _id: 'vendor-1' },
+      params: { orderId: 'order-email-1' },
+      body: { trackingId: 'TRACK-123', trackingUrl: 'https://carrier.example/track/TRACK-123' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(order.status, 'shipped');
+  assert.deepEqual(order.trackingInfo, {
+    trackingId: 'TRACK-123',
+    trackingUrl: 'https://carrier.example/track/TRACK-123',
+  });
+  assert.equal(calls.email.length, 1);
+  assert.deepEqual(calls.email[0], [
+    'update',
+    'customer@example.com',
+    'shipped',
+    'https://carrier.example/track/TRACK-123',
+    { trackingId: 'TRACK-123' },
+  ]);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].event, 'order_shipped');
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'sent');
+  assert.equal(order.saveCount, 2);
+});
+
+test('shipOrder keeps shipped state when tracking email fails', async () => {
+  const order = buildOrder({ status: 'accepted' });
+  const { controller } = loadOrderController({
+    order,
+    sendOrderUpdateEmail: async () => {
+      throw new Error('SMTP unavailable');
+    },
+  });
+  const res = createResponse();
+
+  await controller.shipOrder(
+    {
+      user: { _id: 'vendor-1' },
+      params: { orderId: 'order-email-1' },
+      body: { trackingId: 'TRACK-FAIL', trackingUrl: 'https://carrier.example/track/TRACK-FAIL' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.emailDelivery.emailFailed, true);
+  assert.equal(order.status, 'shipped');
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'failed');
+  assert.ok(order.lifecycleEmailLog[0].error.includes('SMTP unavailable'));
+});
+
+test('initiateReturn sends return received email after returned state is saved', async () => {
+  const order = buildOrder({ status: 'delivered' });
+  const { controller, calls } = loadOrderController({ order });
+  const res = createResponse();
+
+  await controller.initiateReturn(
+    {
+      user: { _id: 'customer-1' },
+      params: { orderId: 'order-email-1' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(order.status, 'returned');
+  assert.equal(calls.email.length, 1);
+  assert.deepEqual(calls.email[0], ['lifecycle', 'customer@example.com', order, 'return_initiated']);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].event, 'return_initiated');
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'sent');
+});
+
+test('acceptReturn sends refund processed email after refund succeeds', async () => {
+  const order = buildOrder({ status: 'returned', paymentStatus: 'paid' });
+  const { controller, calls } = loadOrderController({ order });
+  const res = createResponse();
+
+  await controller.acceptReturn(
+    {
+      user: { _id: 'vendor-1' },
+      params: { orderId: 'order-email-1' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, null);
+  assert.equal(res.body.success, true);
+  assert.equal(order.status, 'refunded');
+  assert.equal(order.paymentStatus, 'refunded');
+  assert.equal(calls.refundCreate.length, 1);
+  assert.equal(calls.email.length, 1);
+  assert.deepEqual(calls.email[0], ['lifecycle', 'customer@example.com', order, 'order_refunded']);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].event, 'order_refunded');
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'sent');
+});

--- a/tests/stripe/order-email-safety.test.js
+++ b/tests/stripe/order-email-safety.test.js
@@ -46,6 +46,7 @@ function buildOrderForPostPayment(overrides = {}) {
     status: 'created',
     statusHistory: [{ status: 'created' }],
     paidConfirmationEmailSentAt: null,
+    lifecycleEmailLog: [],
     items: [{ chargeId: null, transferId: null, applicationFeeId: null }],
     userId: { email: 'customer@example.com' },
     vendorId: { email: 'vendor@example.com' },
@@ -61,13 +62,17 @@ function buildOrderForPostPayment(overrides = {}) {
   };
 }
 
-function loadPostPaymentWebhook({ orders = [], mailShouldFail = false } = {}) {
+function loadPostPaymentWebhook({
+  orders = [],
+  mailShouldFail = false,
+  eventType = 'payment_intent.succeeded',
+} = {}) {
   let emailSendCount = 0;
 
   const stripeMock = {
     webhooks: {
       constructEvent: () => ({
-        type: 'payment_intent.succeeded',
+        type: eventType,
         data: {
           object: {
             id: PAYMENT_ID,
@@ -137,6 +142,9 @@ test('post-payment webhook calls sendOrderPaidEmails on success', async () => {
   assert.ok(res.body.received);
   assert.equal(getEmailSendCount(), 1);
   assert.ok(order.paidConfirmationEmailSentAt instanceof Date);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].event, 'order_paid_confirmation');
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'sent');
 });
 
 test('post-payment webhook still returns received when email send fails', async () => {
@@ -164,6 +172,10 @@ test('post-payment webhook still returns received when email send fails', async 
 
   assert.ok(res.body.received);
   assert.equal(getEmailSendCount(), 1);
+  assert.equal(order.paidConfirmationEmailSentAt, null);
+  assert.equal(order.lifecycleEmailLog.length, 1);
+  assert.equal(order.lifecycleEmailLog[0].deliveryStatus, 'failed');
+  assert.ok(order.lifecycleEmailLog[0].error.includes('SMTP unavailable'));
   assert.ok(errorLogs.some((line) => line.includes('SMTP unavailable')));
   assert.ok(!errorLogs.some((line) => line.includes('whsec_')));
 });
@@ -186,6 +198,30 @@ test('post-payment webhook skips duplicate paid confirmation emails', async () =
 
   assert.ok(res.body.received);
   assert.equal(getEmailSendCount(), 0);
+  assert.equal(order.lifecycleEmailLog.length, 0);
+});
+
+test('post-payment webhook does not send confirmation on failed payment event', async () => {
+  process.env.STRIPE_ORDER_POST_PAYMENT_WEBHOOK_SECRET = 'whsec_post_payment_test';
+  const order = buildOrderForPostPayment();
+  const { stripePaymentWebhook, getEmailSendCount } = loadPostPaymentWebhook({
+    orders: [order],
+    eventType: 'payment_intent.payment_failed',
+  });
+  const res = mockResponse();
+
+  await stripePaymentWebhook(
+    {
+      headers: { 'stripe-signature': 'sig_test' },
+      body: Buffer.from('{}'),
+    },
+    res
+  );
+
+  assert.ok(res.body.received);
+  assert.equal(getEmailSendCount(), 0);
+  assert.equal(order.paidConfirmationEmailSentAt, null);
+  assert.equal(order.lifecycleEmailLog.length, 0);
 });
 
 test('initiateOrder no longer sends pre-payment customer or vendor emails', () => {

--- a/tests/stripe/order-initiate-connect.test.js
+++ b/tests/stripe/order-initiate-connect.test.js
@@ -181,6 +181,7 @@ function loadInitiateOrder({
       return {
         sendOrderStatusEmail: async () => {},
         sendOrderUpdateEmail: async () => {},
+        sendOrderLifecycleEmail: async () => {},
         sendVendorNewOrderEmail: async () => {},
         sendCustomerOrderPlacedEmail: async () => {},
       };

--- a/tests/vendor/vendor-orders.test.js
+++ b/tests/vendor/vendor-orders.test.js
@@ -68,6 +68,7 @@ function loadOrderController({ orders = [], order = null } = {}) {
       return {
         sendOrderStatusEmail: async () => {},
         sendOrderUpdateEmail: async () => {},
+        sendOrderLifecycleEmail: async () => {},
         sendVendorNewOrderEmail: async () => {},
         sendCustomerOrderPlacedEmail: async () => {},
       };

--- a/utils/orderLifecycleEmailDelivery.js
+++ b/utils/orderLifecycleEmailDelivery.js
@@ -1,0 +1,150 @@
+const crypto = require("crypto");
+
+const truncate = (value, maxLength = 180) => {
+  const text = String(value ?? "").trim();
+  if (!text) return "";
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+};
+
+function buildOrderLifecycleEmailFingerprint(order, event, details = {}) {
+  const payload = {
+    orderId: order?._id ? String(order._id) : null,
+    groupOrderId: order?.groupOrderId || null,
+    event,
+    status: order?.status || null,
+    paymentStatus: order?.paymentStatus || null,
+    trackingId: details.trackingId || order?.trackingInfo?.trackingId || null,
+    trackingUrl: details.trackingUrl || order?.trackingInfo?.trackingUrl || null,
+  };
+
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex");
+}
+
+function hasSentOrderLifecycleEmail(order, fingerprint) {
+  return Array.isArray(order?.lifecycleEmailLog)
+    && order.lifecycleEmailLog.some(
+      (entry) => entry?.fingerprint === fingerprint && entry?.deliveryStatus === "sent"
+    );
+}
+
+async function appendOrderLifecycleEmailLog(order, entry) {
+  if (!order) {
+    return { logged: false, error: "order_missing" };
+  }
+
+  if (!Array.isArray(order.lifecycleEmailLog)) {
+    order.lifecycleEmailLog = [];
+  }
+
+  order.lifecycleEmailLog.push({
+    event: entry.event,
+    fingerprint: entry.fingerprint,
+    orderStatus: order.status,
+    paymentStatus: order.paymentStatus,
+    deliveryStatus: entry.deliveryStatus,
+    recipientRole: entry.recipientRole || "customer",
+    attemptedAt: new Date(),
+    error: entry.error ? truncate(entry.error) : undefined,
+  });
+
+  try {
+    await order.save();
+    return { logged: true };
+  } catch (error) {
+    console.error("Order lifecycle email log failed:", error.message);
+    return { logged: false, error: error.message };
+  }
+}
+
+async function sendCustomerOrderLifecycleEmail({
+  order,
+  event,
+  send,
+  fingerprintDetails = {},
+}) {
+  const fingerprint = buildOrderLifecycleEmailFingerprint(order, event, fingerprintDetails);
+
+  if (hasSentOrderLifecycleEmail(order, fingerprint)) {
+    return {
+      emailSent: false,
+      emailSkipped: true,
+      emailFailed: false,
+      emailDeduped: true,
+      notificationLogged: false,
+      fingerprint,
+    };
+  }
+
+  const customerEmail = order?.userId?.email;
+  if (!customerEmail) {
+    const notificationLog = await appendOrderLifecycleEmailLog(order, {
+      event,
+      fingerprint,
+      deliveryStatus: "skipped",
+      recipientRole: "customer",
+      error: "customer_email_missing",
+    });
+
+    console.warn("Order lifecycle email skipped: customer email missing", {
+      orderId: order?._id ? String(order._id) : null,
+      event,
+    });
+
+    return {
+      emailSent: false,
+      emailSkipped: true,
+      emailFailed: false,
+      emailDeduped: false,
+      notificationLogged: notificationLog.logged,
+      fingerprint,
+    };
+  }
+
+  try {
+    await send(customerEmail);
+    const notificationLog = await appendOrderLifecycleEmailLog(order, {
+      event,
+      fingerprint,
+      deliveryStatus: "sent",
+      recipientRole: "customer",
+    });
+
+    return {
+      emailSent: true,
+      emailSkipped: false,
+      emailFailed: false,
+      emailDeduped: false,
+      notificationLogged: notificationLog.logged,
+      fingerprint,
+    };
+  } catch (error) {
+    const message = error?.message || "Unknown email error";
+    console.error(`Order lifecycle email failed (${event}):`, message);
+    const notificationLog = await appendOrderLifecycleEmailLog(order, {
+      event,
+      fingerprint,
+      deliveryStatus: "failed",
+      recipientRole: "customer",
+      error: message,
+    });
+
+    return {
+      emailSent: false,
+      emailSkipped: false,
+      emailFailed: true,
+      emailDeduped: false,
+      notificationLogged: notificationLog.logged,
+      fingerprint,
+    };
+  }
+}
+
+module.exports = {
+  appendOrderLifecycleEmailLog,
+  buildOrderLifecycleEmailFingerprint,
+  hasSentOrderLifecycleEmail,
+  sendCustomerOrderLifecycleEmail,
+};

--- a/utils/orderPhase.js
+++ b/utils/orderPhase.js
@@ -6,6 +6,14 @@ const APP_NAME = process.env.APP_NAME || "Mosaic Biz Hub";
 const LOGO_URL = getFrontendLogoUrl();
 const ORDERS_URL = buildFrontendUrl("/customer/order");
 
+const escapeHtml = (value = "") =>
+  String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+
 // Configure transporter (swap service/config as needed)
 const transporter = nodemailer.createTransport({
   service: "Gmail",
@@ -286,7 +294,7 @@ async function sendOrderStatusEmail(to, orderId, status) {
   }
 }
 
-async function sendOrderUpdateEmail(to, status, trackingUrl = null) {
+async function sendOrderUpdateEmail(to, status, trackingUrl = null, details = {}) {
   const orderUrl = buildFrontendUrl("/customer/order");
 
   let title = "";
@@ -299,13 +307,14 @@ async function sendOrderUpdateEmail(to, status, trackingUrl = null) {
     message = `
       <p>Good news! Your order has been <strong>shipped</strong> and is on its way.</p>
       <p>You can track your shipment using the link below.</p>
+      ${details.trackingId ? `<p><strong>Tracking ID:</strong> ${escapeHtml(details.trackingId)}</p>` : ""}
     `;
 
     // ✅ Add tracking button if URL exists
     if (trackingUrl) {
       extraButton = `
         <div style="text-align:center; margin:20px 0;">
-          <a href="${trackingUrl}" target="_blank"
+          <a href="${escapeHtml(trackingUrl)}" target="_blank"
             style="
               background:#333;
               color:#ffffff;
@@ -379,4 +388,96 @@ async function sendOrderUpdateEmail(to, status, trackingUrl = null) {
   });
 }
 
-module.exports = { sendOrderStatusEmail,sendOrderUpdateEmail,sendVendorNewOrderEmail,sendCustomerOrderPlacedEmail };
+async function sendOrderLifecycleEmail(to, order, event) {
+  const orderReference = order?.groupOrderId || order?._id?.toString?.() || "your order";
+  const orderUrl = buildFrontendUrl("/customer/order");
+
+  const copyByEvent = {
+    order_cancelled: {
+      title: "Order Cancelled",
+      body: `
+        <p>Your order <strong>#${escapeHtml(orderReference)}</strong> has been <strong>cancelled</strong>.</p>
+        ${
+          order?.paymentStatus === "refunded"
+            ? "<p>If payment was captured, the refund has been initiated and will settle according to your payment provider timeline.</p>"
+            : "<p>No paid confirmation email is sent for unpaid or abandoned orders.</p>"
+        }
+      `,
+      textLines: [
+        `Your order #${orderReference} has been cancelled.`,
+        order?.paymentStatus === "refunded"
+          ? "If payment was captured, the refund has been initiated."
+          : "No paid confirmation email is sent for unpaid or abandoned orders.",
+      ],
+    },
+    return_initiated: {
+      title: "Return Request Received",
+      body: `
+        <p>Your return request for order <strong>#${escapeHtml(orderReference)}</strong> has been received.</p>
+        <p>The vendor will review the request and we will send another update when the return is accepted or resolved.</p>
+      `,
+      textLines: [
+        `Your return request for order #${orderReference} has been received.`,
+        "The vendor will review the request and we will send another update when it is resolved.",
+      ],
+    },
+    order_refunded: {
+      title: "Refund Processed",
+      body: `
+        <p>Your refund for order <strong>#${escapeHtml(orderReference)}</strong> has been processed.</p>
+        <p>Refund timing depends on your bank or card provider.</p>
+      `,
+      textLines: [
+        `Your refund for order #${orderReference} has been processed.`,
+        "Refund timing depends on your bank or card provider.",
+      ],
+    },
+  };
+
+  const copy = copyByEvent[event] || {
+    title: "Order Update",
+    body: `<p>There is an update for order <strong>#${escapeHtml(orderReference)}</strong>.</p>`,
+    textLines: [`There is an update for order #${orderReference}.`],
+  };
+
+  const bodyHtml = `
+    ${copy.body}
+
+    <div style="text-align:center; margin:30px 0;">
+      <a href="${orderUrl}" target="_blank"
+        style="
+          background:#C7A040;
+          color:#ffffff;
+          padding:14px 28px;
+          text-decoration:none;
+          border-radius:6px;
+          font-weight:600;
+          display:inline-block;
+        ">
+        View Your Orders
+      </a>
+    </div>
+  `;
+
+  const html = wrapHtml({ title: copy.title, bodyHtml });
+  const text = plainText({
+    title: copy.title,
+    lines: [...copy.textLines, `View your orders: ${orderUrl}`],
+  });
+
+  await transporter.sendMail({
+    from: `"${APP_NAME}" <${process.env.MAIL_USER}>`,
+    to,
+    subject: `${APP_NAME} - ${copy.title}`,
+    html,
+    text,
+  });
+}
+
+module.exports = {
+  sendOrderStatusEmail,
+  sendOrderUpdateEmail,
+  sendOrderLifecycleEmail,
+  sendVendorNewOrderEmail,
+  sendCustomerOrderPlacedEmail,
+};


### PR DESCRIPTION
﻿## Summary

Refs #182.

Adds customer order lifecycle email handling for paid confirmation audit evidence, status/fulfillment updates, tracking, cancellation, return initiation, and refund completion.

## What changed

- Added `Order.lifecycleEmailLog` audit entries for customer lifecycle email attempts.
- Added a shared order lifecycle email delivery helper with fingerprint-based duplicate prevention for already-sent attempts.
- Kept paid confirmation email webhook-only and guarded by `paidConfirmationEmailSentAt`.
- Added best-effort customer lifecycle emails after successful order state changes for accept, reject, ship, deliver, cancel, return initiated, and refund processed.
- Kept lifecycle email audit details out of order JSON responses.
- Updated backend docs so they no longer claim `initiateOrder` sends pre-payment emails or that cancel/return paths are silent.

## Safety notes

- Does not touch Stripe payment intent creation, checkout creation, Stripe Connect payout logic, subscriptions, webhook raw-body mount order, or `GET /api/featured-products`.
- Email failure is logged and does not roll back order/payment state.
- Failed or abandoned payment events do not send paid confirmation emails.
- No secrets or env values included.

## Validation

- `node --test tests/stripe/order-email-safety.test.js tests/orders/customer-order-safety.test.js tests/orders/order-lifecycle-emails.test.js tests/vendor/vendor-orders.test.js tests/stripe/order-initiate-connect.test.js`
- `npm test` — 468 passing
- `npm run test:contract` — 20 passing
- `git diff --cached --check`

## Not tested

- Live SMTP inbox delivery.
- Real Stripe test-mode checkout/webhook replay against deployed staging/prod.
- Real customer cancellation/refund inbox verification.
- Dispute lifecycle email, because no dispute workflow exists in the current backend.

## Rollback

Revert this PR. Existing order/payment state fields remain compatible; `lifecycleEmailLog` is additive and can be ignored by older code.
