### PR TITLE
Release: product stock contract readiness

### DIFF
--- a/controllers/privateListing.js
+++ b/controllers/privateListing.js
@@ -243,6 +243,79 @@ const ProductVariant = require('../models/ProductVariant');
 const Product = require('../models/Product');
 const ProductCategory = require('../models/ProductCategory');
 
+const LOW_STOCK_THRESHOLD = 5;
+
+const toStockNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const getStockStatus = (stock, threshold = LOW_STOCK_THRESHOLD) => {
+  if (stock <= 0) return 'out_of_stock';
+  if (stock <= threshold) return 'low_stock';
+  return 'in_stock';
+};
+
+const toPriceNumber = (value) => {
+  if (value === undefined || value === null || value === '') return 0;
+  const parsed = Number(value.toString());
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const formatVariantAttributes = (attributes) => {
+  if (!attributes) return 'Default';
+
+  if (attributes instanceof Map) {
+    const values = Array.from(attributes.values()).filter(Boolean);
+    return values.length ? values.join(' / ') : 'Default';
+  }
+
+  if (typeof attributes === 'object') {
+    const values = Object.values(attributes).filter(Boolean);
+    return values.length ? values.join(' / ') : 'Default';
+  }
+
+  return 'Default';
+};
+
+const buildVariantSizes = (variant) => {
+  const legacySizes = Array.isArray(variant.sizes) ? variant.sizes : [];
+
+  if (legacySizes.length > 0) {
+    return legacySizes.map((size) => {
+      const stock = toStockNumber(size.stock);
+
+      return {
+        sizeId: size._id,
+        size: size.size,
+        sku: size.sku,
+        stock,
+        stockStatus: getStockStatus(stock),
+        lowStockThreshold: LOW_STOCK_THRESHOLD,
+        price: toPriceNumber(size.price),
+        salePrice: size.salePrice ? toPriceNumber(size.salePrice) : null,
+        discountEndDate: size.discountEndDate || null,
+      };
+    });
+  }
+
+  const stock = toStockNumber(variant.stock);
+
+  return [
+    {
+      sizeId: variant._id,
+      size: variant.label || formatVariantAttributes(variant.attributes),
+      sku: variant.sku,
+      stock,
+      stockStatus: getStockStatus(stock),
+      lowStockThreshold: LOW_STOCK_THRESHOLD,
+      price: toPriceNumber(variant.price),
+      salePrice: variant.salePrice ? toPriceNumber(variant.salePrice) : null,
+      discountEndDate: null,
+    },
+  ];
+};
+
 
 // exports.getAllProducts = async (req, res) => {
 //   try {
@@ -402,18 +475,32 @@ exports.getAllProducts = async (req, res) => {
     }
 
     if (offers === 'true') filters.features = { $in: ['Offers Available'] };
-    if (outOfStock === 'true') filters['sizes.stock'] = { $lte: 0 };
+    if (outOfStock === 'true') {
+      const outOfStockFilter = {
+        $or: [
+          { stock: { $lte: 0 } },
+          { 'sizes.stock': { $lte: 0 } },
+        ],
+      };
+
+      if (filters.$or) {
+        filters.$and = [{ $or: filters.$or }, outOfStockFilter];
+        delete filters.$or;
+      } else {
+        filters.$or = outOfStockFilter.$or;
+      }
+    }
     if (showUnpublished === 'true') filters.isPublished = false;
     filters.isDeleted = false;
 
 
     let sortOption = { createdAt: -1 };
-    if (sort === 'price_asc') sortOption = { 'sizes.price': 1 };
-    if (sort === 'price_desc') sortOption = { 'sizes.price': -1 };
+    if (sort === 'price_asc') sortOption = { price: 1, 'sizes.price': 1 };
+    if (sort === 'price_desc') sortOption = { price: -1, 'sizes.price': -1 };
     if (sort === 'rating') sortOption = { averageRating: -1 };
 
     const productVariants = await ProductVariant.find(filters)
-      .select('color label sizes isPublished images totalReviews averageRating')
+      .select('color label attributes sku price salePrice stock sizes isPublished images totalReviews averageRating')
       .populate('productId', 'title description coverImage')
       .sort(sortOption)
       .lean();
@@ -432,23 +519,26 @@ exports.getAllProducts = async (req, res) => {
           description: variant.productId.description,
           coverImage: variant.productId.coverImage,
           variants: [],
+          totalStock: 0,
+          stockSummary: { in_stock: 0, low_stock: 0, out_of_stock: 0 },
+          lowStockThreshold: LOW_STOCK_THRESHOLD,
         };
       }
 
