### PR TITLE
[codex] Hide invalid public marketplace categories

### DIFF
--- a/controllers/admin/foodCategoryController.js
+++ b/controllers/admin/foodCategoryController.js
@@ -1,27 +1,40 @@
 const FoodCategory = require('../../models/FoodCategory');
+const {
+  assertValidCategoryName,
+  buildPublicCategoryFilter,
+  filterPublicCategories,
+  getCategoryVisibilityFields,
+} = require('../../utils/categoryVisibility');
 
 
 exports.createFoodCategory = async (req, res) => {
   try {
     const { name, description } = req.body;
+    const normalizedName = assertValidCategoryName(name);
 
-    const existing = await FoodCategory.findOne({ name });
+    const existing = await FoodCategory.findOne({ name: normalizedName });
     if (existing) {
       return res.status(400).json({ success: false, message: 'Category already exists' });
     }
 
-    const category = await FoodCategory.create({ name, description });
+    const category = await FoodCategory.create({
+      name: normalizedName,
+      description,
+      ...getCategoryVisibilityFields(req.body),
+    });
 
     res.status(201).json({ success: true, data: category });
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    res.status(err.statusCode || 500).json({ success: false, message: err.message });
   }
 };
 
 
 exports.getFoodCategories = async (req, res) => {
   try {
-    const categories = await FoodCategory.find().sort({ createdAt: -1 });
+    const categories = filterPublicCategories(
+      await FoodCategory.find(buildPublicCategoryFilter()).sort({ createdAt: -1 }).lean()
+    );
     res.json({ success: true, data: categories });
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
@@ -38,14 +51,17 @@ exports.updateFoodCategory = async (req, res) => {
       return res.status(404).json({ success: false, message: 'Category not found' });
     }
 
-    category.name = name || category.name;
+    if (Object.prototype.hasOwnProperty.call(req.body, 'name')) {
+      category.name = assertValidCategoryName(name);
+    }
     category.description = description || category.description;
+    Object.assign(category, getCategoryVisibilityFields(req.body));
 
     await category.save();
 
     res.json({ success: true, data: category });
   } catch (err) {
-    res.status(500).json({ success: false, message: err.message });
+    res.status(err.statusCode || 500).json({ success: false, message: err.message });
   }
 };
 

--- a/controllers/admin/productCategoryController.js
+++ b/controllers/admin/productCategoryController.js
@@ -2,6 +2,12 @@ const ProductCategory = require('../../models/ProductCategory');
 const ProductSubcategory = require('../../models/ProductSubcategory');
 const deleteCloudinaryFile = require('../../utils/deleteCloudinaryFile');
 const {
+  assertValidCategoryName,
+  buildPublicCategoryFilter,
+  filterPublicCategories,
+  getCategoryVisibilityFields,
+} = require('../../utils/categoryVisibility');
+const {
   ADMIN_AUDIT_ACTIONS,
   ADMIN_AUDIT_TARGET_TYPES,
 } = require('../../utils/audit/actionRegistry');
