### PR TITLE
Release backend vendor listing readiness

### DIFF
--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -17,6 +17,11 @@ const { toPublicBusinessCard } = require("../lib/listing/publicListingDto");
 const {
   publicMarketplaceBusinessFilter,
 } = require("../lib/marketplace/businessEligibility");
+const {
+  attachListingSnapshotToBusiness,
+  enrichBusinessesWithListingSnapshots,
+  publishBusinessListings,
+} = require("../utils/businessListingVisibility");
 
 exports.createBusiness = async (req, res) => {
   try {
@@ -186,15 +191,74 @@ exports.getMyBusinesses = async (req, res) => {
       .populate("serviceCategories.category")
       .populate("foodCategories.category")
       .populate("subscriptionId")
-      .sort({ createdAt: -1 });
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const businessesWithListings = await enrichBusinessesWithListingSnapshots(businesses);
 
     res.status(200).json({
-      count: businesses.length,
-      businesses,
+      count: businessesWithListings.length,
+      businesses: businessesWithListings,
     });
   } catch (error) {
     console.error("Error fetching businesses:", error);
     res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+exports.publishStorefront = async (req, res) => {
+  try {
+    const business = await Business.findOne({
+      _id: req.params.id,
+      owner: req.user._id,
+    });
+
+    if (!business) {
+      return res.status(404).json({
+        success: false,
+        message: "Business not found",
+      });
+    }
+
+    const publication = await publishBusinessListings({
+      business,
+      userId: req.user._id,
+    });
+
+    if (!publication.ok) {
+      return res.status(publication.status).json({
+        success: false,
+        message: "Storefront is not ready to publish.",
+        blockers: publication.blockers,
+        publication: publication.publication,
+        business: attachListingSnapshotToBusiness(
+          business,
+          publication.snapshot,
+          publication.onboarding
+        ),
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: "Storefront and eligible listings published successfully.",
+      publication: publication.publication,
+      business: attachListingSnapshotToBusiness(
+        business,
+        publication.snapshot,
+        publication.onboarding
+      ),
+    });
+  } catch (error) {
+    console.error("Storefront publish error:", {
+      businessId: req.params?.id,
+      userId: req.user?._id ? String(req.user._id) : undefined,
+      message: error?.message || "Unknown storefront publish failure",
+    });
+    return res.status(500).json({
+      success: false,
+      message: "Unable to publish storefront right now. Please try again.",
+    });
   }
 };
 

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -682,6 +682,13 @@ exports.getFoodById = async (req, res) => {
       });
     }
 
+    if (food.isPublished !== true) {
+      return res.status(404).json({
+        success: false,
+        message: 'Food item not found',
+      });
+    }
+
     const visibleBusiness = await Business.findOne(
       publicMarketplaceBusinessFilter({ _id: food.businessId?._id })
     ).select('_id').lean();

--- a/routes/businessRoutes.js
+++ b/routes/businessRoutes.js
@@ -49,6 +49,13 @@ router.get(
   businessController.getMyBusinesses
 );
 
+router.post(
+  '/:id/publish-storefront',
+  authenticate,
+  isBusinessOwner,
+  businessController.publishStorefront
+);
+
 router.get(
   '/:id/shipping-settings',
   authenticate,

--- a/tests/integration/business-storefront-publication.integration.test.js
+++ b/tests/integration/business-storefront-publication.integration.test.js
@@ -1,0 +1,370 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+  seedServiceBusiness,
+  seedServiceCategories,
+  seedVendorOnboarding,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Product = require('../../models/Product');
+const ProductVariant = require('../../models/ProductVariant');
+const Service = require('../../models/Service');
+const Food = require('../../models/Food');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+async function setupVendorWithDraftProduct(agent, businessOverrides = {}) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    businessName: `Storefront Publication ${Date.now()}`,
+    listingType: 'product',
+    chargesEnabled: true,
+    payoutsEnabled: true,
+    ...businessOverrides,
+  });
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+
+  const product = await Product.create({
+    title: 'Draft Storefront Product',
+    description: 'A product created during onboarding final review.',
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: user._id,
+    businessId: business._id,
+    coverImage: 'https://example.test/storefront-product.png',
+    isPublished: false,
+    isDeleted: false,
+    price: 25,
+  });
+
+  const variant = await ProductVariant.create({
+    productId: product._id,
+    businessId: business._id,
+    ownerId: user._id,
+    attributes: { size: 'standard' },
+    sku: `PUB-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+    price: 25,
+    stock: 5,
+    images: ['https://example.test/storefront-product.png'],
+    isPublished: false,
+    isDeleted: false,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  return { user, business, product, variant };
+}
+
+test('GET /api/business/my returns zero listing counts and readiness blockers when vendor has no listings', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    chargesEnabled: true,
+    payoutsEnabled: true,
+  });
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const res = await agent.get('/api/business/my');
+  assert.equal(res.status, 200, JSON.stringify(res.body));
+
+  const returnedBusiness = res.body.businesses.find((item) =>
+    String(item._id) === String(business._id)
+  );
+  assert.ok(returnedBusiness);
+  assert.equal(returnedBusiness.products.length, 0);
+  assert.equal(returnedBusiness.services.length, 0);
+  assert.equal(returnedBusiness.foods.length, 0);
+  assert.equal(returnedBusiness.listingCounts.products, 0);
+  assert.equal(returnedBusiness.listingCounts.services, 0);
+  assert.equal(returnedBusiness.listingCounts.foods, 0);
+  assert.equal(returnedBusiness.listingCounts.total, 0);
+  assert.equal(returnedBusiness.onboardingReadiness.hasListing, false);
+  assert.equal(returnedBusiness.onboardingReadiness.canFinalReview, false);
+  assert.ok(
+    returnedBusiness.onboardingReadiness.blockers.some((blocker) =>
+      blocker.code === 'LISTING_REQUIRED'
+    )
+  );
+});
+
+test('GET /api/business/my reports draft and published listing status counts from real records', async () => {
+  const agent = createAgent(getApp());
+  const { business, product } = await setupVendorWithDraftProduct(agent);
+
+  const draftRes = await agent.get('/api/business/my');
+  assert.equal(draftRes.status, 200, JSON.stringify(draftRes.body));
+  const draftBusiness = draftRes.body.businesses.find((item) =>
+    String(item._id) === String(business._id)
+  );
+
+  assert.ok(draftBusiness);
+  assert.equal(draftBusiness.products.length, 1);
+  assert.equal(draftBusiness.listingCounts.products, 1);
+  assert.equal(draftBusiness.listingCounts.productVariants, 1);
+  assert.equal(draftBusiness.listingCounts.publishedProducts, 0);
+  assert.equal(draftBusiness.listingCounts.draftProducts, 1);
+  assert.equal(draftBusiness.listingCounts.statusBreakdown.products.draft, 1);
+  assert.equal(draftBusiness.listingCounts.statusBreakdown.products.published, 0);
+  assert.equal(draftBusiness.onboardingReadiness.hasListing, true);
+  assert.equal(draftBusiness.onboardingReadiness.canFinalReview, true);
+  assert.equal(draftBusiness.onboardingReadiness.canPublish, true);
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+
+  const publishedRes = await agent.get('/api/business/my');
+  assert.equal(publishedRes.status, 200, JSON.stringify(publishedRes.body));
+  const publishedBusiness = publishedRes.body.businesses.find((item) =>
+    String(item._id) === String(business._id)
+  );
+
+  assert.equal(publishedBusiness.listingCounts.publishedProducts, 1);
+  assert.equal(publishedBusiness.listingCounts.draftProducts, 0);
+  assert.equal(publishedBusiness.listingCounts.statusBreakdown.products.published, 1);
+
+  const publicProduct = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(publicProduct.status, 200, JSON.stringify(publicProduct.body));
+});
+
+test('GET /api/business/my counts product service and food records by business', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const productBusiness = await seedApprovedBusiness(user, {
+    businessName: `Product Count ${Date.now()}`,
+    listingType: 'product',
+  });
+  const serviceBusiness = await seedServiceBusiness(user, {
+    businessName: `Service Count ${Date.now()}`,
+  });
+  const foodBusiness = await seedApprovedBusiness(user, {
+    businessName: `Food Count ${Date.now()}`,
+    listingType: 'food',
+  });
+  const { category, subcategory } = await seedServiceCategories();
+
+  await Product.create({
+    title: 'Counted Product',
+    description: 'Product counted from Product collection.',
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: user._id,
+    businessId: productBusiness._id,
+    coverImage: 'https://example.test/counted-product.png',
+    isPublished: true,
+    isDeleted: false,
+    price: 25,
+  });
+  await Service.create({
+    title: 'Counted Service',
+    description: 'Service counted from Service collection.',
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    ownerId: user._id,
+    businessId: serviceBusiness._id,
+    coverImage: 'https://example.test/counted-service.png',
+    services: [{ name: 'Session', durationMinutes: 45, price: 75 }],
+    isPublished: false,
+  });
+  await Food.create({
+    title: 'Counted Food',
+    description: 'Food counted from Food collection.',
+    price: 18,
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: user._id,
+    businessId: foodBusiness._id,
+    businessName: foodBusiness.businessName,
+    coverImage: 'https://example.test/counted-food.png',
+    isPublished: true,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const res = await agent.get('/api/business/my');
+  assert.equal(res.status, 200, JSON.stringify(res.body));
+
+  const byId = new Map(res.body.businesses.map((item) => [String(item._id), item]));
+  assert.equal(byId.get(String(productBusiness._id)).listingCounts.products, 1);
+  assert.equal(byId.get(String(productBusiness._id)).listingCounts.total, 1);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.services, 1);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.total, 1);
+  assert.equal(byId.get(String(foodBusiness._id)).listingCounts.foods, 1);
+  assert.equal(byId.get(String(foodBusiness._id)).listingCounts.total, 1);
+});
+
+test('vendor publish-storefront publishes draft product listings and makes public product visible', async () => {
+  const agent = createAgent(getApp());
+  const { business, product, variant } = await setupVendorWithDraftProduct(agent);
+
+  const beforePublic = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(beforePublic.status, 404);
+
+  const myBusinesses = await agent.get('/api/business/my');
+  assert.equal(myBusinesses.status, 200);
+  assert.equal(myBusinesses.body.businesses[0].products.length, 1);
+  assert.equal(myBusinesses.body.businesses[0].listingCounts.products, 1);
+  assert.equal(myBusinesses.body.businesses[0].publication.hasRequiredListing, true);
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+  assert.equal(publishRes.body.success, true);
+  assert.equal(publishRes.body.publication.publicMarketplaceEligible, true);
+  assert.equal(publishRes.body.publication.blockers.length, 0);
+
+  const reloadedProduct = await Product.findById(product._id).lean();
+  const reloadedVariant = await ProductVariant.findById(variant._id).lean();
+  assert.equal(reloadedProduct.isPublished, true);
+  assert.equal(reloadedVariant.isPublished, true);
+
+  const afterPublic = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(afterPublic.status, 200, JSON.stringify(afterPublic.body));
+  assert.equal(afterPublic.body.data.title, 'Draft Storefront Product');
+});
+
+test('publish-storefront returns actionable blockers and keeps listings private when payout is incomplete', async () => {
+  const agent = createAgent(getApp());
+  const { business, product, variant } = await setupVendorWithDraftProduct(agent, {
+    chargesEnabled: false,
+    payoutsEnabled: false,
+  });
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 409);
+  assert.equal(publishRes.body.success, false);
+  assert.ok(
+    publishRes.body.blockers.some((blocker) => blocker.code === 'PAYOUT_SETUP_REQUIRED')
+  );
+
+  const reloadedProduct = await Product.findById(product._id).lean();
+  const reloadedVariant = await ProductVariant.findById(variant._id).lean();
+  assert.equal(reloadedProduct.isPublished, false);
+  assert.equal(reloadedVariant.isPublished, false);
+
+  const publicRes = await agent.get(`/api/public/product/${product._id}`);
+  assert.equal(publicRes.status, 404);
+});
+
+test('vendor publish-storefront publishes draft service listings', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user, {
+    chargesEnabled: true,
+    payoutsEnabled: true,
+  });
+  const { category, subcategory } = await seedServiceCategories();
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+  const service = await Service.create({
+    title: 'Draft Storefront Service',
+    description: 'A service created during onboarding final review.',
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    ownerId: user._id,
+    businessId: business._id,
+    coverImage: 'https://example.test/storefront-service.png',
+    services: [{ name: 'Consultation', durationMinutes: 30, price: 50 }],
+    isPublished: false,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const beforeList = await agent.get('/api/services/list');
+  assert.equal(beforeList.status, 200);
+  assert.ok(!beforeList.body.data.some((entry) => String(entry.id || entry._id) === String(service._id)));
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+  assert.equal(publishRes.body.publication.published.services, 1);
+
+  const reloadedService = await Service.findById(service._id).lean();
+  assert.equal(reloadedService.isPublished, true);
+
+  const afterDetail = await agent.get(`/api/public/services/${service._id}`);
+  assert.equal(afterDetail.status, 200, JSON.stringify(afterDetail.body));
+});
+
+test('vendor publish-storefront publishes draft food listings and public food detail stays private before publish', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    listingType: 'food',
+    chargesEnabled: true,
+    payoutsEnabled: true,
+  });
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+  const food = await Food.create({
+    title: 'Draft Storefront Food',
+    description: 'A food listing created during onboarding final review.',
+    price: 18,
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: user._id,
+    businessId: business._id,
+    businessName: business.businessName,
+    coverImage: 'https://example.test/storefront-food.png',
+    isPublished: false,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const beforeDetail = await agent.get(`/api/public/foods/${food._id}`);
+  assert.equal(beforeDetail.status, 404);
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+  assert.equal(publishRes.body.publication.published.foods, 1);
+
+  const reloadedFood = await Food.findById(food._id).lean();
+  assert.equal(reloadedFood.isPublished, true);
+
+  const afterList = await agent.get('/api/food/list');
+  assert.equal(afterList.status, 200);
+  assert.ok(afterList.body.data.some((entry) => String(entry.id || entry._id) === String(food._id)));
+
+  const afterDetail = await agent.get(`/api/public/foods/${food._id}`);
+  assert.equal(afterDetail.status, 200, JSON.stringify(afterDetail.body));
+});

--- a/utils/businessListingVisibility.js
+++ b/utils/businessListingVisibility.js
@@ -1,0 +1,420 @@
+const Product = require('../models/Product');
+const ProductVariant = require('../models/ProductVariant');
+const Service = require('../models/Service');
+const Food = require('../models/Food');
+const VendorOnboardingStage1 = require('../models/VendorOnboardingStage1');
+const {
+  isPublicMarketplaceBusiness,
+} = require('../lib/marketplace/businessEligibility');
+
+const LISTING_TYPES = new Set(['product', 'service', 'food']);
+
+function normalizeId(value) {
+  if (!value) return null;
+  if (value._id) return String(value._id);
+  return String(value);
+}
+
+function toPlain(value) {
+  if (!value) return value;
+  if (typeof value.toObject === 'function') return value.toObject();
+  return value;
+}
+
+function groupByBusinessId(items = []) {
+  const grouped = new Map();
+  for (const item of items) {
+    const businessId = normalizeId(item.businessId);
+    if (!businessId) continue;
+    if (!grouped.has(businessId)) grouped.set(businessId, []);
+    grouped.get(businessId).push(item);
+  }
+  return grouped;
+}
+
+function groupVariantsByProductId(variants = []) {
+  const grouped = new Map();
+  for (const variant of variants) {
+    const productId = normalizeId(variant.productId);
+    if (!productId) continue;
+    if (!grouped.has(productId)) grouped.set(productId, []);
+    grouped.get(productId).push(variant);
+  }
+  return grouped;
+}
+
+function countPublished(items = []) {
+  return items.filter((item) => item.isPublished === true).length;
+}
+
+function countDraft(items = []) {
+  return items.filter((item) => item.isPublished !== true).length;
+}
+
+function summarizeCounts(snapshot) {
+  const products = snapshot.products || [];
+  const services = snapshot.services || [];
+  const foods = snapshot.foods || [];
+  const productVariants = products.flatMap((product) => product.variants || []);
+
+  return {
+    products: products.length,
+    publishedProducts: countPublished(products),
+    draftProducts: countDraft(products),
+    productVariants: productVariants.length,
+    publishedProductVariants: countPublished(productVariants),
+    draftProductVariants: countDraft(productVariants),
+    services: services.length,
+    publishedServices: countPublished(services),
+    draftServices: countDraft(services),
+    foods: foods.length,
+    publishedFoods: countPublished(foods),
+    draftFoods: countDraft(foods),
+    total: products.length + services.length + foods.length,
+    statusBreakdown: {
+      products: {
+        draft: countDraft(products),
+        published: countPublished(products),
+      },
+      services: {
+        draft: countDraft(services),
+        published: countPublished(services),
+      },
+      foods: {
+        draft: countDraft(foods),
+        published: countPublished(foods),
+      },
+    },
+  };
+}
+
+function getEligibleListingsForBusiness(business, snapshot) {
+  const listingType = String(business?.listingType || '').trim().toLowerCase();
+
+  if (listingType === 'product') {
+    return {
+      type: listingType,
+      listings: snapshot.products || [],
+      variantIds: (snapshot.products || [])
+        .flatMap((product) => product.variants || [])
+        .map((variant) => variant._id)
+        .filter(Boolean),
+    };
+  }
+
+  if (listingType === 'service') {
+    return {
+      type: listingType,
+      listings: (snapshot.services || []).filter((service) => (
+        Array.isArray(service.services) && service.services.length > 0
+      )),
+    };
+  }
+
+  if (listingType === 'food') {
+    return {
+      type: listingType,
+      listings: snapshot.foods || [],
+    };
+  }
+
+  return { type: listingType, listings: [] };
+}
+
+function resolveOnboardingForBusiness(business, onboardingRows = []) {
+  const businessId = normalizeId(business?._id);
+  const matchingBusiness = onboardingRows.find((row) =>
+    normalizeId(row.businessId) === businessId
+  );
+  if (matchingBusiness) return matchingBusiness;
+
+  const legacyWithoutBusinessId = onboardingRows.find((row) => !row.businessId);
+  return legacyWithoutBusinessId || onboardingRows[0] || null;
+}
+
+async function loadOnboardingRowsByOwnerIds(ownerIds = []) {
+  const ids = [...new Set(ownerIds.map(normalizeId).filter(Boolean))];
+  const grouped = new Map(ids.map((id) => [id, []]));
+
+  if (!ids.length) return grouped;
+
+  const rows = await VendorOnboardingStage1.find({ userId: { $in: ids } })
+    .select('userId businessId status applicationId updatedAt')
+    .sort({ updatedAt: -1 })
+    .lean();
+
+  for (const row of rows) {
+    const ownerId = normalizeId(row.userId);
+    if (!ownerId) continue;
+    if (!grouped.has(ownerId)) grouped.set(ownerId, []);
+    grouped.get(ownerId).push(row);
+  }
+
+  return grouped;
+}
+
+async function loadListingSnapshotsByBusinessIds(businessIds = []) {
+  const ids = [...new Set(businessIds.map(normalizeId).filter(Boolean))];
+  const emptySnapshot = () => ({ products: [], services: [], foods: [], listingCounts: {} });
+  const snapshots = new Map(ids.map((id) => [id, emptySnapshot()]));
+
+  if (!ids.length) return snapshots;
+
+  const [products, services, foods, variants] = await Promise.all([
+    Product.find({ businessId: { $in: ids }, isDeleted: false })
+      .select('_id title slug businessId ownerId coverImage isPublished isDeleted createdAt updatedAt')
+      .lean(),
+    Service.find({ businessId: { $in: ids } })
+      .select('_id title slug businessId ownerId coverImage isPublished services createdAt updatedAt')
+      .lean(),
+    Food.find({ businessId: { $in: ids } })
+      .select('_id title slug businessId ownerId coverImage isPublished createdAt updatedAt')
+      .lean(),
+    ProductVariant.find({ businessId: { $in: ids }, isDeleted: false })
+      .select('_id productId businessId ownerId sku stock isPublished isDeleted createdAt updatedAt')
+      .lean(),
+  ]);
+
+  const variantsByProductId = groupVariantsByProductId(variants);
+  const productsWithVariants = products.map((product) => ({
+    ...product,
+    variants: variantsByProductId.get(String(product._id)) || [],
+  }));
+
+  const groupedProducts = groupByBusinessId(productsWithVariants);
+  const groupedServices = groupByBusinessId(services);
+  const groupedFoods = groupByBusinessId(foods);
+
+  for (const id of ids) {
+    const snapshot = {
+      products: groupedProducts.get(id) || [],
+      services: groupedServices.get(id) || [],
+      foods: groupedFoods.get(id) || [],
+    };
+    snapshot.listingCounts = summarizeCounts(snapshot);
+    snapshots.set(id, snapshot);
+  }
+
+  return snapshots;
+}
+
+function attachListingSnapshotToBusiness(business, snapshot, onboarding = null) {
+  const plain = toPlain(business);
+  const listingSnapshot = snapshot || { products: [], services: [], foods: [] };
+  const eligible = getEligibleListingsForBusiness(plain, listingSnapshot);
+  const onboardingReadiness = buildOnboardingReadiness({
+    business: plain,
+    onboarding,
+    snapshot: listingSnapshot,
+  });
+
+  return {
+    ...plain,
+    products: listingSnapshot.products || [],
+    services: listingSnapshot.services || [],
+    foods: listingSnapshot.foods || [],
+    listingCounts: listingSnapshot.listingCounts || summarizeCounts(listingSnapshot),
+    publication: {
+      listingType: plain?.listingType || null,
+      publicMarketplaceEligible: isPublicMarketplaceBusiness(plain),
+      hasRequiredListing: eligible.listings.length > 0,
+      requiredListingCount: eligible.listings.length,
+    },
+    onboardingReadiness,
+  };
+}
+
+async function enrichBusinessesWithListingSnapshots(businesses = []) {
+  const plainBusinesses = businesses.map(toPlain);
+  const [snapshots, onboardingRowsByOwner] = await Promise.all([
+    loadListingSnapshotsByBusinessIds(
+      plainBusinesses.map((business) => business?._id)
+    ),
+    loadOnboardingRowsByOwnerIds(
+      plainBusinesses.map((business) => business?.owner)
+    ),
+  ]);
+
+  return plainBusinesses.map((business) => {
+    const onboarding = resolveOnboardingForBusiness(
+      business,
+      onboardingRowsByOwner.get(normalizeId(business?.owner)) || []
+    );
+
+    return attachListingSnapshotToBusiness(
+      business,
+      snapshots.get(normalizeId(business?._id)),
+      onboarding
+    );
+  });
+}
+
+function buildPublicationBlockers({ business, onboarding, snapshot }) {
+  const blockers = [];
+  const listingType = String(business?.listingType || '').trim().toLowerCase();
+  const eligible = getEligibleListingsForBusiness(business, snapshot);
+
+  if (!onboarding || onboarding.status !== 'verified') {
+    blockers.push({
+      code: 'VENDOR_VERIFICATION_REQUIRED',
+      message: 'Vendor application must be approved before publishing.',
+    });
+  }
+
+  if (business?.isApproved !== true) {
+    blockers.push({
+      code: 'BUSINESS_APPROVAL_REQUIRED',
+      message: 'Business must be approved before publishing.',
+    });
+  }
+
+  if (business?.isActive !== true) {
+    blockers.push({
+      code: 'BUSINESS_ACTIVE_REQUIRED',
+      message: 'Business must be active before publishing.',
+    });
+  }
+
+  if (business?.chargesEnabled !== true || business?.payoutsEnabled !== true) {
+    blockers.push({
+      code: 'PAYOUT_SETUP_REQUIRED',
+      message: 'Complete payout setup before publishing.',
+    });
+  }
+
+  if (!LISTING_TYPES.has(listingType)) {
+    blockers.push({
+      code: 'LISTING_TYPE_REQUIRED',
+      message: 'Choose a valid business listing type before publishing.',
+    });
+  } else if (eligible.listings.length === 0) {
+    blockers.push({
+      code: 'LISTING_REQUIRED',
+      message: `Add at least one ${listingType} listing before publishing.`,
+    });
+  }
+
+  return blockers;
+}
+
+function buildOnboardingReadiness({ business, onboarding, snapshot }) {
+  const eligible = getEligibleListingsForBusiness(business, snapshot);
+  const hasListing = eligible.listings.length > 0;
+  const payoutComplete = Boolean(business?.chargesEnabled && business?.payoutsEnabled);
+  const blockers = buildPublicationBlockers({ business, onboarding, snapshot });
+
+  return {
+    listingType: business?.listingType || null,
+    hasListing,
+    requiredListingCount: eligible.listings.length,
+    payoutComplete,
+    vendorVerificationStatus: onboarding?.status || null,
+    canFinalReview: hasListing && payoutComplete,
+    canPublish: blockers.length === 0,
+    blockers,
+  };
+}
+
+async function publishBusinessListings({ business, userId }) {
+  const businessId = normalizeId(business?._id);
+  const snapshots = await loadListingSnapshotsByBusinessIds([businessId]);
+  const snapshot = snapshots.get(businessId) || { products: [], services: [], foods: [] };
+  const onboarding = await VendorOnboardingStage1.findOne({
+    userId,
+    status: 'verified',
+    $or: [
+      { businessId: business._id },
+      { businessId: { $exists: false } },
+      { businessId: null },
+    ],
+  }).select('status applicationId businessId').sort({ updatedAt: -1 }).lean();
+  const blockers = buildPublicationBlockers({ business, onboarding, snapshot });
+
+  if (blockers.length) {
+    return {
+      ok: false,
+      status: 409,
+      blockers,
+      onboarding,
+      snapshot,
+      publication: {
+        listingType: business.listingType,
+        publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
+        hasRequiredListing: getEligibleListingsForBusiness(business, snapshot).listings.length > 0,
+        blockers,
+      },
+    };
+  }
+
+  const eligible = getEligibleListingsForBusiness(business, snapshot);
+  const listingIds = eligible.listings.map((item) => item._id).filter(Boolean);
+  const published = {
+    products: 0,
+    productVariants: 0,
+    services: 0,
+    foods: 0,
+  };
+
+  if (eligible.type === 'product') {
+    const productResult = await Product.updateMany(
+      { _id: { $in: listingIds }, businessId: business._id, ownerId: userId, isDeleted: false },
+      { $set: { isPublished: true } }
+    );
+    const variantResult = await ProductVariant.updateMany(
+      {
+        businessId: business._id,
+        ownerId: userId,
+        productId: { $in: listingIds },
+        isDeleted: false,
+      },
+      { $set: { isPublished: true } }
+    );
+
+    published.products = productResult.modifiedCount ?? productResult.nModified ?? 0;
+    published.productVariants = variantResult.modifiedCount ?? variantResult.nModified ?? 0;
+  }
+
+  if (eligible.type === 'service') {
+    const serviceResult = await Service.updateMany(
+      { _id: { $in: listingIds }, businessId: business._id, ownerId: userId },
+      { $set: { isPublished: true } }
+    );
+    published.services = serviceResult.modifiedCount ?? serviceResult.nModified ?? 0;
+  }
+
+  if (eligible.type === 'food') {
+    const foodResult = await Food.updateMany(
+      { _id: { $in: listingIds }, businessId: business._id, ownerId: userId },
+      { $set: { isPublished: true } }
+    );
+    published.foods = foodResult.modifiedCount ?? foodResult.nModified ?? 0;
+  }
+
+  const refreshedSnapshots = await loadListingSnapshotsByBusinessIds([business._id]);
+  const refreshedSnapshot = refreshedSnapshots.get(businessId) || snapshot;
+
+  return {
+    ok: true,
+    status: 200,
+    published,
+    onboarding,
+    snapshot: refreshedSnapshot,
+    publication: {
+      listingType: business.listingType,
+      publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
+      hasRequiredListing: true,
+      requiredListingCount: eligible.listings.length,
+      published,
+      blockers: [],
+    },
+  };
+}
+
+module.exports = {
+  attachListingSnapshotToBusiness,
+  buildPublicationBlockers,
+  enrichBusinessesWithListingSnapshots,
+  getEligibleListingsForBusiness,
+  loadListingSnapshotsByBusinessIds,
+  publishBusinessListings,
+};


### PR DESCRIPTION
## Summary
- Enrich GET /api/business/my with real product/service/food listing snapshots and readiness blockers.
- Add POST /api/business/:id/publish-storefront so final review can publish eligible vendor listings only after backend preconditions pass.
- Keep draft food detail private until published.

## Verification
- npm test: passed, 487/487
- npm run test:contract: passed, 20/20
- npm run test:integration: passed, 70/70
- node --test tests/integration/business-storefront-publication.integration.test.js: passed, 7/7

## Notes
- No Stripe/payment/webhook logic changed.
- No deployment performed.