### PR TITLE
Fix production S3 upload CORS policy

### DIFF
--- a/docs/S3_UPLOAD_CORS.md
+++ b/docs/S3_UPLOAD_CORS.md
@@ -3,7 +3,7 @@
 **Issue:** Vendor onboarding browser upload fails when `PUT`ing directly to S3 pre-signed URL (not Express API CORS).  
 **Evidence date:** 2026-06-19 (UTC)  
 **Production API:** `https://api.mosaicbizhub.com`  
-**Production bucket (from presigned URL host):** `mosaic-biz-hub` · region `us-east-1`
+**Production bucket:** value of `AWS_S3_BUCKET` in the backend environment.
 
 No AWS keys, signed URLs, ETag values, cookies, JWTs, or env values in this document.
 
@@ -49,27 +49,31 @@ See also [`docs/CORS_PRODUCTION_SMOKE_PROOF.md`](CORS_PRODUCTION_SMOKE_PROOF.md)
 
 ## Required S3 bucket CORS policy
 
-Apply on bucket **`mosaic-biz-hub`** (must match production `AWS_S3_BUCKET`):
+Apply on the bucket named by production `AWS_S3_BUCKET`:
 
 ```json
 [
   {
+    "ID": "MosaicVendorPresignedUploads",
     "AllowedOrigins": [
       "https://mosaicbizhub.com",
       "https://www.mosaicbizhub.com",
       "https://app.mosaicbizhub.com",
-      "https://mosaic-biz-frontend-launch.vercel.app"
+      "https://mosaic-biz-frontend-launch.vercel.app",
+      "http://localhost:3000",
+      "http://127.0.0.1:3000"
     ],
-    "AllowedMethods": ["PUT", "GET", "HEAD"],
-    "AllowedHeaders": ["Content-Type"],
-    "ExposeHeaders": ["ETag"],
+    "AllowedMethods": ["GET", "HEAD", "PUT", "POST"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag", "x-amz-request-id", "x-amz-id-2"],
     "MaxAgeSeconds": 3000
   }
 ]
 ```
 
-**Console:** S3 → `mosaic-biz-hub` → Permissions → Cross-origin resource sharing (CORS)  
-**CLI (release owner):** `aws s3api get-bucket-cors --bucket mosaic-biz-hub --region us-east-1`
+**Console:** S3 → bucket from `AWS_S3_BUCKET` → Permissions → Cross-origin resource sharing (CORS)
+
+**CLI (release owner):** `npm run s3:cors:vendor-upload` to preview, then `npm run s3:cors:vendor-upload -- --apply` to update the managed rule.
 
 ---
 
@@ -93,7 +97,7 @@ Probes used credentialed vendor session against production API; signed URL query
 | `https://mosaic-biz-frontend-launch.vercel.app` | exact match | **200** | **PASS** |
 | `https://app.mosaicbizhub.com` | exact match | **200** | **PASS** |
 
-Observed on launch origin (sanitized): `Access-Control-Allow-Methods` includes PUT; `Access-Control-Expose-Headers` includes ETag.
+Observed on launch origin (sanitized): `Access-Control-Allow-Methods` includes PUT; `Access-Control-Expose-Headers` includes ETag. Current managed policy also exposes AWS request IDs for production diagnostics.
 
 ### S3 presigned PUT
 