@@ -14,15 +20,17 @@ const {
 exports.createProductCategory = async (req, res) => {
   try {
     const { name, description, img } = req.body;
+    const normalizedName = assertValidCategoryName(name);
 
-    const existing = await ProductCategory.findOne({ name });
+    const existing = await ProductCategory.findOne({ name: normalizedName });
     if (existing) {
       return res.status(400).json({ success: false, message: 'Category already exists' });
     }
 
     const category = new ProductCategory({
-      name,
+      name: normalizedName,
       description,
+      ...getCategoryVisibilityFields(req.body),
       img, // ✅ Directly saving image URL
     });
 
@@ -37,8 +45,12 @@ exports.createProductCategory = async (req, res) => {
 
     return res.status(201).json({ success: true, data: category });
   } catch (err) {
-    console.error('Create Product Category Error:', err);
-    return res.status(500).json({ success: false, message: err.message });
+    if (err.statusCode && err.statusCode < 500) {
+      console.warn('Create Product Category validation error:', err.message);
+    } else {
+      console.error('Create Product Category Error:', err);
+    }
+    return res.status(err.statusCode || 500).json({ success: false, message: err.message });
   }
 };
 
@@ -53,9 +65,12 @@ exports.updateProductCategory = async (req, res) => {
     }
 
     const beforeName = category.name;
-    category.name = name || category.name;
+    if (Object.prototype.hasOwnProperty.call(req.body, 'name')) {
+      category.name = assertValidCategoryName(name);
+    }
     category.description = description || category.description;
     category.img = img || category.img;
+    Object.assign(category, getCategoryVisibilityFields(req.body));
 
     await category.save();
 
@@ -68,8 +83,12 @@ exports.updateProductCategory = async (req, res) => {
 
     return res.status(200).json({ success: true, data: category });
   } catch (err) {
-    console.error('Update Product Category Error:', err);
-    return res.status(500).json({ success: false, message: err.message });
+    if (err.statusCode && err.statusCode < 500) {
+      console.warn('Update Product Category validation error:', err.message);
+    } else {
+      console.error('Update Product Category Error:', err);
+    }
+    return res.status(err.statusCode || 500).json({ success: false, message: err.message });
   }
 };
 
@@ -109,7 +128,9 @@ exports.deleteProductCategory = async (req, res) => {
 // ✅ Get All Product Categories
 exports.getAllProductCategories = async (req, res) => {
   try {
-    const categories = await ProductCategory.find().sort({ createdAt: 1 });
+    const categories = filterPublicCategories(
+      await ProductCategory.find(buildPublicCategoryFilter()).sort({ createdAt: 1 }).lean()
+    );
     return res.status(200).json({ success: true, data: categories });
   } catch (err) {
     console.error('Fetch Categories Error:', err);

--- a/controllers/admin/serviceCategoryController.js
+++ b/controllers/admin/serviceCategoryController.js
@@ -1,10 +1,18 @@
 const ServiceCategory = require('../../models/ServiceCategory');
 const deleteCloudinaryFile = require('../../utils/deleteCloudinaryFile');
+const {
+  assertValidCategoryName,
+  buildPublicCategoryFilter,
+  filterPublicCategories,
+  getCategoryVisibilityFields,
+} = require('../../utils/categoryVisibility');
 
 
 exports.getServiceCategories = async (req, res) => {
   try {
-    const categories = await ServiceCategory.find().sort({ createdAt: -1 });
+    const categories = filterPublicCategories(
+      await ServiceCategory.find(buildPublicCategoryFilter()).sort({ createdAt: -1 }).lean()
+    );
     res.json({ success: true, categories });
   } catch (err) {
     res.status(500).json({ success: false, message: err.message });
@@ -14,7 +22,13 @@ exports.getServiceCategories = async (req, res) => {
 exports.createServiceCategory = async (req, res) => {
   try {
     const { name, description, img } = req.body;
-    const category = new ServiceCategory({ name, description, img });
+    const normalizedName = assertValidCategoryName(name);
+    const category = new ServiceCategory({
+      name: normalizedName,
+      description,
+      img,
+      ...getCategoryVisibilityFields(req.body),
+    });
     await category.save();
     res.status(201).json({ success: true, category });
   } catch (err) {
@@ -25,10 +39,19 @@ exports.createServiceCategory = async (req, res) => {
 exports.updateServiceCategory = async (req, res) => {
   try {
     const { name, description, img } = req.body;
+    const updates = {
+      description,
+      img,
+      ...getCategoryVisibilityFields(req.body),
+    };
+    if (Object.prototype.hasOwnProperty.call(req.body, 'name')) {
+      updates.name = assertValidCategoryName(name);
+    }
+
     const category = await ServiceCategory.findByIdAndUpdate(
       req.params.id,
-      { name, description, img },
-      { new: true }
+      updates,
+      { new: true, runValidators: true }
     );
     if (!category) return res.status(404).json({ success: false, message: 'Category not found' });
     res.json({ success: true, category });

--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -8,6 +8,12 @@ const CategoryRequest = require('../models/CategoryRequest');
 const Product = require('../models/Product');
 const Service = require('../models/Service');
 const {
+  assertValidCategoryName,
+  buildPublicCategoryFilter,
+  filterPublicCategories,
+  findPublicCategory,
+} = require('../utils/categoryVisibility');
+const {
   ADMIN_AUDIT_ACTIONS,
   ADMIN_AUDIT_TARGET_TYPES,
 } = require('../utils/audit/actionRegistry');
@@ -313,8 +319,8 @@ const createCategoryRequest = async (req, res) => {
       });
     }
 
-    const trimmedCategoryName = String(categoryName).trim();
-    const trimmedSubcategoryName = String(subcategoryName).trim();
+    const trimmedCategoryName = assertValidCategoryName(categoryName);
+    const trimmedSubcategoryName = assertValidCategoryName(subcategoryName);
 
     // Check for existing pending requests
     const existingPendingRequest = await CategoryRequest.findOne({
@@ -368,9 +374,10 @@ const createCategoryRequest = async (req, res) => {
     });
   } catch (error) {
     console.error('Error creating category request:', error);
-    return res.status(500).json({
+    const statusCode = error.statusCode || 500;
+    return res.status(statusCode).json({
       success: false,
-      message: 'Error creating category request',
+      message: statusCode === 400 ? error.message : 'Error creating category request',
       error: error.message,
     });
   }
@@ -486,15 +493,18 @@ const approveCategoryRequest = async (req, res) => {
       });
     }
 
+    const approvedCategoryName = assertValidCategoryName(categoryRequest.categoryName);
+    const approvedSubcategoryName = assertValidCategoryName(categoryRequest.subcategoryName);
+
     let category = await findByNameInsensitive(
       modelConfig.categoryModel,
-      categoryRequest.categoryName
+      approvedCategoryName
     );
 
     if (!category) {
       category = await modelConfig.categoryModel.create(
         buildCreatePayload(modelConfig.categoryModel, {
-          name: categoryRequest.categoryName,
+          name: approvedCategoryName,
           description: categoryRequest.description,
         })
       );
@@ -502,14 +512,14 @@ const approveCategoryRequest = async (req, res) => {
 
     let subcategory = await findByNameInsensitive(
       modelConfig.subcategoryModel,
-      categoryRequest.subcategoryName,
+      approvedSubcategoryName,
       { category: category._id }
     );
 
     if (!subcategory) {
       subcategory = await modelConfig.subcategoryModel.create(
         buildCreatePayload(modelConfig.subcategoryModel, {
-          name: categoryRequest.subcategoryName,
+          name: approvedSubcategoryName,
           description: categoryRequest.description,
           category: category._id,
         })
@@ -554,9 +564,10 @@ const approveCategoryRequest = async (req, res) => {
     });
   } catch (error) {
     console.error('Error approving category request:', error);
-    return res.status(500).json({
+    const statusCode = error.statusCode || 500;
+    return res.status(statusCode).json({
       success: false,
-      message: 'Error approving category request',
+      message: statusCode === 400 ? error.message : 'Error approving category request',
       error: error.message,
     });
   }
@@ -636,18 +647,20 @@ const rejectCategoryRequest = async (req, res) => {
 // Controller to get all categories
 const getAllCategories = async (req, res) => {
   try {
-    
-    const foodCategories = await FoodCategory.find();
-    const productCategories = await ProductCategory.find();
-    const serviceCategories = await ServiceCategory.find();
+    const publicCategoryFilter = buildPublicCategoryFilter();
+    const [foodCategories, productCategories, serviceCategories] = await Promise.all([
+      FoodCategory.find(publicCategoryFilter).lean(),
+      ProductCategory.find(publicCategoryFilter).lean(),
+      ServiceCategory.find(publicCategoryFilter).lean(),
+    ]);
     
 
     return res.status(200).json({
       success: true,
       data: {
-        foodCategories,
-        productCategories,
-        serviceCategories,
+        foodCategories: filterPublicCategories(foodCategories),
+        productCategories: filterPublicCategories(productCategories),
+        serviceCategories: filterPublicCategories(serviceCategories),
       },
     });
   } catch (error) {
@@ -662,7 +675,9 @@ const getAllCategories = async (req, res) => {
 
 const getProductCategories = async (req, res) => {
   try {
-    const productCategories = await ProductCategory.find().lean();
+    const productCategories = filterPublicCategories(
+      await ProductCategory.find(buildPublicCategoryFilter()).lean()
+    );
 
     // Aggregate product counts
     const counts = await Product.aggregate([
@@ -680,7 +695,7 @@ const getProductCategories = async (req, res) => {
     // Convert to map for quick lookup
     const countMap = {};
     counts.forEach(item => {
-      countMap[item._id.toString()] = item.totalProducts;
+      if (item._id) countMap[item._id.toString()] = item.totalProducts;
     });
 
     // Add totalProducts field to each category
@@ -730,7 +745,9 @@ const getProductCategories = async (req, res) => {
 
 const getServiceCategories = async (req, res) => {
   try {
-    const serviceCategories = await ServiceCategory.find().lean();
+    const serviceCategories = filterPublicCategories(
+      await ServiceCategory.find(buildPublicCategoryFilter()).lean()
+    );
 
     // Aggregate service counts
     const counts = await Service.aggregate([
@@ -748,7 +765,7 @@ const getServiceCategories = async (req, res) => {
     // Convert to map
     const countMap = {};
     counts.forEach(item => {
-      countMap[item._id.toString()] = item.totalServices;
+      if (item._id) countMap[item._id.toString()] = item.totalServices;
     });
 
     // Attach totalServices field
@@ -796,7 +813,9 @@ const getServiceCategories = async (req, res) => {
 
 const getFoodCategories = async (req, res) => {
   try {
-    const foodCategories = await FoodCategory.find();
+    const foodCategories = filterPublicCategories(
+      await FoodCategory.find(buildPublicCategoryFilter()).lean()
+    );
     return res.status(200).json({
       success: true,
       data: {
@@ -828,6 +847,14 @@ const getProductSubcategories = async (req, res) => {
       });
     }
 
+    const category = await findPublicCategory(ProductCategory, { id: categoryId });
+    if (!category) {
+      return res.status(404).json({
+        success: false,
+        message: "Category not found.",
+      });
+    }
+
     const subcategories = await ProductSubcategory.find({ category: categoryId }).select(
       "_id name"
     );
@@ -852,12 +879,14 @@ const listSubcategories = async (req, res) => {
 
     let catId = categoryId;
     if (!catId && categorySlug) {
-      const cat = await ProductCategory.findOne(
-        { slug: String(categorySlug) },
-        { _id: 1 }
-      ).lean();
+      const cat = await findPublicCategory(ProductCategory, { slug: categorySlug });
       if (!cat) return res.status(404).json({ error: 'Unknown category slug' });
       catId = String(cat._id);
+    }
+
+    if (catId) {
+      const cat = await findPublicCategory(ProductCategory, { id: catId });
+      if (!cat) return res.status(404).json({ error: 'Unknown category' });
     }
 
     const filter = {};

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -32,6 +32,9 @@ const {
 const {
   publicMarketplaceBusinessFilter,
 } = require('../lib/marketplace/businessEligibility');
+const {
+  findPublicCategory,
+} = require('../utils/categoryVisibility');
 
 const getVisibleBusinessIds = async () => {
   const businesses = await Business.find(
@@ -181,15 +184,15 @@ exports.getAllServices = async (req, res) => {
     }
 
     // Category filtering - accept both slug and ID
-    if (categoryId) {
-      filters.categoryId = categoryId;
-    } else if (categorySlug) {
-      const category = await ServiceCategory.findOne({ slug: categorySlug });
-      if (category) {
-        filters.categoryId = category._id;
-      } else {
-        return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+    if (categoryId || categorySlug) {
+      const category = await findPublicCategory(ServiceCategory, {
+        id: categoryId,
+        slug: categorySlug,
+      });
+      if (!category) {
+        return res.json(emptyListResponse(page));
       }
+      filters.categoryId = category._id;
     }
 
     // Subcategory filtering - accept both slug and ID
@@ -561,12 +564,13 @@ exports.getAllFood = async (req, res) => {
     }
 
     // Category filtering
-    if (categoryId) {
-      filters.categoryId = categoryId;
-    } else if (categorySlug) {
-      const category = await FoodCategory.findOne({ slug: categorySlug });
+    if (categoryId || categorySlug) {
+      const category = await findPublicCategory(FoodCategory, {
+        id: categoryId,
+        slug: categorySlug,
+      });
       if (!category) {
-        return res.json({ success: true, total: 0, page: parseInt(page), totalPages: 0, data: [] });
+        return res.json(emptyListResponse(page));
       }
       filters.categoryId = category._id;
     }
@@ -925,19 +929,27 @@ const ProductSubcategory = require('../models/ProductSubcategory');
 const MinorityType = require('../models/MinorityType');
 
 async function resolveCategoryIdForListingType(listingType, { categoryId, categorySlug }) {
-  if (categoryId) return categoryId;
-  if (!categorySlug) return null;
+  if (!categoryId && !categorySlug) return null;
 
   if (listingType === 'product') {
-    const category = await ProductCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    const category = await findPublicCategory(ProductCategory, {
+      id: categoryId,
+      slug: categorySlug,
+    });
     return category?._id || null;
   }
   if (listingType === 'service') {
-    const category = await ServiceCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    const category = await findPublicCategory(ServiceCategory, {
+      id: categoryId,
+      slug: categorySlug,
+    });
     return category?._id || null;
   }
   if (listingType === 'food') {
-    const category = await FoodCategory.findOne({ slug: categorySlug }).select('_id').lean();
+    const category = await findPublicCategory(FoodCategory, {
+      id: categoryId,
+      slug: categorySlug,
+    });
     return category?._id || null;
   }
   return null;
@@ -1008,12 +1020,13 @@ exports.getAllProducts = async (req, res) => {
     }
 
     // Category filtering - accept both slug and ID
-    if (categoryId) {
-      filters.categoryId = categoryId;
-    } else if (categorySlug) {
-      const category = await ProductCategory.findOne({ slug: categorySlug });
-      if (category) filters.categoryId = category._id;
-      else return res.json(emptyListResponse(page));
+    if (categoryId || categorySlug) {
+      const category = await findPublicCategory(ProductCategory, {
+        id: categoryId,
+        slug: categorySlug,
+      });
+      if (!category) return res.json(emptyListResponse(page));
+      filters.categoryId = category._id;
     }
 
     // Subcategory filtering - accept both slug and ID
@@ -1109,12 +1122,13 @@ exports.getProductsByFilters = async (req, res) => {
     const filters = { isDeleted: false, isPublished: true };
 
     // Category filtering - accept both slug and ID
-    if (categoryId) {
-      filters.categoryId = categoryId;
-    } else if (categorySlug) {
-      const category = await ProductCategory.findOne({ slug: categorySlug });
-      if (category) filters.categoryId = category._id;
-      else return res.json({ success: true, total: 0, data: [] });
+    if (categoryId || categorySlug) {
+      const category = await findPublicCategory(ProductCategory, {
+        id: categoryId,
+        slug: categorySlug,
+      });
+      if (!category) return res.json({ success: true, total: 0, data: [] });
+      filters.categoryId = category._id;
     }
 
     // Subcategory filtering - accept both slug and ID
@@ -1628,33 +1642,39 @@ exports.searchPublicListings = async (req, res) => {
       ...baseBusinessFilter,
     };
 
-    const resolvedCategoryId = await resolveCategoryIdForListingType(parsed.listingType === 'all' ? 'product' : parsed.listingType, parsed)
-      || (parsed.categoryId || null);
-
     if (parsed.categoryId || parsed.categorySlug) {
+      let resolvedAnyCategory = false;
+
       if (shouldIncludeListingType(parsed.listingType, 'product')) {
-        const productCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('product', parsed);
+        const productCategoryId = await resolveCategoryIdForListingType('product', parsed);
         if (productCategoryId) {
           productFilter.categoryId = productCategoryId;
-        } else if (parsed.categorySlug) {
-          return res.json(emptyPayload);
+          resolvedAnyCategory = true;
+        } else {
+          productFilter._id = { $exists: false };
         }
       }
       if (shouldIncludeListingType(parsed.listingType, 'service')) {
-        const serviceCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('service', parsed);
+        const serviceCategoryId = await resolveCategoryIdForListingType('service', parsed);
         if (serviceCategoryId) {
           serviceFilter.categoryId = serviceCategoryId;
-        } else if (parsed.categorySlug) {
-          return res.json(emptyPayload);
+          resolvedAnyCategory = true;
+        } else {
+          serviceFilter._id = { $exists: false };
         }
       }
       if (shouldIncludeListingType(parsed.listingType, 'food')) {
-        const foodCategoryId = parsed.categoryId || await resolveCategoryIdForListingType('food', parsed);
+        const foodCategoryId = await resolveCategoryIdForListingType('food', parsed);
         if (foodCategoryId) {
           foodFilter.categoryId = foodCategoryId;
-        } else if (parsed.categorySlug) {
-          return res.json(emptyPayload);
+          resolvedAnyCategory = true;
+        } else {
+          foodFilter._id = { $exists: false };
         }
+      }
+
+      if (!resolvedAnyCategory) {
+        return res.json(emptyPayload);
       }
     }
 

--- a/controllers/subcategoryController.js
+++ b/controllers/subcategoryController.js
@@ -7,6 +7,9 @@ const FoodCategory = require('../models/FoodCategory');
 const mongoose = require('mongoose');
 const Product = require('../models/Product');
 const Service = require('../models/Service');
+const {
+  findPublicCategory,
+} = require('../utils/categoryVisibility');
 
 // Get Product Subcategories by Category ID or Slug
 
@@ -16,11 +19,16 @@ exports.getProductSubcategories = async (req, res) => {
     let categoryId = categoryIdOrSlug;
 
     if (!mongoose.Types.ObjectId.isValid(categoryIdOrSlug)) {
-      const category = await ProductCategory.findOne({ slug: categoryIdOrSlug });
+      const category = await findPublicCategory(ProductCategory, { slug: categoryIdOrSlug });
       if (!category) {
         return res.status(404).json({ success: false, message: 'Category not found' });
       }
       categoryId = category._id;
+    } else {
+      const category = await findPublicCategory(ProductCategory, { id: categoryIdOrSlug });
+      if (!category) {
+        return res.status(404).json({ success: false, message: 'Category not found' });
+      }
     }
 
     const subcategories = await ProductSubcategory.find({ category: categoryId })
@@ -99,11 +107,16 @@ exports.getServiceSubcategories = async (req, res) => {
     let categoryId = categoryIdOrSlug;
 
     if (!mongoose.Types.ObjectId.isValid(categoryIdOrSlug)) {
-      const category = await ServiceCategory.findOne({ slug: categoryIdOrSlug });
+      const category = await findPublicCategory(ServiceCategory, { slug: categoryIdOrSlug });
       if (!category) {
         return res.status(404).json({ success: false, message: 'Category not found' });
       }
       categoryId = category._id;
+    } else {
+      const category = await findPublicCategory(ServiceCategory, { id: categoryIdOrSlug });
+      if (!category) {
+        return res.status(404).json({ success: false, message: 'Category not found' });
+      }
     }
 
     const subcategories = await ServiceSubcategory.find({ category: categoryId })
@@ -180,11 +193,16 @@ exports.getFoodSubcategories = async (req, res) => {
 
     // Check if it's a slug (not a valid ObjectId)
     if (!mongoose.Types.ObjectId.isValid(categoryIdOrSlug)) {
-      const category = await FoodCategory.findOne({ slug: categoryIdOrSlug });
+      const category = await findPublicCategory(FoodCategory, { slug: categoryIdOrSlug });
       if (!category) {
         return res.status(404).json({ success: false, message: 'Category not found' });
       }
       categoryId = category._id;
+    } else {
+      const category = await findPublicCategory(FoodCategory, { id: categoryIdOrSlug });
+      if (!category) {
+        return res.status(404).json({ success: false, message: 'Category not found' });
+      }
     }
 
     const subcategories = await FoodSubcategory.find({ category: categoryId })

--- a/models/FoodCategory.js
+++ b/models/FoodCategory.js
@@ -1,5 +1,9 @@
 const mongoose = require('mongoose');
 const slugify = require('slugify');
+const {
+  normalizeCategoryName,
+  getInvalidCategoryNameReason,
+} = require('../utils/categoryVisibility');
 
 const foodCategorySchema = new mongoose.Schema(
   {
@@ -8,6 +12,18 @@ const foodCategorySchema = new mongoose.Schema(
       required: true,
       unique: true,
       trim: true,
+      set: normalizeCategoryName,
+      validate: {
+        validator(value) {
+          if (!this.isNew && typeof this.isModified === 'function' && !this.isModified('name')) {
+            return true;
+          }
+          return !getInvalidCategoryNameReason(value);
+        },
+        message(props) {
+          return getInvalidCategoryNameReason(props.value) || 'Invalid category name';
+        },
+      },
     },
     slug: {
       type: String,
@@ -17,6 +33,43 @@ const foodCategorySchema = new mongoose.Schema(
     description: {
       type: String,
       trim: true,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isDeleted: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isPublic: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isPublished: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    hidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isHidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    status: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: 'active',
+      index: true,
     },
   },
   { timestamps: true }

--- a/models/ProductCategory.js
+++ b/models/ProductCategory.js
@@ -1,5 +1,9 @@
 const mongoose = require('mongoose');
 const slugify = require('slugify');
+const {
+  normalizeCategoryName,
+  getInvalidCategoryNameReason,
+} = require('../utils/categoryVisibility');
 
 const productCategorySchema = new mongoose.Schema(
   {
@@ -8,6 +12,18 @@ const productCategorySchema = new mongoose.Schema(
       required: true,
       unique: true,
       trim: true,
+      set: normalizeCategoryName,
+      validate: {
+        validator(value) {
+          if (!this.isNew && typeof this.isModified === 'function' && !this.isModified('name')) {
+            return true;
+          }
+          return !getInvalidCategoryNameReason(value);
+        },
+        message(props) {
+          return getInvalidCategoryNameReason(props.value) || 'Invalid category name';
+        },
+      },
     },
     slug: {
       type: String,
@@ -21,6 +37,43 @@ const productCategorySchema = new mongoose.Schema(
     img: {
       type: String, // S3 URL
       trim: true,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isDeleted: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isPublic: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isPublished: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    hidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isHidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    status: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: 'active',
+      index: true,
     },
   },
   { timestamps: true }

--- a/models/ServiceCategory.js
+++ b/models/ServiceCategory.js
@@ -1,5 +1,9 @@
 const mongoose = require('mongoose');
 const slugify = require('slugify');
+const {
+  normalizeCategoryName,
+  getInvalidCategoryNameReason,
+} = require('../utils/categoryVisibility');
 
 const serviceCategorySchema = new mongoose.Schema(
   {
@@ -8,6 +12,18 @@ const serviceCategorySchema = new mongoose.Schema(
       required: true,
       unique: true,
       trim: true,
+      set: normalizeCategoryName,
+      validate: {
+        validator(value) {
+          if (!this.isNew && typeof this.isModified === 'function' && !this.isModified('name')) {
+            return true;
+          }
+          return !getInvalidCategoryNameReason(value);
+        },
+        message(props) {
+          return getInvalidCategoryNameReason(props.value) || 'Invalid category name';
+        },
+      },
     },
     slug: {
       type: String,
@@ -21,6 +37,43 @@ const serviceCategorySchema = new mongoose.Schema(
     img: {
       type: String, // S3 URL for category image
       trim: true,
+    },
+    isActive: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isDeleted: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isPublic: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    isPublished: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    hidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    isHidden: {
+      type: Boolean,
+      default: false,
+      index: true,
+    },
+    status: {
+      type: String,
+      trim: true,
+      lowercase: true,
+      default: 'active',
+      index: true,
     },
   },
   { timestamps: true }

--- a/tests/integration/public-category-visibility.integration.test.js
+++ b/tests/integration/public-category-visibility.integration.test.js
@@ -1,0 +1,141 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  createAdminDirect,
+  login,
+} = require('./helpers/factories');
+const ProductCategory = require('../../models/ProductCategory');
+const ServiceCategory = require('../../models/ServiceCategory');
+const FoodCategory = require('../../models/FoodCategory');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('public category endpoints hide legacy invalid and hidden categories', async () => {
+  const agent = createAgent(getApp());
+
+  await ProductCategory.create({ name: 'Electronics' });
+  await ServiceCategory.create({ name: 'Home Cleaning' });
+  await FoodCategory.create({ name: 'Food & Grocery' });
+  await ProductCategory.create({ name: 'Office Supplies', hidden: true });
+  await ServiceCategory.create({ name: 'Window Washing', isActive: false });
+  await FoodCategory.create({ name: 'Prepared Meals', status: 'hidden' });
+
+  await ProductCategory.collection.insertMany([
+    { name: 'gcgjgjgg', slug: 'gcgjgjgg' },
+    { name: 'vvvvv', slug: 'vvvvv' },
+    { name: 'v v v v', slug: 'v-v-v-v' },
+  ]);
+  await ServiceCategory.collection.insertOne({ name: 'gcgjgjgg', slug: 'gcgjgjgg' });
+  await FoodCategory.collection.insertOne({ name: 'vvvvv', slug: 'vvvvv' });
+
+  const all = await agent.get('/api/categories');
+  assert.equal(all.status, 200);
+  assertNames(all.body.data.productCategories, {
+    includes: ['Electronics'],
+    excludes: ['gcgjgjgg', 'vvvvv', 'v v v v', 'Office Supplies'],
+  });
+  assertNames(all.body.data.serviceCategories, {
+    includes: ['Home Cleaning'],
+    excludes: ['gcgjgjgg', 'Window Washing'],
+  });
+  assertNames(all.body.data.foodCategories, {
+    includes: ['Food & Grocery'],
+    excludes: ['vvvvv', 'Prepared Meals'],
+  });
+
+  const products = await agent.get('/api/categories/products');
+  assert.equal(products.status, 200);
+  assertNames(products.body.data.productCategories, {
+    includes: ['Electronics'],
+    excludes: ['gcgjgjgg', 'vvvvv', 'v v v v', 'Office Supplies'],
+  });
+
+  const services = await agent.get('/api/categories/services');
+  assert.equal(services.status, 200);
+  assertNames(services.body.data.serviceCategories, {
+    includes: ['Home Cleaning'],
+    excludes: ['gcgjgjgg', 'Window Washing'],
+  });
+
+  const foods = await agent.get('/api/categories/foods');
+  assert.equal(foods.status, 200);
+  assertNames(foods.body.data.foodCategories, {
+    includes: ['Food & Grocery'],
+    excludes: ['vvvvv', 'Prepared Meals'],
+  });
+
+  const legacyProducts = await agent.get('/api/admin/category/product');
+  assert.equal(legacyProducts.status, 200);
+  assertNames(legacyProducts.body.data, {
+    includes: ['Electronics'],
+    excludes: ['gcgjgjgg', 'vvvvv', 'v v v v', 'Office Supplies'],
+  });
+
+  const legacyServices = await agent.get('/api/admin/category/service');
+  assert.equal(legacyServices.status, 200);
+  assertNames(legacyServices.body.categories, {
+    includes: ['Home Cleaning'],
+    excludes: ['gcgjgjgg', 'Window Washing'],
+  });
+
+  const legacyFoods = await agent.get('/api/admin/category/food');
+  assert.equal(legacyFoods.status, 200);
+  assertNames(legacyFoods.body.data, {
+    includes: ['Food & Grocery'],
+    excludes: ['vvvvv', 'Prepared Meals'],
+  });
+});
+
+test('admin category creation rejects obvious test names', async () => {
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const product = await adminAgent
+    .post('/api/admin/category/product')
+    .send({ name: 'gcgjgjgg' });
+  assert.equal(product.status, 400);
+  assert.match(product.body.message, /test data|reserved/i);
+
+  const service = await adminAgent
+    .post('/api/admin/category/service')
+    .send({ name: 'vvvvv' });
+  assert.equal(service.status, 400);
+  assert.match(service.body.message, /placeholder|test data|reserved/i);
+
+  const food = await adminAgent
+    .post('/api/admin/category/food')
+    .send({ name: 'v v v v' });
+  assert.equal(food.status, 400);
+  assert.match(food.body.message, /placeholder|test data|reserved/i);
+});
+
+function assertNames(categories, { includes = [], excludes = [] }) {
+  assert.ok(Array.isArray(categories));
+  const names = categories.map((category) => category.name);
+
+  for (const expected of includes) {
+    assert.ok(names.includes(expected), `${expected} should be public`);
+  }
+
+  for (const blocked of excludes) {
+    assert.equal(names.includes(blocked), false, `${blocked} should be hidden`);
+  }
+}

--- a/tests/marketplace/category-visibility.test.js
+++ b/tests/marketplace/category-visibility.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildPublicCategoryFilter,
+  filterPublicCategories,
+  getInvalidCategoryNameReason,
+  isValidCategoryName,
+} = require('../../utils/categoryVisibility');
+
+test('known broken public category names are invalid', () => {
+  for (const name of ['gcgjgjgg', 'vvvvv', 'v v v v']) {
+    assert.equal(isValidCategoryName(name), false);
+    assert.ok(getInvalidCategoryNameReason(name));
+  }
+});
+
+test('legitimate marketplace category names remain valid', () => {
+  for (const name of ['Electronics', 'Home Cleaning', 'Food & Grocery', 'HVAC', 'BBQ']) {
+    assert.equal(isValidCategoryName(name), true, `${name} should be valid`);
+  }
+});
+
+test('public category filter excludes hidden and disabled status fields', () => {
+  const filter = buildPublicCategoryFilter({ slug: 'electronics' });
+
+  assert.deepEqual(filter.isActive, { $ne: false });
+  assert.deepEqual(filter.isDeleted, { $ne: true });
+  assert.deepEqual(filter.isPublic, { $ne: false });
+  assert.deepEqual(filter.isPublished, { $ne: false });
+  assert.deepEqual(filter.hidden, { $ne: true });
+  assert.deepEqual(filter.isHidden, { $ne: true });
+  assert.ok(filter.status.$nin.includes('hidden'));
+  assert.equal(filter.slug, 'electronics');
+});
+
+test('filterPublicCategories removes invalid and hidden records only', () => {
+  const categories = filterPublicCategories([
+    { name: 'Electronics', slug: 'electronics' },
+    { name: 'gcgjgjgg', slug: 'gcgjgjgg' },
+    { name: 'vvvvv', slug: 'vvvvv' },
+    { name: 'Home Cleaning', slug: 'home-cleaning', hidden: true },
+    { name: 'Food & Grocery', slug: 'food-grocery', status: 'hidden' },
+    { name: 'HVAC', slug: 'hvac', isActive: true },
+  ]);
+
+  assert.deepEqual(categories.map((category) => category.name), [
+    'Electronics',
+    'HVAC',
+  ]);
+});

--- a/utils/categoryVisibility.js
+++ b/utils/categoryVisibility.js
@@ -1,0 +1,185 @@
+const mongoose = require('mongoose');
+
+const KNOWN_INVALID_PUBLIC_CATEGORY_NAMES = new Set([
+  'gcgjgjgg',
+  'vvvvv',
+  'v v v v',
+]);
+
+const PUBLIC_CATEGORY_STATUS_DENYLIST = [
+  'inactive',
+  'hidden',
+  'deleted',
+  'draft',
+  'rejected',
+  'archived',
+  'disabled',
+  'test',
+];
+
+const VISIBILITY_BOOLEAN_FIELDS = [
+  'isActive',
+  'isDeleted',
+  'isPublic',
+  'isPublished',
+  'hidden',
+  'isHidden',
+];
+
+const normalizeCategoryName = (value = '') =>
+  String(value).replace(/\s+/g, ' ').trim();
+
+const compactCategoryName = (value = '') =>
+  normalizeCategoryName(value).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const getInvalidCategoryNameReason = (value) => {
+  const normalized = normalizeCategoryName(value);
+  const compact = compactCategoryName(normalized);
+  const lettersOnly = compact.replace(/[^a-z]/g, '');
+
+  if (!normalized) return 'Category name is required';
+  if (normalized.length < 2) return 'Category name must be at least 2 characters';
+  if (normalized.length > 80) return 'Category name must be 80 characters or fewer';
+  if (!/[a-z]/i.test(normalized)) return 'Category name must include letters';
+  if (
+    KNOWN_INVALID_PUBLIC_CATEGORY_NAMES.has(normalized.toLowerCase()) ||
+    KNOWN_INVALID_PUBLIC_CATEGORY_NAMES.has(compact)
+  ) {
+    return 'Category name is reserved for test data';
+  }
+
+  if (compact.length >= 3 && /^([a-z0-9])\1+$/.test(compact)) {
+    return 'Category name cannot be repeated placeholder characters';
+  }
+
+  const uniqueLetters = new Set(lettersOnly).size;
+  if (
+    lettersOnly.length >= 6 &&
+    !/[aeiou]/.test(lettersOnly) &&
+    uniqueLetters <= 3
+  ) {
+    return 'Category name appears to be test data';
+  }
+
+  return null;
+};
+
+const isValidCategoryName = (value) => !getInvalidCategoryNameReason(value);
+
+const assertValidCategoryName = (value) => {
+  const normalized = normalizeCategoryName(value);
+  const reason = getInvalidCategoryNameReason(normalized);
+
+  if (reason) {
+    const error = new Error(reason);
+    error.statusCode = 400;
+    throw error;
+  }
+
+  return normalized;
+};
+
+const buildPublicCategoryFilter = (extraFilter = {}) => ({
+  isActive: { $ne: false },
+  isDeleted: { $ne: true },
+  isPublic: { $ne: false },
+  isPublished: { $ne: false },
+  hidden: { $ne: true },
+  isHidden: { $ne: true },
+  status: { $nin: PUBLIC_CATEGORY_STATUS_DENYLIST },
+  ...extraFilter,
+});
+
+const isPublicCategory = (category) => {
+  if (!category) return false;
+  if (category.isActive === false) return false;
+  if (category.isDeleted === true) return false;
+  if (category.isPublic === false) return false;
+  if (category.isPublished === false) return false;
+  if (category.hidden === true || category.isHidden === true) return false;
+
+  const status = normalizeCategoryName(category.status).toLowerCase();
+  if (status && PUBLIC_CATEGORY_STATUS_DENYLIST.includes(status)) return false;
+
+  return isValidCategoryName(category.name);
+};
+
+const filterPublicCategories = (categories = []) =>
+  categories.filter(isPublicCategory);
+
+const parseOptionalBoolean = (value) => {
+  if (value === true || value === false) return value;
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes'].includes(normalized)) return true;
+  if (['false', '0', 'no'].includes(normalized)) return false;
+
+  return undefined;
+};
+
+const getCategoryVisibilityFields = (input = {}) => {
+  const updates = {};
+
+  for (const field of VISIBILITY_BOOLEAN_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(input, field)) {
+      const parsed = parseOptionalBoolean(input[field]);
+      if (parsed !== undefined) updates[field] = parsed;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'status')) {
+    const status = normalizeCategoryName(input.status).toLowerCase();
+    if (status) updates.status = status;
+  }
+
+  return updates;
+};
+
+const findPublicCategory = async (Model, { id, slug }, projection = {}) => {
+  const categoryFilter = {};
+
+  if (id) {
+    if (!mongoose.Types.ObjectId.isValid(String(id))) return null;
+    categoryFilter._id = id;
+  } else if (slug) {
+    categoryFilter.slug = normalizeCategoryName(slug).toLowerCase();
+  } else {
+    return null;
+  }
+
+  const query = Model.findOne(buildPublicCategoryFilter(categoryFilter), {
+    _id: 1,
+    name: 1,
+    slug: 1,
+    status: 1,
+    isActive: 1,
+    isDeleted: 1,
+    isPublic: 1,
+    isPublished: 1,
+    hidden: 1,
+    isHidden: 1,
+    ...projection,
+  });
+
+  const category = query && typeof query.lean === 'function'
+    ? await query.lean()
+    : await query;
+
+  return isPublicCategory(category) ? category : null;
+};
+
+module.exports = {
+  KNOWN_INVALID_PUBLIC_CATEGORY_NAMES,
+  PUBLIC_CATEGORY_STATUS_DENYLIST,
+  normalizeCategoryName,
+  compactCategoryName,
+  getInvalidCategoryNameReason,
+  isValidCategoryName,
+  assertValidCategoryName,
+  buildPublicCategoryFilter,
+  isPublicCategory,
+  filterPublicCategories,
+  getCategoryVisibilityFields,
+  findPublicCategory,
+};


### PR DESCRIPTION
## Summary
- adds shared public category visibility validation/filtering
- hides legacy invalid/test category names from public category and marketplace category-filtered responses
- adds category visibility fields to category schemas and blocks obvious placeholder names on create/update/approval paths

## Validation
- node --test tests/marketplace/category-visibility.test.js: passed
- node --test tests/integration/public-category-visibility.integration.test.js: passed
- npm test: passed
- npm run test:contract: passed
- npm run test:integration: passed

## Notes
No deploy performed. No env files or secrets included. Stripe/payment/webhook logic was not touched.