-      const sizes = variant.sizes.map(size => ({
-        sizeId: size._id,
-        size: size.size,
-        sku: size.sku,
-        stock: size.stock,
-        price: size.price ? Number(size.price) : 0,
-        salePrice: size.salePrice ? Number(size.salePrice) : null,
-        discountEndDate: size.discountEndDate || null,
-      }));
+      const sizes = buildVariantSizes(variant);
+      const variantTotalStock = sizes.reduce((sum, size) => sum + toStockNumber(size.stock), 0);
+      const variantStockStatus = getStockStatus(variantTotalStock);
 
       groupedProductsMap[productId].variants.push({
         variantId: variant._id,
         color: variant.color,
         label: variant.label,
+        attributes: variant.attributes,
+        sku: variant.sku,
+        stock: variantTotalStock,
+        totalStock: variantTotalStock,
+        stockStatus: variantStockStatus,
+        lowStockThreshold: LOW_STOCK_THRESHOLD,
         isPublished: variant.isPublished,
         images: variant.images,
         averageRating: variant.averageRating,
@@ -457,14 +547,18 @@ exports.getAllProducts = async (req, res) => {
       });
 
       // ✅ Count if this variant is sellable
-      if (
-        variant.sizes.some(s => s.stock > 0)
-      ) {
+      groupedProductsMap[productId].totalStock += variantTotalStock;
+      groupedProductsMap[productId].stockSummary[variantStockStatus] += 1;
+
+      if (variantTotalStock > 0) {
         sellableCount++;
       }
     }
 
-    const groupedProducts = Object.values(groupedProductsMap);
+    const groupedProducts = Object.values(groupedProductsMap).map((product) => ({
+      ...product,
+      stockStatus: getStockStatus(product.totalStock),
+    }));
     const total = groupedProducts.length;
     const totalVariants = productVariants.length;
     const pageNum = parseInt(page);

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -120,6 +120,134 @@ const normalizeVariantShipping = (incomingShipping, existingShipping) => {
   return base;
 };
 
+const LOW_STOCK_THRESHOLD = 5;
+
+const hasOwnField = (value, field) =>
+  value && typeof value === "object" && Object.prototype.hasOwnProperty.call(value, field);
+
+const getFirstVariantSize = (variant) =>
+  Array.isArray(variant?.sizes) ? variant.sizes.find((size) => size && typeof size === "object") : null;
+
+const resolveVariantField = (variant, field) => {
+  if (hasOwnField(variant, field)) {
+    return { found: true, value: variant[field] };
+  }
+
+  const firstSize = getFirstVariantSize(variant);
+  if (hasOwnField(firstSize, field)) {
+    return { found: true, value: firstSize[field] };
+  }
+
+  return { found: false, value: undefined };
+};
+
+const parseNonNegativeVariantNumber = (variant, field, options = {}) => {
+  const { required = false, defaultValue } = options;
+  const resolved = resolveVariantField(variant, field);
+  const rawValue = resolved.value;
+
+  if (!resolved.found || rawValue === undefined || rawValue === null || rawValue === "") {
+    if (required) {
+      return { ok: false, error: `${field} is required` };
+    }
+
+    return {
+      ok: true,
+      found: false,
+      value: defaultValue,
+    };
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { ok: false, error: `${field} must be a non-negative number` };
+  }
+
+  return {
+    ok: true,
+    found: true,
+    value: parsed,
+  };
+};
+
+const resolveVariantSku = (variant) => {
+  const resolved = resolveVariantField(variant, "sku");
+  if (!resolved.found || resolved.value === undefined || resolved.value === null) {
+    return undefined;
+  }
+
+  const sku = String(resolved.value).trim();
+  return sku || undefined;
+};
+
+const normalizeVariantPayload = (variant, options = {}) => {
+  const { requirePrice = true, defaultStock = 0 } = options;
+  const price = parseNonNegativeVariantNumber(variant, "price", { required: requirePrice });
+  if (!price.ok) return price;
+
+  const salePrice = parseNonNegativeVariantNumber(variant, "salePrice");
+  if (!salePrice.ok) return salePrice;
+
+  const stock = parseNonNegativeVariantNumber(variant, "stock", { defaultValue: defaultStock });
+  if (!stock.ok) return stock;
+
+  return {
+    ok: true,
+    price: price.value,
+    hasPrice: price.found,
+    salePrice: salePrice.found ? salePrice.value : null,
+    hasSalePrice: salePrice.found,
+    stock: stock.value,
+    hasStock: stock.found,
+    sku: resolveVariantSku(variant),
+  };
+};
+
+const toDecimal128 = (value) => Decimal128.fromString(String(value));
+
+const toStockNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const getStockStatus = (stock, threshold = LOW_STOCK_THRESHOLD) => {
+  if (stock <= 0) return "out_of_stock";
+  if (stock <= threshold) return "low_stock";
+  return "in_stock";
+};
+
+const addStockMetadataToVariant = (variant, threshold = LOW_STOCK_THRESHOLD) => {
+  const stock = toStockNumber(variant.stock);
+
+  return {
+    ...variant,
+    stock,
+    totalStock: stock,
+    stockStatus: getStockStatus(stock, threshold),
+    lowStockThreshold: threshold,
+  };
+};
+
+const buildProductStockSummary = (variants, threshold = LOW_STOCK_THRESHOLD) => {
+  const variantsWithStock = variants.map((variant) => addStockMetadataToVariant(variant, threshold));
+  const totalStock = variantsWithStock.reduce((sum, variant) => sum + variant.stock, 0);
+  const stockSummary = variantsWithStock.reduce(
+    (summary, variant) => {
+      summary[variant.stockStatus] += 1;
+      return summary;
+    },
+    { in_stock: 0, low_stock: 0, out_of_stock: 0 }
+  );
+
+  return {
+    variantsWithStock,
+    totalStock,
+    stockSummary,
+    stockStatus: getStockStatus(totalStock, threshold),
+    lowStockThreshold: threshold,
+  };
+};
+
 
 /**
  * Generate SKU for variant
@@ -251,8 +379,12 @@ exports.createProductWithVariants = async (req, res) => {
 
 for (const variant of variants) {
   const attrMap = new Map(Object.entries(variant.attributes || {}));
+  const normalizedVariant = normalizeVariantPayload(variant);
+  if (!normalizedVariant.ok) {
+    return res.status(400).json({ error: normalizedVariant.error });
+  }
 
-  let sku = variant.sku;
+  let sku = normalizedVariant.sku;
 
   // If frontend didn't send SKU
   if (!sku) {
@@ -274,7 +406,7 @@ for (const variant of variants) {
 
   if (existingSku) {
     const newSku = await generateUniqueSKU(businessId, product._id, attrMap);
-    sku = `${onboarding.applicationId}-${newSku}`;
+    sku = onboarding?.applicationId ? `${onboarding.applicationId}-${newSku}` : newSku;
   }
 
   variantDocs.push({
@@ -283,11 +415,9 @@ for (const variant of variants) {
     ownerId: userId,
     attributes: attrMap,
     sku,
-    price: Decimal128.fromString(variant.price.toString()),
-    salePrice: variant.salePrice
-      ? Decimal128.fromString(variant.salePrice.toString())
-      : null,
-    stock: variant.stock || 0,
+    price: toDecimal128(normalizedVariant.price),
+    salePrice: normalizedVariant.hasSalePrice ? toDecimal128(normalizedVariant.salePrice) : null,
+    stock: normalizedVariant.stock,
     shipping: normalizeVariantShipping(variant.shipping),
     images: variant.images || [],
     isPublished: isPublished || false,
@@ -757,6 +887,10 @@ exports.updateProduct = async (req, res) => {
 
       for (const variant of variants) {
         const attrMap = new Map(Object.entries(variant.attributes || {}));
+        const normalizedVariant = normalizeVariantPayload(variant, { requirePrice: Boolean(!variant._id) });
+        if (!normalizedVariant.ok) {
+          return res.status(400).json({ error: normalizedVariant.error });
+        }
 
         // UPDATE existing variant
         if (variant._id) {
@@ -767,13 +901,15 @@ exports.updateProduct = async (req, res) => {
 
           if (existingVariant) {
             existingVariant.attributes = attrMap;
-            existingVariant.price = Decimal128.fromString(
-              variant.price.toString()
-            );
-            existingVariant.salePrice = variant.salePrice
-              ? Decimal128.fromString(variant.salePrice.toString())
-              : null;
-            existingVariant.stock = variant.stock || 0;
+            if (normalizedVariant.hasPrice) {
+              existingVariant.price = toDecimal128(normalizedVariant.price);
+            }
+            if (normalizedVariant.hasSalePrice) {
+              existingVariant.salePrice = toDecimal128(normalizedVariant.salePrice);
+            }
+            if (normalizedVariant.hasStock) {
+              existingVariant.stock = normalizedVariant.stock;
+            }
             existingVariant.shipping = normalizeVariantShipping(
               variant.shipping,
               existingVariant.shipping
@@ -812,11 +948,9 @@ exports.updateProduct = async (req, res) => {
             ownerId: userId,
             attributes: attrMap,
             sku,
-            price: Decimal128.fromString(variant.price.toString()),
-            salePrice: variant.salePrice
-              ? Decimal128.fromString(variant.salePrice.toString())
-              : null,
-            stock: variant.stock || 0,
+            price: toDecimal128(normalizedVariant.price),
+            salePrice: normalizedVariant.hasSalePrice ? toDecimal128(normalizedVariant.salePrice) : null,
+            stock: normalizedVariant.stock,
             shipping: normalizeVariantShipping(variant.shipping),
             images: variant.images || [],
             isPublished: isPublished || false
@@ -1001,7 +1135,8 @@ exports.getBusinessProducts = async (req, res) => {
           isDeleted: false,
         }).lean();
         
-        const totalStock = variants.reduce((sum, v) => sum + (v.stock || 0), 0);
+        const stockDetails = buildProductStockSummary(variants);
+        const totalStock = stockDetails.totalStock;
         const minPrice = variants.length > 0 
           ? Math.min(...variants.map(v => parseFloat(v.price?.toString() || 0)))
           : 0;
@@ -1013,6 +1148,10 @@ exports.getBusinessProducts = async (req, res) => {
           ...product,
           variantCount: variants.length,
           totalStock,
+          variants: stockDetails.variantsWithStock,
+          stockStatus: stockDetails.stockStatus,
+          stockSummary: stockDetails.stockSummary,
+          lowStockThreshold: stockDetails.lowStockThreshold,
           priceRange: {
             min: minPrice,
             max: maxPrice,
@@ -1102,27 +1241,33 @@ exports.addVariants = async (req, res) => {
     }
 
     // Create new variants with unique SKUs
-    const variantDocs = variants.map((variant) => {
+    const variantDocs = [];
+    for (const variant of variants) {
+      const normalizedVariant = normalizeVariantPayload(variant);
+      if (!normalizedVariant.ok) {
+        return res.status(400).json({ error: normalizedVariant.error });
+      }
+
       // Generate unique SKU for each variant
       const attributeMap = new Map(Object.entries(variant.attributes || {}));
       const timestamp = Date.now();
       const random = Math.floor(1000 + Math.random() * 9000);
-      const sku = variant.sku || `PRD-${timestamp}-${random}`;
+      const sku = normalizedVariant.sku || `PRD-${timestamp}-${random}`;
       
-      return {
+      variantDocs.push({
         productId: product._id,
         businessId: business._id,
         ownerId: req.user._id,
         attributes: attributeMap,
         sku: sku,
-        price: variant.price,
-        salePrice: variant.salePrice,
-        stock: variant.stock || 0,
+        price: toDecimal128(normalizedVariant.price),
+        salePrice: normalizedVariant.hasSalePrice ? toDecimal128(normalizedVariant.salePrice) : null,
+        stock: normalizedVariant.stock,
         shipping: normalizeVariantShipping(variant.shipping),
         images: variant.images || [],
         isPublished: product.isPublished,
-      };
-    });
+      });
+    }
 
     const savedVariants = await ProductVariant.insertMany(variantDocs);
     const variantIds = savedVariants.map(v => v._id);
@@ -1156,9 +1301,6 @@ exports.updateVariant = async (req, res) => {
     const {
       attributes,
       sku,
-      price,
-      salePrice,
-      stock,
       shipping,
       images,
       isPublished,
@@ -1169,6 +1311,10 @@ exports.updateVariant = async (req, res) => {
       return res.status(404).json({ error: 'Product not found' });
     }
 
+    if (product.ownerId.toString() !== req.user._id.toString()) {
+      return res.status(403).json({ error: 'Unauthorized' });
+    }
+
     if (!mongoose.Types.ObjectId.isValid(variantId)) {
   return res.status(400).json({ error: 'Invalid variant ID' });
 }
@@ -1176,6 +1322,14 @@ exports.updateVariant = async (req, res) => {
     const variant = await ProductVariant.findOne({ _id: variantId, productId });
     if (!variant) {
       return res.status(404).json({ error: 'Variant not found' });
+    }
+
+    const normalizedVariant = normalizeVariantPayload(req.body, {
+      requirePrice: false,
+      defaultStock: undefined,
+    });
+    if (!normalizedVariant.ok) {
+      return res.status(400).json({ error: normalizedVariant.error });
     }
 
     // Handle image cleanup if changed
@@ -1189,10 +1343,12 @@ exports.updateVariant = async (req, res) => {
 
     // Update variant
     if (attributes) variant.attributes = new Map(Object.entries(attributes));
-    if (sku) variant.sku = sku;
-    if (price !== undefined) variant.price = price;
-    if (salePrice !== undefined) variant.salePrice = salePrice;
-    if (stock !== undefined) variant.stock = stock;
+    if (sku || normalizedVariant.sku) variant.sku = normalizedVariant.sku || sku;
+    if (normalizedVariant.hasPrice) variant.price = toDecimal128(normalizedVariant.price);
+    if (normalizedVariant.hasSalePrice) {
+      variant.salePrice = normalizedVariant.hasSalePrice ? toDecimal128(normalizedVariant.salePrice) : null;
+    }
+    if (normalizedVariant.hasStock) variant.stock = normalizedVariant.stock;
     if (shipping !== undefined) {
       variant.shipping = normalizeVariantShipping(shipping, variant.shipping);
     }

--- a/docs/backend/API_CONTRACT_AS_BUILT.md
+++ b/docs/backend/API_CONTRACT_AS_BUILT.md
@@ -78,6 +78,12 @@
 
 ---
 
+## Vendor product stock
+
+Vendor product inventory uses `ProductVariant.stock` as the source of truth. The vendor inventory endpoints now expose derived stock metadata while keeping existing fields backward compatible. See [`docs/product-stock-contract.md`](../product-stock-contract.md) for the route matrix, request payloads, response fields, QA checklist, and release limitations.
+
+---
+
 ## Public marketplace
 
 ### GET `/api/public/search`

--- a/docs/product-stock-contract.md
+++ b/docs/product-stock-contract.md
@@ -1,0 +1,68 @@
+# Product Stock Contract
+
+Status: release-readiness sweep for vendor inventory, July 3, 2026.
+
+This document records the backend contract used by the vendor inventory dashboard. It is intentionally scoped to product variant stock and does not change checkout, Stripe, payouts, subscriptions, or webhook behavior.
+
+## Source of Truth
+
+- `ProductVariant.stock` is the authoritative stock field for vendor product inventory.
+- Legacy callers may still send stock inside the first `sizes[]` row. Product create/update paths normalize that fallback into top-level variant stock for backward compatibility.
+- Product-level stock values are derived summaries only. The backend now exposes aggregate stock metadata so frontend screens do not have to infer inventory state from stale nested size data.
+- Negative stock is invalid. Stock decrement operations that would go below zero are rejected.
+
+## Route Matrix
+
+| Purpose | Method | Route | Auth | Request contract | Response contract |
+| --- | --- | --- | --- | --- | --- |
+| Vendor product inventory | GET | `/api/private/products/list` | `authenticate`, `isBusinessOwner` | Query supports `businessId`, pagination, filters, and `outOfStock=true` | Grouped product rows with `variants[]`, `totalStock`, `stockStatus`, `stockSummary`, and `lowStockThreshold` |
+| Vendor products by business | GET | `/api/product/business/:businessId` | `authenticate`, `isBusinessOwner` | Path `businessId` owned by current vendor | Products with `variants[]`, `variantCount`, `totalStock`, `stockStatus`, `stockSummary`, and `lowStockThreshold` |
+| Create product with variants | POST | `/api/product/` | `authenticate`, `isBusinessOwner` | Variants may send top-level `sku`, `stock`, `price`, `salePrice`, `attributes`; legacy `sizes[0]` fallback is accepted | Product and variant records using normalized top-level stock |
+| Add variants | POST | `/api/product/add-variants/:productId` | `authenticate`, `isBusinessOwner` | Same normalized variant payload as product create | Created variants using normalized top-level stock |
+| Get variant | GET | `/api/product/get-variant/:productId/:variantId` | `authenticate`, `isBusinessOwner` | Product and variant ids must belong to current vendor | Variant record, preserving existing fields |
+| Edit variant | PUT | `/api/product/update-variant/:productId/:variantId` | `authenticate`, `isBusinessOwner` | Same normalized variant payload; owner is checked before save | Updated variant record, preserving existing fields |
+| Quick stock update | PATCH | `/api/product/update-variantstock/:variantId` | `authenticate`, `isBusinessOwner` | `{ "operation": "set" | "increment" | "decrement", "stock": number }` | `{ success, message, stock }` with updated numeric stock |
+
+## Stock Status Rules
+
+The current backend response uses these normalized statuses:
+
+| Status | Rule |
+| --- | --- |
+| `out_of_stock` | Total derived stock is `0` |
+| `low_stock` | Total derived stock is greater than `0` and less than or equal to `lowStockThreshold` |
+| `in_stock` | Total derived stock is greater than `lowStockThreshold` |
+
+The current `lowStockThreshold` is `5`.
+
+## Failure Behavior
+
+- Invalid stock values return a client error instead of silently saving malformed inventory.
+- Vendor ownership is checked before variant edits and stock updates.
+- The private product list can filter stock issue rows with `outOfStock=true`.
+- Existing response fields remain in place for backward compatibility.
+
+## Verification
+
+Automated coverage includes:
+
+- zero-stock, low-stock, and in-stock status derivation
+- quick stock set/increment/decrement
+- decrement rejection below zero
+- top-level stock normalization
+- legacy `sizes[0]` stock fallback
+- vendor private product list stock metadata
+
+Manual release smoke should still verify:
+
+1. A vendor can create a product variant with stock.
+2. The inventory page displays that stock.
+3. The vendor can set stock to `0` and see the row as out of stock.
+4. The vendor can increase stock and see the row leave the out-of-stock filter.
+5. The public product detail/cart behavior remains unchanged except for existing backend stock validation.
+
+## Limitations
+
+- This contract covers product inventory only. Service and food listing availability are separate flows.
+- This pass does not alter checkout stock reservation, Stripe payment, payout, subscription, or webhook logic.
+- Public cart and paid checkout behavior require separate staging smoke with approved test accounts.

--- a/tests/vendor/vendor-variant-stock.test.js
+++ b/tests/vendor/vendor-variant-stock.test.js
@@ -40,6 +40,12 @@ function buildVariant(stock = 5) {
   };
 }
 
+function mockQueryResult(value) {
+  return {
+    sort: async () => value,
+  };
+}
+
 function loadStockController(variant = buildVariant()) {
   const originalLoad = Module._load;
 
@@ -68,6 +74,77 @@ function loadStockController(variant = buildVariant()) {
   return controller;
 }
 
+function loadProductControllerWithMocks(mocks) {
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Product')) return mocks.Product || {};
+    if (request.endsWith('models/ProductVariant')) return mocks.ProductVariant || {};
+    if (request.endsWith('models/Business')) return mocks.Business || {};
+    if (request.endsWith('models/Subscription')) return mocks.Subscription || {};
+    if (request.endsWith('models/SubscriptionPlan')) return mocks.SubscriptionPlan || {};
+    if (request.endsWith('models/VendorOnboardingStage1')) {
+      return mocks.VendorOnboardingStage1 || { findOne: async () => null };
+    }
+    if (request.endsWith('utils/deleteCloudinaryFile')) {
+      return async () => {};
+    }
+    if (request.endsWith('@aws-sdk/client-s3')) {
+      return awsMocks();
+    }
+    if (request.endsWith('@aws-sdk/s3-request-presigner')) {
+      return { getSignedUrl: async () => 'https://signed.example/upload' };
+    }
+    if (request === 'express-validator') {
+      return { validationResult: () => ({ isEmpty: () => true, array: () => [] }) };
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[productControllerPath];
+  const controller = require(productControllerPath);
+  Module._load = originalLoad;
+  return controller;
+}
+
+function buildVariantMutationMocks(captured) {
+  const businessId = '507f1f77bcf86cd799439012';
+  const productId = '507f1f77bcf86cd799439013';
+
+  return {
+    Product: {
+      findById: async () => ({
+        _id: productId,
+        businessId,
+        ownerId,
+        isDeleted: false,
+        isPublished: false,
+      }),
+      findByIdAndUpdate: async () => ({}),
+      countDocuments: async () => 0,
+    },
+    ProductVariant: {
+      countDocuments: async () => 0,
+      insertMany: async (docs) => {
+        captured.docs = docs;
+        return docs.map((doc, index) => ({ ...doc, _id: `variant-${index}` }));
+      },
+    },
+    Business: {
+      findById: async () => ({ _id: businessId }),
+    },
+    Subscription: {
+      findOne: () => mockQueryResult({
+        subscriptionPlanId: '507f1f77bcf86cd799439014',
+      }),
+    },
+    SubscriptionPlan: {
+      findById: async () => ({ limits: { productListings: 10 } }),
+    },
+  };
+}
+
 test('updateVariantStock sets stock with operation set', async () => {
   const variant = buildVariant(2);
   const { updateVariantStock } = loadStockController(variant);
@@ -84,6 +161,44 @@ test('updateVariantStock sets stock with operation set', async () => {
 
   assert.equal(res.statusCode, 200);
   assert.equal(variant.stock, 10);
+});
+
+test('updateVariantStock increments stock', async () => {
+  const variant = buildVariant(2);
+  const { updateVariantStock } = loadStockController(variant);
+  const res = mockResponse();
+
+  await updateVariantStock(
+    {
+      params: { variantId: 'var-1' },
+      user: { _id: ownerId },
+      body: { stock: 3, operation: 'increment' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(variant.stock, 5);
+  assert.equal(res.body.stock, 5);
+});
+
+test('updateVariantStock decrements stock', async () => {
+  const variant = buildVariant(5);
+  const { updateVariantStock } = loadStockController(variant);
+  const res = mockResponse();
+
+  await updateVariantStock(
+    {
+      params: { variantId: 'var-1' },
+      user: { _id: ownerId },
+      body: { stock: 2, operation: 'decrement' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(variant.stock, 3);
+  assert.equal(res.body.stock, 3);
 });
 
 test('updateVariantStock rejects negative set values', async () => {
@@ -170,4 +285,120 @@ test('updateVariantStock returns 404 for missing variant', async () => {
   );
 
   assert.equal(res.statusCode, 404);
+});
+
+test('addVariants preserves top-level stock over nested size stock', async () => {
+  const captured = {};
+  const { addVariants } = loadProductControllerWithMocks(buildVariantMutationMocks(captured));
+  const res = mockResponse();
+
+  await addVariants(
+    {
+      params: { productId: '507f1f77bcf86cd799439013' },
+      user: { _id: ownerId },
+      body: {
+        variants: [
+          {
+            attributes: { Size: 'M' },
+            sku: 'TOP-STOCK',
+            price: 12,
+            stock: 7,
+            sizes: [{ sku: 'NESTED-STOCK', price: 99, stock: 2 }],
+          },
+        ],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(captured.docs[0].stock, 7);
+  assert.equal(captured.docs[0].sku, 'TOP-STOCK');
+  assert.equal(captured.docs[0].price.toString(), '12');
+});
+
+test('addVariants maps nested sizes[0] stock when top-level stock is absent', async () => {
+  const captured = {};
+  const { addVariants } = loadProductControllerWithMocks(buildVariantMutationMocks(captured));
+  const res = mockResponse();
+
+  await addVariants(
+    {
+      params: { productId: '507f1f77bcf86cd799439013' },
+      user: { _id: ownerId },
+      body: {
+        variants: [
+          {
+            attributes: { Size: 'L' },
+            sizes: [{ sku: 'NESTED-STOCK', price: '19.5', salePrice: '15.5', stock: '9' }],
+          },
+        ],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(captured.docs[0].stock, 9);
+  assert.equal(captured.docs[0].sku, 'NESTED-STOCK');
+  assert.equal(captured.docs[0].price.toString(), '19.5');
+  assert.equal(captured.docs[0].salePrice.toString(), '15.5');
+});
+
+test('getBusinessProducts includes stock metadata from real variant stock', async () => {
+  const productId = '507f1f77bcf86cd799439013';
+  const businessId = '507f1f77bcf86cd799439012';
+  const productFindChain = {
+    populate() { return this; },
+    sort() { return this; },
+    lean: async () => [
+      {
+        _id: productId,
+        title: 'Stocked Product',
+        businessId,
+        ownerId,
+        isDeleted: false,
+      },
+    ],
+  };
+  const variantFindChain = {
+    lean: async () => [
+      { _id: 'var-zero', stock: 0, price: 10, isDeleted: false },
+      { _id: 'var-low', stock: 3, price: 11, isDeleted: false },
+      { _id: 'var-ok', stock: 8, price: 12, isDeleted: false },
+    ],
+  };
+
+  const { getBusinessProducts } = loadProductControllerWithMocks({
+    Product: {
+      find: () => productFindChain,
+    },
+    ProductVariant: {
+      find: () => variantFindChain,
+    },
+    Business: {
+      findOne: async () => ({ _id: businessId, owner: ownerId }),
+    },
+  });
+  const res = mockResponse();
+
+  await getBusinessProducts(
+    {
+      params: { businessId },
+      user: { _id: ownerId },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.products[0].totalStock, 11);
+  assert.equal(res.body.products[0].stockStatus, 'in_stock');
+  assert.deepEqual(res.body.products[0].stockSummary, {
+    in_stock: 1,
+    low_stock: 1,
+    out_of_stock: 1,
+  });
+  assert.equal(res.body.products[0].variants[0].stockStatus, 'out_of_stock');
+  assert.equal(res.body.products[0].variants[1].stockStatus, 'low_stock');
+  assert.equal(res.body.products[0].variants[2].stockStatus, 'in_stock');
 });


### PR DESCRIPTION
﻿## Summary
- Normalizes vendor product variant stock around `ProductVariant.stock` as the backend source of truth.
- Adds stock metadata to vendor product list responses so the frontend can show out-of-stock, low-stock, and total-stock state reliably.
- Preserves backward compatibility for legacy `sizes[0]` stock/price/sku payloads.
- Adds backend contract tests and product stock contract documentation.

## Route Matrix
| Purpose | Method | Route |
| --- | --- | --- |
| Vendor inventory list | GET | `/api/private/products/list` |
| Vendor products by business | GET | `/api/product/business/:businessId` |
| Create product with variants | POST | `/api/product/` |
| Add variants | POST | `/api/product/add-variants/:productId` |
| Edit variant | PUT | `/api/product/update-variant/:productId/:variantId` |
| Quick stock update | PATCH | `/api/product/update-variantstock/:variantId` |
| Get variant | GET | `/api/product/get-variant/:productId/:variantId` |

## Validation
- `npm test` passed.
- `npm run test:contract --if-present` passed.
- `npm run lint --if-present` passed.

## Safety Notes
- No Stripe checkout, payment intent, Connect payout, subscription, or webhook logic changed.
- No `app.js` middleware order changed.
- `GET /api/featured-products` remains canonical.
- `/api/products/featured` was not added.
- No secrets or environment values included.

## Manual QA Checklist
- Vendor creates a product with variant stock.
- Vendor inventory page shows stock metadata.
- Vendor sets stock to `0` and sees out-of-stock status.
- Vendor increments stock and sees the row leave the out-of-stock filter.
- Public product detail/cart stock behavior is smoke tested on staging.
