### PR TITLE
Fix service draft lookup contract

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -222,14 +222,17 @@ exports.createService = async (req, res) => {
       });
     }
 
+    const publishValidation = validatePublishRequest({ isPublished, normalizedServices });
+    if (!publishValidation.ok) {
+      return res.status(400).json(formatValidationErrorResponse(
+        publishValidation.fieldErrors,
+        publishValidation.message
+      ));
+    }
+
     const childValidation = validateChildServices(normalizedServices);
     if (!childValidation.ok) {
       return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
-    }
-
-    const publishValidation = validatePublishRequest({ isPublished, normalizedServices });
-    if (!publishValidation.ok) {
-      return res.status(400).json(formatValidationErrorResponse(publishValidation.fieldErrors));
     }
 
     const subscription = await Subscription.findOne({
@@ -745,28 +748,39 @@ exports.updateService = async (req, res) => {
       }
     }
 
+    const requestedPublish =
+      req.body.isPublished === true || req.body.isPublished === 'true';
+
     let nextServices = service.services;
     if (req.body.services !== undefined) {
       const payload = normalizeServicePayload({
         ...req.body,
         services: req.body.services,
       });
-      const childValidation = validateChildServices(payload.normalizedServices);
-      if (!childValidation.ok) {
-        return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
-      }
 
-      const otherChildServiceCount = await getOwnerChildServiceCount(userId, service._id);
-      if (otherChildServiceCount + payload.normalizedServices.length > serviceLimit) {
-        return res.status(403).json({
-          message: `Service listing limit reached. You can add only ${Math.max(serviceLimit - otherChildServiceCount, 0)} more child services.`,
-        });
-      }
+      if (payload.normalizedServices.length === 0 && !requestedPublish) {
+        nextServices = [];
+        service.services = nextServices;
+        service.price = 0;
+        service.duration = '';
+      } else {
+        const childValidation = validateChildServices(payload.normalizedServices);
+        if (!childValidation.ok) {
+          return res.status(400).json(formatValidationErrorResponse(childValidation.fieldErrors));
+        }
 
-      nextServices = payload.normalizedServices;
-      service.services = nextServices;
-      service.price = getMinimumChildServicePrice(nextServices, service.price);
-      service.duration = '';
+        const otherChildServiceCount = await getOwnerChildServiceCount(userId, service._id);
+        if (otherChildServiceCount + payload.normalizedServices.length > serviceLimit) {
+          return res.status(403).json({
+            message: `Service listing limit reached. You can add only ${Math.max(serviceLimit - otherChildServiceCount, 0)} more child services.`,
+          });
+        }
+
+        nextServices = payload.normalizedServices;
+        service.services = nextServices;
+        service.price = getMinimumChildServicePrice(nextServices, service.price);
+        service.duration = '';
+      }
     }
 
     const updatableFields = [
@@ -789,7 +803,7 @@ exports.updateService = async (req, res) => {
     }
 
     if (req.body.isPublished !== undefined) {
-      service.isPublished = req.body.isPublished === true || req.body.isPublished === 'true';
+      service.isPublished = requestedPublish;
     }
 
     const publishValidation = validatePublishRequest({
@@ -797,7 +811,10 @@ exports.updateService = async (req, res) => {
       normalizedServices: nextServices,
     });
     if (!publishValidation.ok) {
-      return res.status(400).json(formatValidationErrorResponse(publishValidation.fieldErrors));
+      return res.status(400).json(formatValidationErrorResponse(
+        publishValidation.fieldErrors,
+        publishValidation.message
+      ));
     }
 
     const nextGalleryImages = req.body.images !== undefined ? req.body.images : service.images;
@@ -856,6 +873,53 @@ exports.getServiceById = async (req, res) => {
     console.error('Failed to fetch service:', err.message);
     res.status(500).json({
       message: 'Internal server error'
+    });
+  }
+};
+
+exports.getPrivateBusinessServiceByBusinessId = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { businessId } = req.params;
+
+    const business = await Business.findOne({ _id: businessId, owner: userId })
+      .select('_id isActive isApproved owner businessName name');
+
+    if (!business) {
+      return res.status(403).json({
+        success: false,
+        message: 'You do not own this business.',
+      });
+    }
+
+    const service = await Service.findOne({ businessId, ownerId: userId })
+      .sort({ createdAt: -1 })
+      .populate('categoryId', 'name')
+      .populate('subcategoryId', 'name')
+      .populate('businessId', 'businessName name owner isActive isApproved');
+
+    if (!service) {
+      return res.status(404).json({
+        success: false,
+        message: 'Service draft not found for this business.',
+      });
+    }
+
+    const response = formatOwnerServiceResponse(
+      service,
+      business,
+      'Service draft retrieved successfully.'
+    );
+
+    return res.status(200).json({
+      ...response,
+      hasChildServices: Array.isArray(service.services) && service.services.length > 0,
+    });
+  } catch (err) {
+    console.error('Failed to fetch private business service:', err.message);
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
     });
   }
 };

