### PR TITLE
Release backend staging to main

### DIFF
--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -134,6 +134,7 @@ const appendVerificationNotificationLog = async (application, {
     applicationStatus: application.status,
     deliveryStatus: getDeliveryStatus(emailDelivery),
     labels: (emailDelivery?.results || []).map((result) => result.label).filter(Boolean),
+    messageIds: (emailDelivery?.results || []).map((result) => result.messageId).filter(Boolean),
     reasonSummary: normalizeGuidanceList(reasons).join('; '),
     documentsNeeded: normalizeGuidanceList(documentsNeeded),
     fieldsNeeded: normalizeGuidanceList(fieldsNeeded),

--- a/docs/VENDOR_EMAIL_LIFECYCLE_MATRIX.md
+++ b/docs/VENDOR_EMAIL_LIFECYCLE_MATRIX.md
@@ -1,0 +1,75 @@
+# Vendor Email Lifecycle Matrix
+
+Audit date: 2026-07-02
+
+## Resend Integration Status
+
+The backend does not use the Resend SDK or `RESEND_*` environment variables. Active transactional email uses Nodemailer through the shared SMTP configuration in `utils/smtpTransport.js`. In production, Resend is supported through provider-neutral SMTP configuration:
+
+- `MAIL_HOST`
+- `MAIL_PORT`
+- `MAIL_SECURE`
+- `MAIL_USER`
+- `MAIL_PASSWORD`
+- `MAIL_FROM`
+
+For Resend SMTP, `MAIL_FROM` is required because `MAIL_USER` is commonly the SMTP login identity, not a verified sender address. Vendor onboarding email delivery now treats Resend SMTP as not configured when `MAIL_FROM` is missing, and logs missing environment variable names only.
+
+## Lifecycle Matrix
+
+| Email Type | Trigger Event | Recipient | Source File/Function | Resend Template/Subject | Status | Test Coverage |
+| --- | --- | --- | --- | --- | --- | --- |
+| business_owner welcome email | OTP verification succeeds after business owner registration | `User.email` | `controllers/userController.js` -> `utils/mailer.sendWelcomeEmail` | `Welcome to Mosaic Biz Hub - Grow your business and build generational wealth` | Working through shared SMTP/Resend-SMTP config; sent after verification, not before OTP verification | `tests/email/auth-mailer-smtp.test.js` |
+| vendor application received email | `POST /api/vendor-onboarding/submit` transitions draft/rejected/payment_pending to submitted | authenticated vendor `User.email` | `controllers/vendorOnboarding.controller.js` -> `sendVendorSubmissionConfirmationEmail` | `Your Mosaic Biz Hub Application Is Under Review` | Working; non-blocking; idempotent resubmit does not resend | `tests/vendor/vendor-onboarding-submit-email.test.js`, `tests/email/vendor-verification-guidance-mail.test.js` |
+| admin new vendor application notification | `POST /api/vendor-onboarding/submit` succeeds | `ADMIN_EMAIL` | `controllers/vendorOnboarding.controller.js` -> `sendAdminOnboardingSubmissionEmail` | `New Vendor Application Submitted - Review Required` | Working when `ADMIN_EMAIL` is configured; admin failure does not block vendor confirmation job | `tests/vendor/vendor-onboarding-submit-email.test.js` |
+| vendor application approved email | Admin finalizes a submitted application and required docs are verified | populated `application.userId.email` | `controllers/admin/vendorOnboardVerifyStage1.js` -> `sendVendorApprovedEmail` | `Your Business Has Been Successfully Verified` | Working; non-blocking; finalize route only runs from submitted status | `tests/admin/vendor-onboarding-finalize.test.js` |
+| vendor trust badge assigned email | Admin approval assigns a badge | populated `application.userId.email` | `controllers/admin/vendorOnboardVerifyStage1.js` -> `sendVendorTrustBadgeAssignedEmail` | `Your Trust Badge Has Been Verified and Activated` | Working when a badge is assigned; non-blocking | `tests/admin/vendor-onboarding-finalize.test.js` |
+| vendor application rejected / missing documents email | Admin finalizes submitted application with missing required docs | populated `application.userId.email` | `controllers/admin/vendorOnboardVerifyStage1.js` -> `sendVendorRejectionEmail` -> `sendVendorVerificationGuidanceEmail` | `Action Required: Vendor Application Documents Needed` | Working; writes `verificationNotificationLog` including delivery status and provider message ids when available | `tests/admin/vendor-onboarding-finalize.test.js`, `tests/email/vendor-verification-guidance-mail.test.js` |
+| vendor missing documents / failing verification guidance | Admin calls `POST /api/vendor-onboarding/:applicationId/verification-guidance` | populated `application.userId.email` | `controllers/admin/vendorOnboardVerifyStage1.js` -> `sendVendorVerificationGuidanceEmail` | Outcome-specific guidance subject | Working; duplicate outcome/reason/doc/field payloads are deduped by fingerprint | `tests/admin/vendor-onboarding-finalize.test.js`, `tests/email/vendor-verification-guidance-mail.test.js` |
+| admin vendor profile completed notification | Vendor completes business profile plus required docs | `ADMIN_EMAIL` | `controllers/vendorOnboarding.controller.js` -> `sendAdminVendorProfileCompletedEmail` | `Vendor Profile Completed - Documentation Ready for Trust Badge Verification` | Working; deduped with `profileCompletionNotifiedAt`; no dedicated unit test yet | Needs follow-up test |
+| vendor verification fee/payment receipt | Stripe vendor verification payment succeeds | Vendor/business owner | `controllers/vendorOnboarding.controller.js` webhook only updates `verificationPayment` | Not implemented | Future/needs decision; Stripe webhook logic intentionally not changed in this audit | Not covered |
+| vendor tier/subscription confirmation | Subscription invoice/payment succeeds | Vendor/business owner | `controllers/webhookController.handleSubscriptionWebhook` updates subscription status | Not implemented | Future/needs decision; subscription webhook logic intentionally not changed in this audit | Not covered |
+| Stripe Connect onboarding started/reminder/status | Connect account link created or status polled | Vendor/business owner | `controllers/connectController.js` | Not implemented | Future/needs decision; Connect routes return UI state only | Not covered |
+| vendor listing published/approved | Listing created/published | Vendor/business owner | Product/service/food controllers | Not implemented as email | Future/needs decision | Not covered |
+
+## Required Environment Variable Names
+
+Vendor lifecycle email delivery requires:
+
+- `MAIL_USER`
+- `MAIL_PASSWORD`
+- `MAIL_FROM` when using Resend SMTP
+
+Recommended for Resend SMTP:
+
+- `MAIL_HOST`
+- `MAIL_PORT`
+- `MAIL_SECURE`
+
+Additional notification/link names:
+
+- `ADMIN_EMAIL`
+- `SUPPORT_EMAIL`
+- `FRONTEND_URL`
+- `APP_URL`
+- `CANONICAL_FRONTEND_URL`
+- `PUBLIC_FRONTEND_URL`
+
+Legacy or unused in active code:
+
+- `RESEND_API_KEY`
+- `RESEND_FROM_EMAIL`
+- `RESEND_FROM_NAME`
+
+## Production-Safe Smoke Plan
+
+1. Configure only names above in the production environment; do not record values.
+2. Create a new business owner test account and verify OTP.
+3. Confirm the business-owner welcome email is accepted by the SMTP/Resend provider.
+4. Save a complete vendor onboarding draft and complete the verification payment in Stripe test mode where available.
+5. Submit the vendor application with `POST /api/vendor-onboarding/submit`.
+6. Confirm vendor application received email and admin new application email.
+7. Approve one submitted application as admin and confirm vendor approval/trust badge email.
+8. Use a separate submitted test application with missing docs, finalize/reject, and confirm missing-documents email.
+9. Use `POST /api/vendor-onboarding/:applicationId/verification-guidance` with a unique reason and confirm guidance email plus dedupe on retry.
+10. Capture user id, application id, delivery status, and provider message id/log status only. Do not capture secrets, OTPs, cookies, document URLs, or full message bodies.

--- a/models/VendorOnboardingStage1.js
+++ b/models/VendorOnboardingStage1.js
@@ -175,6 +175,7 @@ const VendorOnboardingStage1Schema = new mongoose.Schema(
           enum: ["sent", "skipped", "failed"],
         },
         labels: [String],
+        messageIds: [String],
         reasonSummary: String,
         documentsNeeded: [String],
         fieldsNeeded: [String],

--- a/tests/admin/vendor-onboarding-finalize.test.js
+++ b/tests/admin/vendor-onboarding-finalize.test.js
@@ -77,16 +77,20 @@ function loadController({ application, mailerCalls = {}, emailConfigured = true,
   const mailerMock = {
     sendVendorApprovedEmail: mailerOverrides.sendVendorApprovedEmail || (async (payload) => {
       mailerCalls.approved = payload;
+      return { messageId: 'vendor-approved-message' };
     }),
     sendVendorRejectionEmail: mailerOverrides.sendVendorRejectionEmail || (async (payload) => {
       mailerCalls.rejection = payload;
+      return { messageId: 'vendor-rejection-message' };
     }),
     sendVendorTrustBadgeAssignedEmail: mailerOverrides.sendVendorTrustBadgeAssignedEmail || (async (payload) => {
       mailerCalls.badge = payload;
+      return { messageId: 'vendor-badge-message' };
     }),
     sendVendorVerificationGuidanceEmail: mailerOverrides.sendVendorVerificationGuidanceEmail || (async (payload) => {
       mailerCalls.guidance = mailerCalls.guidance || [];
       mailerCalls.guidance.push(payload);
+      return { messageId: `vendor-guidance-message-${mailerCalls.guidance.length}` };
     }),
   };
 
@@ -171,6 +175,7 @@ test('finalizeVerification rejects when required docs missing', async () => {
   assert.equal(application.verificationNotificationLog.length, 1);
   assert.equal(application.verificationNotificationLog[0].event, 'missing_documents');
   assert.equal(application.verificationNotificationLog[0].deliveryStatus, 'sent');
+  assert.deepEqual(application.verificationNotificationLog[0].messageIds, ['vendor-rejection-message']);
   assert.deepEqual(application.verificationNotificationLog[0].documentsNeeded, ['EIN document']);
   assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
 });
@@ -271,6 +276,7 @@ test('sendVerificationGuidanceNotification sends failed-validation email and log
   assert.equal(application.verificationNotificationLog.length, 1);
   assert.equal(application.verificationNotificationLog[0].event, 'failed_validation');
   assert.equal(application.verificationNotificationLog[0].deliveryStatus, 'sent');
+  assert.deepEqual(application.verificationNotificationLog[0].messageIds, ['vendor-guidance-message-1']);
 });
 
 test('sendVerificationGuidanceNotification supports discrepancy, under-review, and manual-review outcomes', async () => {

--- a/tests/email/vendor-verification-guidance-mail.test.js
+++ b/tests/email/vendor-verification-guidance-mail.test.js
@@ -12,6 +12,7 @@ function loadMailerWithMocks(sendMailCalls, createdConfigs = []) {
       return {
         sendMail: async (message) => {
           sendMailCalls.push(message);
+          return { messageId: `message-${sendMailCalls.length}` };
         },
       };
     },
@@ -48,7 +49,7 @@ test('vendor verification guidance email escapes vendor-visible admin notes', as
   const sendMailCalls = [];
   const mailer = loadMailerWithMocks(sendMailCalls);
 
-  await mailer.sendVendorVerificationGuidanceEmail({
+  const info = await mailer.sendVendorVerificationGuidanceEmail({
     to: 'vendor@example.com',
     vendorName: 'Vendor <User>',
     businessName: 'Test & Co',
@@ -65,6 +66,7 @@ test('vendor verification guidance email escapes vendor-visible admin notes', as
   process.env.SUPPORT_EMAIL = originalSupportEmail;
 
   assert.equal(sendMailCalls.length, 1);
+  assert.equal(info.messageId, 'message-1');
   const message = sendMailCalls[0];
   assert.equal(message.subject, 'Action Required: Vendor Verification Correction Needed');
   assert.ok(message.html.includes('Current status:</strong> submitted'));
@@ -86,7 +88,7 @@ test('vendor rejection email uses missing-document guidance copy', async () => {
   const sendMailCalls = [];
   const mailer = loadMailerWithMocks(sendMailCalls);
 
-  await mailer.sendVendorRejectionEmail({
+  const info = await mailer.sendVendorRejectionEmail({
     to: 'vendor@example.com',
     vendorName: 'Vendor User',
     businessName: 'Missing Docs LLC',
@@ -98,6 +100,7 @@ test('vendor rejection email uses missing-document guidance copy', async () => {
   process.env.MAIL_USER = originalMailUser;
 
   assert.equal(sendMailCalls.length, 1);
+  assert.equal(info.messageId, 'message-1');
   const message = sendMailCalls[0];
   assert.equal(message.subject, 'Action Required: Vendor Application Documents Needed');
   assert.ok(message.html.includes('Missing Docs LLC'));
@@ -128,11 +131,12 @@ test('vendor onboarding mailer uses provider-neutral SMTP config and MAIL_FROM',
   const mailer = loadMailerWithMocks(sendMailCalls, createdConfigs);
 
   try {
-    await mailer.sendVendorSubmissionConfirmationEmail({
+    const info = await mailer.sendVendorSubmissionConfirmationEmail({
       to: 'vendor@example.com',
       vendorName: 'Vendor User',
       applicationId: 'MBH-APP-SMTP-001',
     });
+    assert.equal(info.messageId, 'message-1');
   } finally {
     Object.entries(savedEnv).forEach(([key, value]) => {
       if (value === undefined) {

--- a/tests/utils/vendor-onboarding-email-delivery.test.js
+++ b/tests/utils/vendor-onboarding-email-delivery.test.js
@@ -3,28 +3,45 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  getVendorEmailConfigStatus,
+  getVendorEmailProvider,
   isVendorEmailConfigured,
   deliverVendorOnboardingEmail,
   deliverVendorOnboardingEmails,
+  normalizeProviderMessageId,
 } = require('../../utils/vendorOnboardingEmailDelivery');
 
-const originalMailUser = process.env.MAIL_USER;
-const originalMailPassword = process.env.MAIL_PASSWORD;
+const MAIL_ENV_KEYS = [
+  'MAIL_HOST',
+  'MAIL_PORT',
+  'MAIL_SECURE',
+  'MAIL_USER',
+  'MAIL_PASSWORD',
+  'MAIL_FROM',
+];
 
-function restoreMailEnv() {
-  if (originalMailUser === undefined) {
-    delete process.env.MAIL_USER;
-  } else {
-    process.env.MAIL_USER = originalMailUser;
+const originalMailEnv = Object.fromEntries(
+  MAIL_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
+function restoreMailEnv(saved = originalMailEnv) {
+  for (const key of MAIL_ENV_KEYS) {
+    if (saved[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved[key];
+    }
   }
-  if (originalMailPassword === undefined) {
-    delete process.env.MAIL_PASSWORD;
-  } else {
-    process.env.MAIL_PASSWORD = originalMailPassword;
+}
+
+function clearMailEnv() {
+  for (const key of MAIL_ENV_KEYS) {
+    delete process.env[key];
   }
 }
 
 test('isVendorEmailConfigured returns false when MAIL_USER or MAIL_PASSWORD missing', () => {
+  clearMailEnv();
   process.env.MAIL_USER = '';
   process.env.MAIL_PASSWORD = 'secret';
   assert.equal(isVendorEmailConfigured(), false);
@@ -37,15 +54,31 @@ test('isVendorEmailConfigured returns false when MAIL_USER or MAIL_PASSWORD miss
 });
 
 test('isVendorEmailConfigured returns true when both env vars are set', () => {
+  clearMailEnv();
   process.env.MAIL_USER = 'mail@example.com';
   process.env.MAIL_PASSWORD = 'app-password';
   assert.equal(isVendorEmailConfigured(), true);
   restoreMailEnv();
 });
 
+test('vendor email config treats Resend SMTP as requiring MAIL_FROM', () => {
+  clearMailEnv();
+  process.env.MAIL_HOST = 'smtp.resend.com';
+  process.env.MAIL_USER = 'resend';
+  process.env.MAIL_PASSWORD = 'smtp-password';
+
+  assert.equal(getVendorEmailProvider(), 'resend_smtp');
+  assert.equal(isVendorEmailConfigured(), false);
+  assert.deepEqual(getVendorEmailConfigStatus().missing, ['MAIL_FROM']);
+
+  process.env.MAIL_FROM = 'Mosaic Biz Hub <hello@mosaicbizhub.com>';
+  assert.equal(isVendorEmailConfigured(), true);
+
+  restoreMailEnv();
+});
+
 test('deliverVendorOnboardingEmail skips when SMTP not configured', async () => {
-  process.env.MAIL_USER = '';
-  process.env.MAIL_PASSWORD = '';
+  clearMailEnv();
 
   const warnLogs = [];
   const originalWarn = console.warn;
@@ -64,25 +97,31 @@ test('deliverVendorOnboardingEmail skips when SMTP not configured', async () => 
   assert.equal(result.sent, false);
   assert.equal(result.skipped, true);
   assert.equal(result.reason, 'email_not_configured');
+  assert.deepEqual(result.missingEnvNames, ['MAIL_USER', 'MAIL_PASSWORD']);
   assert.ok(warnLogs.some((line) => line.includes('test_skip')));
+  assert.ok(warnLogs.some((line) => line.includes('MAIL_USER')));
 });
 
 test('deliverVendorOnboardingEmail returns sent on success', async () => {
+  clearMailEnv();
   process.env.MAIL_USER = 'mail@example.com';
   process.env.MAIL_PASSWORD = 'app-password';
 
   const result = await deliverVendorOnboardingEmail({
     label: 'test_success',
-    send: async () => {},
+    send: async () => ({ messageId: '<vendor-message-id@example.test>' }),
   });
 
   restoreMailEnv();
 
   assert.equal(result.sent, true);
   assert.equal(result.skipped, false);
+  assert.equal(result.provider, 'legacy_gmail');
+  assert.equal(result.messageId, '<vendor-message-id@example.test>');
 });
 
 test('deliverVendorOnboardingEmail logs message only on failure', async () => {
+  clearMailEnv();
   process.env.MAIL_USER = 'mail@example.com';
   process.env.MAIL_PASSWORD = 'app-password';
 
@@ -108,13 +147,14 @@ test('deliverVendorOnboardingEmail logs message only on failure', async () => {
 });
 
 test('deliverVendorOnboardingEmails aggregates partial success', async () => {
+  clearMailEnv();
   process.env.MAIL_USER = 'mail@example.com';
   process.env.MAIL_PASSWORD = 'app-password';
 
   const delivery = await deliverVendorOnboardingEmails([
     {
       label: 'first',
-      send: async () => {},
+      send: async () => ({ messageId: 'first-message' }),
     },
     {
       label: 'second',
@@ -131,5 +171,12 @@ test('deliverVendorOnboardingEmails aggregates partial success', async () => {
   assert.equal(delivery.emailFailed, false);
   assert.equal(delivery.results.length, 2);
   assert.equal(delivery.results[0].sent, true);
+  assert.equal(delivery.results[0].messageId, 'first-message');
   assert.equal(delivery.results[1].sent, false);
+});
+
+test('normalizeProviderMessageId safely bounds provider ids', () => {
+  const oversizedId = 'x'.repeat(300);
+  assert.equal(normalizeProviderMessageId({ messageId: oversizedId }).length, 180);
+  assert.equal(normalizeProviderMessageId({}), undefined);
 });

--- a/utils/WellcomeMailer.js
+++ b/utils/WellcomeMailer.js
@@ -160,7 +160,7 @@ exports.sendVendorVerificationGuidanceEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 exports.sendWelcomeEmail = async (to, vendorName) => {
@@ -196,7 +196,7 @@ exports.sendWelcomeEmail = async (to, vendorName) => {
     ]
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -250,7 +250,7 @@ exports.sendAdminOnboardingSubmissionEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -286,7 +286,7 @@ exports.sendVendorSubmissionConfirmationEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -324,7 +324,7 @@ exports.sendVendorApprovedEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -339,7 +339,7 @@ exports.sendVendorRejectionEmail = async ({
   documentsNeeded,
   responseWindowDays,
 }) => {
-  await exports.sendVendorVerificationGuidanceEmail({
+  return exports.sendVendorVerificationGuidanceEmail({
     to,
     vendorName,
     businessName,
@@ -535,7 +535,7 @@ exports.sendAdminVendorProfileCompletedEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -593,7 +593,7 @@ exports.sendVendorTrustBadgeAssignedEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };
 
 
@@ -657,5 +657,5 @@ exports.sendAdminVendorCategoryRequestEmail = async ({
     `,
   };
 
-  await transporter.sendMail(mailOptions);
+  return transporter.sendMail(mailOptions);
 };

--- a/utils/vendorOnboardingEmailDelivery.js
+++ b/utils/vendorOnboardingEmailDelivery.js
@@ -1,13 +1,54 @@
 /**
  * Graceful vendor onboarding email delivery.
- * Skips when SMTP env is missing; never logs secrets or full payloads.
+ * Skips when required SMTP env is missing; never logs secrets or full payloads.
  */
 
-function isVendorEmailConfigured() {
-  return Boolean(
-    process.env.MAIL_USER && String(process.env.MAIL_USER).trim()
-    && process.env.MAIL_PASSWORD && String(process.env.MAIL_PASSWORD).trim()
-  );
+function getTrimmedEnv(env, name) {
+  const value = env[name];
+  return typeof value === 'string' ? value.trim() : value;
+}
+
+function getVendorEmailProvider(env = process.env) {
+  const host = String(getTrimmedEnv(env, 'MAIL_HOST') || '').toLowerCase();
+  const user = String(getTrimmedEnv(env, 'MAIL_USER') || '').toLowerCase();
+
+  if (host.includes('resend') || user === 'resend') {
+    return 'resend_smtp';
+  }
+
+  if (host) {
+    return 'smtp';
+  }
+
+  return 'legacy_gmail';
+}
+
+function getVendorEmailConfigStatus(env = process.env) {
+  const missing = [];
+  if (!getTrimmedEnv(env, 'MAIL_USER')) missing.push('MAIL_USER');
+  if (!getTrimmedEnv(env, 'MAIL_PASSWORD')) missing.push('MAIL_PASSWORD');
+
+  const provider = getVendorEmailProvider(env);
+  if (provider === 'resend_smtp' && !getTrimmedEnv(env, 'MAIL_FROM')) {
+    missing.push('MAIL_FROM');
+  }
+
+  return {
+    configured: missing.length === 0,
+    missing,
+    provider,
+  };
+}
+
+function isVendorEmailConfigured(env = process.env) {
+  return getVendorEmailConfigStatus(env).configured;
+}
+
+function normalizeProviderMessageId(info) {
+  const raw = info && typeof info === 'object' ? info.messageId : undefined;
+  if (!raw) return undefined;
+
+  return String(raw).trim().slice(0, 180) || undefined;
 }
 
 /**
@@ -15,18 +56,38 @@ function isVendorEmailConfigured() {
  * @returns {Promise<{ sent: boolean, skipped?: boolean, reason?: string, error?: string }>}
  */
 async function deliverVendorOnboardingEmail({ label, send }) {
-  if (!isVendorEmailConfigured()) {
-    console.warn(`Vendor onboarding email skipped (${label}): MAIL_USER/MAIL_PASSWORD not configured`);
-    return { sent: false, skipped: true, reason: 'email_not_configured' };
+  const configStatus = getVendorEmailConfigStatus();
+
+  if (!configStatus.configured) {
+    console.warn(
+      `Vendor onboarding email skipped (${label}): email not configured; missing env names: ${configStatus.missing.join(', ')}`
+    );
+    return {
+      sent: false,
+      skipped: true,
+      reason: 'email_not_configured',
+      provider: configStatus.provider,
+      missingEnvNames: configStatus.missing,
+    };
   }
 
   try {
-    await send();
-    return { sent: true, skipped: false };
+    const info = await send();
+    return {
+      sent: true,
+      skipped: false,
+      provider: configStatus.provider,
+      messageId: normalizeProviderMessageId(info),
+    };
   } catch (err) {
     const message = err && err.message ? String(err.message) : 'Unknown email error';
     console.error(`Vendor onboarding email failed (${label}):`, message);
-    return { sent: false, skipped: false, error: message };
+    return {
+      sent: false,
+      skipped: false,
+      provider: configStatus.provider,
+      error: message,
+    };
   }
 }
 
@@ -57,7 +118,10 @@ async function deliverVendorOnboardingEmails(jobs = []) {
 }
 
 module.exports = {
+  getVendorEmailConfigStatus,
+  getVendorEmailProvider,
   isVendorEmailConfigured,
   deliverVendorOnboardingEmail,
   deliverVendorOnboardingEmails,
+  normalizeProviderMessageId,
 };


### PR DESCRIPTION
## Summary
- Release backend staging to main with vendor email lifecycle hardening.
- Adds provider-aware vendor onboarding email delivery metadata, including safe missing env name reporting and provider message IDs.
- Documents the vendor email lifecycle matrix and MAIL_* dependency names.

## Verification
- `npm test` passed on staging: 487/487.
- `git diff --check` passed before merge; only normal Windows CRLF notices were observed.

## Notes
- No Stripe payment/webhook behavior was changed.
- No secrets or env values are committed.
- This prepares backend SMTP/Resend-SMTP lifecycle handling, but production email delivery still requires deployed `MAIL_*` configuration and real inbox smoke tests.