@@ -137,9 +141,9 @@ Unit tests prove MIME allowlist, auth wiring, and `ContentType` on `PutObjectCom
 
 | Symptom | Likely cause | Action |
 | --- | --- | --- |
-| No `Access-Control-Allow-Origin` on S3 PUT | Bucket CORS missing/wrong origin | Re-apply policy above on correct bucket |
-| CORS OK, PUT 403 | Content-Type ≠ signed type | Align `fileType` query with PUT header |
-| `upload-url` 401/403 | Vendor auth / OTP | Express auth — not S3 |
+| No `Access-Control-Allow-Origin` on S3 PUT | Bucket CORS missing/wrong origin/header/method | Re-apply policy above on correct bucket |
+| CORS OK, PUT 403 | Content-Type does not match signed type | Align `fileType` query with PUT header |
+| `upload-url` 401/403 | Vendor auth / OTP | Express auth, not S3 |
 | PUT OK, file not viewable | Bucket policy / object ACL | Separate from upload CORS |
 
 ---

--- a/docs/S3_UPLOAD_CORS.md
+++ b/docs/S3_UPLOAD_CORS.md
@@ -11,9 +11,11 @@ No AWS keys, signed URLs, ETag values, cookies, JWTs, or env values in this docu
 
 ## Executive verdict
 
-**S3 upload CORS: PASS**
+**Managed policy updated; production AWS apply still required**
 
-After bucket CORS was updated on `mosaic-biz-hub`, production probes confirm browser-allowed origins, successful OPTIONS preflight, and successful presigned PUT for vendor onboarding Stage 1 documents.
+The backend now generates the production-safe bucket CORS rule for direct browser S3 uploads. Production uploads can still fail until the release owner applies the managed rule to the bucket named by `AWS_S3_BUCKET`.
+
+Historical probes from 2026-06-19 confirmed successful OPTIONS preflight and presigned PUT after the then-current bucket CORS was updated. Run the smoke plan below again after applying this rule for the active production origins.
 
 ---
 

--- a/docs/VENDOR_PDF_UPLOAD_CORS.md
+++ b/docs/VENDOR_PDF_UPLOAD_CORS.md
@@ -61,9 +61,9 @@ Required rule shape:
         "http://localhost:3000",
         "http://127.0.0.1:3000"
       ],
-      "AllowedMethods": ["PUT", "GET", "HEAD"],
-      "AllowedHeaders": ["Content-Type"],
-      "ExposeHeaders": ["ETag"],
+      "AllowedMethods": ["GET", "HEAD", "PUT", "POST"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag", "x-amz-request-id", "x-amz-id-2"],
       "MaxAgeSeconds": 3000
     }
   ]

--- a/tests/vendor/vendor-upload-s3-cors-config.test.js
+++ b/tests/vendor/vendor-upload-s3-cors-config.test.js
@@ -29,26 +29,42 @@ test('vendor upload S3 CORS origins include app and local browser origins', () =
   assert.equal(origins.includes('*'), false);
 });
 
-test('vendor upload S3 CORS rule allows presigned PUT with only required headers', () => {
+test('vendor upload S3 CORS rule allows browser presigned uploads', () => {
   const corsConfiguration = buildS3UploadCorsConfiguration({
     S3_UPLOAD_CORS_ORIGINS: 'https://mosaicbizhub.com',
   });
   const [rule] = corsConfiguration.CORSRules;
 
   assert.equal(rule.ID, 'MosaicVendorPresignedUploads');
-  assert.deepEqual(rule.AllowedMethods, ['PUT', 'GET', 'HEAD']);
-  assert.deepEqual(rule.AllowedHeaders, ['Content-Type']);
-  assert.deepEqual(rule.ExposeHeaders, ['ETag']);
+  assert.deepEqual(rule.AllowedMethods, ['GET', 'HEAD', 'PUT', 'POST']);
+  assert.deepEqual(rule.AllowedHeaders, ['*']);
+  assert.deepEqual(rule.ExposeHeaders, ['ETag', 'x-amz-request-id', 'x-amz-id-2']);
   assert.equal(rule.MaxAgeSeconds, 3000);
   assert.equal(rule.AllowedMethods.includes('DELETE'), false);
   assert.equal(rule.AllowedMethods.includes('OPTIONS'), false);
 });
 
+test('vendor upload S3 CORS origins are normalized without trailing slashes', () => {
+  const origins = getS3UploadCorsOrigins({
+    S3_UPLOAD_CORS_ORIGINS:
+      'https://mosaicbizhub.com/,https://preview.example.vercel.app/,https://mosaicbizhub.com/path',
+  });
+
+  assert.ok(origins.includes('https://mosaicbizhub.com'));
+  assert.ok(origins.includes('https://preview.example.vercel.app'));
+  assert.equal(origins.includes('https://mosaicbizhub.com/'), false);
+  assert.equal(origins.includes('https://preview.example.vercel.app/'), false);
+  assert.equal(origins.includes('https://mosaicbizhub.com/path'), false);
+});
+
 test('vendor upload S3 CORS origin validation rejects non-browser or wildcard origins', () => {
   assert.equal(isSafeBrowserOrigin('https://*.vercel.app'), true);
+  assert.equal(isSafeBrowserOrigin('https://mosaic-biz-frontend-launch-*.vercel.app'), true);
   assert.equal(isSafeBrowserOrigin('https://mosaicbizhub.com'), true);
+  assert.equal(isSafeBrowserOrigin('https://mosaicbizhub.com/'), true);
   assert.equal(isSafeBrowserOrigin('http://localhost:3000'), true);
   assert.equal(isSafeBrowserOrigin('*'), false);
+  assert.equal(isSafeBrowserOrigin('https://*'), false);
   assert.equal(isSafeBrowserOrigin('https://api.mosaicbizhub.com'), false);
   assert.equal(isSafeBrowserOrigin('https://mosaicbizhub.com/path'), false);
   assert.equal(isSafeBrowserOrigin('not-a-url'), false);

--- a/utils/s3UploadCorsConfig.js
+++ b/utils/s3UploadCorsConfig.js
@@ -11,9 +11,9 @@ const DEFAULT_S3_UPLOAD_CORS_ORIGINS = [
   'http://127.0.0.1:3000',
 ];
 
-const S3_UPLOAD_CORS_ALLOWED_METHODS = ['PUT', 'GET', 'HEAD'];
-const S3_UPLOAD_CORS_ALLOWED_HEADERS = ['Content-Type'];
-const S3_UPLOAD_CORS_EXPOSE_HEADERS = ['ETag'];
+const S3_UPLOAD_CORS_ALLOWED_METHODS = ['GET', 'HEAD', 'PUT', 'POST'];
+const S3_UPLOAD_CORS_ALLOWED_HEADERS = ['*'];
+const S3_UPLOAD_CORS_EXPOSE_HEADERS = ['ETag', 'x-amz-request-id', 'x-amz-id-2'];
 const S3_UPLOAD_CORS_MAX_AGE_SECONDS = 3000;
 const S3_UPLOAD_CORS_RULE_ID = 'MosaicVendorPresignedUploads';
 
@@ -24,26 +24,48 @@ function parseOriginList(value) {
 
   return value
     .split(',')
-    .map((origin) => origin.trim())
+    .map(normalizeCorsOrigin)
     .filter(Boolean);
 }
 
-function isSafeBrowserOrigin(origin) {
-  if (origin === '*' || /\/\*$/.test(origin)) {
-    return false;
-  }
-
-  if (/^https:\/\/\*\.[a-z0-9.-]+$/i.test(origin)) {
-    return true;
+function normalizeCorsOrigin(origin) {
+  const trimmed = String(origin || '').trim();
+  if (!trimmed) {
+    return '';
   }
 
   try {
-    const parsed = new URL(origin);
+    const parsed = new URL(trimmed);
+    if (parsed.pathname === '/' && !parsed.search && !parsed.hash) {
+      return parsed.origin;
+    }
+  } catch (_error) {
+    // Wildcard S3 origins are not valid URL hostnames; validate them separately.
+  }
+
+  return trimmed.replace(/\/+$/, '');
+}
+
+function isSafeBrowserOrigin(origin) {
+  const normalizedOrigin = normalizeCorsOrigin(origin);
+
+  if (normalizedOrigin === '*' || /\/\*$/.test(normalizedOrigin)) {
+    return false;
+  }
+
+  const wildcardMatch = normalizedOrigin.match(/^https:\/\/([^/\s]*\*[^/\s]*)$/i);
+  if (wildcardMatch) {
+    const wildcardHost = wildcardMatch[1].toLowerCase();
+    return wildcardHost !== '*' && wildcardHost.endsWith('.vercel.app');
+  }
+
+  try {
+    const parsed = new URL(normalizedOrigin);
     if (!['http:', 'https:'].includes(parsed.protocol)) {
       return false;
     }
 
-    if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    if (parsed.origin !== normalizedOrigin || parsed.search || parsed.hash) {
       return false;
     }
 


### PR DESCRIPTION
## What changed
- Updated the managed S3 vendor upload CORS rule to support production browser presigned uploads from Mosaic marketplace origins.
- Normalized configured S3 CORS origins so trailing slashes do not land in the bucket policy.
- Expanded upload CORS tests and updated the S3 upload runbooks.

## Why
Production listing image uploads can fail before the API sees the request when the browser preflights the presigned S3 PUT and the bucket CORS rule does not match the active origin, method, or headers.

## Validation
- node --test tests/vendor/vendor-upload-s3-cors-config.test.js tests/vendor/s3-presigned-upload-contract.test.js tests/vendor/vendor-onboarding-upload-mime.test.js
- git diff --check
- npm test
- npm run test:contract --if-present
- npm run lint --if-present

## Notes
No Stripe, payment, webhook, or app.js middleware changes. AWS bucket CORS still needs the release owner to apply the managed rule in the target environment.