--- a/docs/backend/API_CONTRACT_AS_BUILT.md
+++ b/docs/backend/API_CONTRACT_AS_BUILT.md
@@ -84,6 +84,12 @@ Vendor product inventory uses `ProductVariant.stock` as the source of truth. The
 
 ---
 
+## Vendor service drafts
+
+Vendor service draft lookup uses authenticated `GET /api/service/private/business/:businessId`. Public `GET /api/service/business-service/:id` still hides unpublished services and must not be used for vendor draft prefill. See [`docs/service-draft-lookup-contract.md`](../service-draft-lookup-contract.md).
+
+---
+
 ## Public marketplace
 
 ### GET `/api/public/search`

--- a/docs/service-draft-lookup-contract.md
+++ b/docs/service-draft-lookup-contract.md
@@ -1,0 +1,43 @@
+# Service Draft Lookup Contract
+
+Status: launch corrective fix, July 3, 2026.
+
+This contract separates vendor-owned draft lookup from public service lookup. It is scoped to service listing save/publish behavior and does not change uploads, Stripe, checkout, payouts, subscriptions, webhooks, or middleware ordering.
+
+## Routes
+
+| Purpose | Method | Route | Auth | Visibility |
+| --- | --- | --- | --- | --- |
+| Vendor draft lookup by business | GET | `/api/service/private/business/:businessId` | `authenticate`, `isBusinessOwner` | Returns the current vendor's parent service whether published or unpublished |
+| Public service lookup by service or business | GET | `/api/service/business-service/:id` | Public | Returns only publicly visible published services for active businesses |
+| Parent draft create | POST | `/api/service/parent` | `authenticate`, `isBusinessOwner` | Creates an unpublished parent service with no child offerings |
+| Parent update/publish | PUT | `/api/service/:id` | `authenticate`, `isBusinessOwner` | Updates the vendor-owned parent service by service id |
+| Child offering add | POST | `/api/service/add-child-services` | `authenticate`, `isBusinessOwner` | Adds child offerings to the parent service |
+
+## Publish Rule
+
+Saving a draft may persist parent service details and media without child offerings.
+
+Publishing requires at least one valid child service offering with:
+
+- `name`
+- `price`
+- `durationMinutes` or parseable `duration`
+
+If publish is requested without child offerings, the backend returns HTTP 400 with:
+
+```json
+{
+  "success": false,
+  "message": "Add at least one service offering before publishing.",
+  "error": "Add at least one service offering before publishing.",
+  "fieldErrors": {
+    "services": "Add at least one service offering before publishing.",
+    "isPublished": "Add at least one service offering before publishing."
+  }
+}
+```
+
+## Regression Guard
+
+The add-service frontend must not use `GET /api/service/business-service/:businessId` for vendor draft detection. That route is public and intentionally hides unpublished services.

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -156,6 +156,8 @@ const deriveParentPricing = (children = []) => ({
   duration: children.length > 0 ? '' : '',
 });
 
+const PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE = 'Add at least one service offering before publishing.';
+
 const evaluateServicePublication = ({ service, business }) => {
   const isPublished = Boolean(service?.isPublished);
   const children = Array.isArray(service?.services) ? service.services : [];
@@ -205,13 +207,25 @@ const validatePublishRequest = ({ isPublished, normalizedServices }) => {
     return { ok: true, fieldErrors: {} };
   }
 
+  if (!Array.isArray(normalizedServices) || normalizedServices.length === 0) {
+    return {
+      ok: false,
+      message: PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
+      fieldErrors: {
+        services: PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
+        isPublished: PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
+      },
+    };
+  }
+
   const validation = validateChildServices(normalizedServices);
   if (!validation.ok) {
     return {
       ok: false,
+      message: 'Add at least one service offering with name, price, and duration before publishing.',
       fieldErrors: {
         ...validation.fieldErrors,
-        isPublished: 'Cannot publish a service without valid child service data.',
+        isPublished: 'Add at least one service offering with name, price, and duration before publishing.',
       },
     };
   }
@@ -258,6 +272,7 @@ module.exports = {
   validateChildServices,
   validatePublishRequest,
   deriveParentPricing,
+  PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
   getMinimumChildServicePrice,
   evaluateServicePublication,
   formatOwnerServiceResponse,

--- a/routes/serviceRoutes.js
+++ b/routes/serviceRoutes.js
@@ -1,6 +1,19 @@
 const express = require('express');
 const router = express.Router();
-const { createService, getMyServices, deleteService, updateService, getServiceById, getBusinessServiceById, getServiceUploadUrl, createParentService, addChildServices, getParentServices, getChildServices } = require('../controllers/serviceController');
+const {
+  createService,
+  getMyServices,
+  deleteService,
+  updateService,
+  getServiceById,
+  getBusinessServiceById,
+  getPrivateBusinessServiceByBusinessId,
+  getServiceUploadUrl,
+  createParentService,
+  addChildServices,
+  getParentServices,
+  getChildServices,
+} = require('../controllers/serviceController');
 const { deleteChildService } = require('../controllers/serviceChildController');
 const authenticate = require('../middlewares/authenticate');
 const isBusinessOwner = require('../middlewares/isBusinessOwner');
@@ -62,6 +75,13 @@ router.get(
   authenticate,
   isBusinessOwner,
   getMyServices
+);
+
+router.get(
+  '/private/business/:businessId',
+  authenticate,
+  isBusinessOwner,
+  getPrivateBusinessServiceByBusinessId
 );
 
 router.get(

--- a/tests/service/service-draft-lookup-contract.test.js
+++ b/tests/service/service-draft-lookup-contract.test.js
@@ -1,0 +1,191 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(__dirname, '../../controllers/serviceController.js');
+
+const ownerId = '507f1f77bcf86cd799439011';
+const otherOwnerId = '507f1f77bcf86cd799439099';
+const businessId = '507f1f77bcf86cd799439012';
+const serviceId = '507f1f77bcf86cd799439013';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function makeQuery(value) {
+  const exec = async () => value;
+  const query = {
+    sort: () => query,
+    populate: () => query,
+    select: () => query,
+    lean: () => exec(),
+    exec,
+    then: (resolve, reject) => exec().then(resolve, reject),
+  };
+  return query;
+}
+
+function buildBusiness(overrides = {}) {
+  return {
+    _id: businessId,
+    owner: ownerId,
+    businessName: 'QA Services',
+    isActive: true,
+    isApproved: true,
+    ...overrides,
+  };
+}
+
+function buildService(overrides = {}) {
+  const service = {
+    _id: serviceId,
+    ownerId,
+    businessId: {
+      _id: businessId,
+      owner: ownerId,
+      businessName: 'QA Services',
+    },
+    title: 'Draft services',
+    description: 'Draft parent',
+    categoryId: { _id: '507f1f77bcf86cd799439014', name: 'Beauty' },
+    subcategoryId: { _id: '507f1f77bcf86cd799439015', name: 'Hair' },
+    isPublished: false,
+    coverImage: 'https://example.com/cover.jpg',
+    images: ['https://example.com/gallery.jpg'],
+    services: [],
+    businessHours: [],
+    save: async function save() { return this; },
+    ...overrides,
+  };
+  service.toObject = () => ({ ...service });
+  return service;
+}
+
+function loadController(options = {}) {
+  const {
+    service = buildService(),
+    business = buildBusiness(),
+    authorized = true,
+  } = options;
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request.endsWith('models/Service')) {
+      return {
+        findById: () => makeQuery(null),
+        findOne: (query) => {
+          if (query.businessId === businessId && (!query.ownerId || query.ownerId === ownerId)) {
+            return makeQuery(service);
+          }
+          return makeQuery(null);
+        },
+        find: () => makeQuery([]),
+        startSession: async () => ({
+          startTransaction: () => {},
+          commitTransaction: async () => {},
+          abortTransaction: async () => {},
+          endSession: () => {},
+        }),
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findOne: (query) => {
+          if (query._id === businessId && query.owner && query.owner !== ownerId) {
+            return makeQuery(null);
+          }
+          if (query._id === businessId && query.owner === ownerId && authorized) {
+            return makeQuery(business);
+          }
+          if (query._id === businessId && query.isActive === true) {
+            return makeQuery(business);
+          }
+          return makeQuery(null);
+        },
+        findById: async () => business,
+      };
+    }
+    if (request.endsWith('models/Subscription')) {
+      return { findOne: () => ({ sort: async () => ({ subscriptionPlanId: 'plan-1' }) }) };
+    }
+    if (request.endsWith('models/SubscriptionPlan')) {
+      return { findById: async () => ({ limits: { serviceListings: 10, imageLimit: 5 } }) };
+    }
+    if (request.endsWith('models/PendingImage')) {
+      return { deleteMany: async () => {}, deleteOne: async () => {} };
+    }
+    if (request.endsWith('utils/deleteCloudinaryFile')) return async () => {};
+    if (request.endsWith('@aws-sdk/client-s3')) {
+      return {
+        S3Client: class S3Client {},
+        PutObjectCommand: class PutObjectCommand {},
+      };
+    }
+    if (request.endsWith('@aws-sdk/s3-request-presigner')) {
+      return { getSignedUrl: async () => 'signed-url' };
+    }
+    if (request.endsWith('models/ServiceCategory')) return {};
+    if (request.endsWith('models/ServiceSubcategory')) return {};
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+  return controller;
+}
+
+test('private business service lookup returns unpublished parent service for owner', async () => {
+  const controller = loadController({
+    service: buildService({ isPublished: false, services: [] }),
+  });
+  const res = mockResponse();
+
+  await controller.getPrivateBusinessServiceByBusinessId(
+    { user: { _id: ownerId }, params: { businessId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.service._id, serviceId);
+  assert.equal(res.body.service.isPublished, false);
+  assert.equal(res.body.hasChildServices, false);
+});
+
+test('private business service lookup rejects unauthorized owner', async () => {
+  const controller = loadController();
+  const res = mockResponse();
+
+  await controller.getPrivateBusinessServiceByBusinessId(
+    { user: { _id: otherOwnerId }, params: { businessId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 403);
+});
+
+test('public business-service lookup still hides unpublished parent service', async () => {
+  const controller = loadController({
+    service: buildService({ isPublished: false }),
+  });
+  const res = mockResponse();
+
+  await controller.getBusinessServiceById({ params: { id: businessId } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Business service not found.');
+});

--- a/tests/service/service-payload-contract.test.js
+++ b/tests/service/service-payload-contract.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   normalizeServicePayload,
+  PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
   validateChildServices,
   validatePublishRequest,
   evaluateServicePublication,
@@ -68,6 +69,18 @@ test('validatePublishRequest rejects publish without valid children', () => {
 
   assert.equal(result.ok, false);
   assert.ok(result.fieldErrors.isPublished);
+});
+
+test('validatePublishRequest uses clear copy when publishing without child services', () => {
+  const result = validatePublishRequest({
+    isPublished: true,
+    normalizedServices: [],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.message, PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE);
+  assert.equal(result.fieldErrors.services, PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE);
+  assert.equal(result.fieldErrors.isPublished, PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE);
 });
 
 test('evaluateServicePublication returns SERVICE_UNPUBLISHED for drafts', () => {

--- a/tests/service/service-publication-visibility.test.js
+++ b/tests/service/service-publication-visibility.test.js
@@ -367,3 +367,24 @@ test('updateService publish response exposes publication block without duplicate
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.data.publication.isPublished, true);
 });
+
+test('updateService returns clear validation when publishing without child services', async () => {
+  const draft = buildServiceDoc({ isPublished: false, services: [] });
+  const { controller } = loadServiceController({
+    existingService: draft,
+  });
+  const res = mockResponse();
+
+  await controller.updateService(
+    {
+      user: { _id: ownerId },
+      params: { id: serviceId },
+      body: { isPublished: true },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, 'Add at least one service offering before publishing.');
+  assert.equal(res.body.fieldErrors.services, 'Add at least one service offering before publishing.');
+});


### PR DESCRIPTION
﻿## Summary
- Adds authenticated vendor-owned draft lookup: `GET /api/service/private/business/:businessId`.
- Keeps public `GET /api/service/business-service/:id` strict so unpublished services remain hidden.
- Allows draft parent service updates without child offerings while keeping publish strict.
- Returns clear publish validation copy: "Add at least one service offering before publishing."
- Adds backend service contract tests and docs.

## Root Cause
The Add Service frontend was using the public `business-service` route for vendor draft detection. That route correctly returns 404 for unpublished parent services, so the UI could lose the parent service id and then hit update/publish validation paths with the wrong state.

## Validation
- `node --test tests/service/service-payload-contract.test.js tests/service/service-publication-visibility.test.js tests/service/service-draft-lookup-contract.test.js` passed.
- `npm test` passed.
- `npm run lint --if-present` passed.

## Safety Notes
- No S3 upload contract changes.
- No Stripe, checkout, Connect, payout, subscription, webhook, or middleware-order changes.
- `GET /api/featured-products` remains canonical.
- `/api/products/featured` was not added.
- No secrets or environment values included.

## Manual Smoke Checklist
- Login as a service business owner.
- Upload cover/gallery images on Add Service.
- Save draft without child offerings and confirm images persist.
- Try publishing without offerings and confirm 400 clear validation if frontend guard is bypassed.
- Add a child offering with name, price, and duration.
- Publish and confirm public visibility only after publish succeeds.
