### PR TITLE
Fix P0 checkout cart coupon and total integrity

### DIFF
--- a/controllers/customer/cartController.js
+++ b/controllers/customer/cartController.js
@@ -17,6 +17,7 @@ const {
     getPublicMarketplaceBusinessBlock,
     isPublicMarketplaceBusiness,
 } = require('../../lib/marketplace/businessEligibility');
+const { evaluateCouponDiscount } = require('../../utils/couponDiscount');
 
 const toNum = (value) => {
     if (value && typeof value === 'object' && value.$numberDecimal != null) {
@@ -47,7 +48,11 @@ const getEffectiveShipping = (productDoc, variantDoc) => {
 };
 
 const resolveRequestedShippingMethod = (body) => {
-    return body?.shippingMethod || body?.shippingType || body?.shippingOption || body?.shipping?.method || body?.shipping?.type || null;
+    const raw = body?.shippingMethod || body?.shippingType || body?.shippingOption || body?.shipping?.method || body?.shipping?.type || null;
+    if (!raw) return null;
+    const requested = String(raw).trim().toLowerCase();
+    const validMethods = ['standard', 'overnight', 'local'];
+    return validMethods.includes(requested) ? requested : null;
 };
 
 const resolveRequestedDeliverySpeed = (source) => {
@@ -84,7 +89,7 @@ const resolveShippingSelection = (productDoc, variantDoc, requestedMethod) => {
     };
 };
 
-const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc }) => {
+const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc, couponCode }) => {
     const subtotalAmount = items.reduce(
         (sum, item) => sum + (Number(item.lineTotalAmount || 0)),
         0
@@ -108,6 +113,30 @@ const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc }) 
             .lean()
         : null);
 
+    let discount = null;
+    let discountAmount = 0;
+    let discountedSubtotal = subtotalAmount;
+
+    if (couponCode && business?._id) {
+        const couponResult = await evaluateCouponDiscount({
+            couponCode,
+            businessId: business._id,
+            subtotalAmount,
+        });
+
+        if (!couponResult.ok) {
+            return { error: couponResult };
+        }
+
+        discountAmount = couponResult.discountAmount;
+        discountedSubtotal = couponResult.discountedSubtotal;
+        discount = {
+            couponCode: couponResult.couponCode,
+            discountAmount,
+            discountedSubtotal,
+        };
+    }
+
     let shipping = null;
     let shippingError = null;
 
@@ -117,7 +146,7 @@ const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc }) 
                 business.shippingSettings,
                 {
                     deliverySpeed,
-                    subtotal: subtotalAmount,
+                    subtotal: discountedSubtotal,
                     totalQuantity,
                 }
             );
@@ -154,9 +183,12 @@ const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc }) 
         taxTotal,
         taxIncluded: true,
         totalQuantity,
+        discount,
+        discountAmount,
+        discountedSubtotal,
         shipping,
         shippingError,
-        totalAmount: subtotalAmount + shippingAmount,
+        totalAmount: discountedSubtotal + shippingAmount,
         currency: 'USD',
     };
 };
@@ -358,211 +390,240 @@ const addItemToCart = async (req, res) => {
 
 
 // Get Cart
+async function fetchEnrichedCart(userId, { deliverySpeed, couponCode } = {}) {
+    const cart = await Cart.findOne({ userId })
+        .populate({
+            path: 'items',
+            populate: [
+                { path: 'productId', select: 'title coverImage shipping taxCategory isPublished isDeleted', match: { isPublished: true, isDeleted: false } },
+                { path: 'variantId', select: 'attributes sku price salePrice stock color label sizes allowBackorder shipping isPublished isDeleted images', match: { isPublished: true, isDeleted: false } },
+            ],
+        });
+
+    if (!cart) {
+        return {
+            status: 200,
+            message: 'Cart retrieved successfully',
+            cart: null,
+        };
+    }
+
+    const cartBusinessIds = [...new Set(
+        [
+            cart.businessId,
+            ...(Array.isArray(cart.items) ? cart.items.map((item) => item.businessId) : []),
+        ]
+            .filter(Boolean)
+            .map(String)
+    )];
+
+    const businesses = cartBusinessIds.length
+        ? await Business.find({ _id: { $in: cartBusinessIds } })
+            .select('businessName slug shippingSettings taxSettings owner isApproved isActive')
+            .lean()
+        : [];
+
+    const businessById = new Map(
+        businesses.map((business) => [String(business._id), business])
+    );
+    const businessDoc = cart.businessId
+        ? businessById.get(String(cart.businessId)) || null
+        : null;
+
+    const invalidItems = [];
+    const removedItems = [];
+
+    const cartItems = cart.items.map(cartItem => {
+        const variant = cartItem.variantId;
+        const product = cartItem.productId;
+
+        if (!product || !variant) {
+            invalidItems.push(cartItem._id);
+            removedItems.push({
+                cartItemId: cartItem._id,
+                productId: cartItem.productId?._id || cartItem.productId || null,
+                reason: 'unavailable_listing',
+            });
+            return null;
+        }
+
+        const itemBusiness = businessById.get(String(cartItem.businessId || cart.businessId));
+        if (!isPublicMarketplaceBusiness(itemBusiness)) {
+            invalidItems.push(cartItem._id);
+            removedItems.push({
+                cartItemId: cartItem._id,
+                productId: product._id,
+                businessId: cartItem.businessId,
+                reason: 'ineligible_vendor',
+                message: 'Vendor is not approved and active for the public marketplace.',
+            });
+            return null;
+        }
+
+        const selectedVariant = resolveVariantSelection(variant, cartItem.variant);
+        if (!selectedVariant) {
+            invalidItems.push(cartItem._id);
+            removedItems.push({
+                cartItemId: cartItem._id,
+                productId: product._id,
+                businessId: cartItem.businessId,
+                reason: 'unavailable_variant_selection',
+            });
+            return null;
+        }
+
+        const discountEnd = selectedVariant.discountEndDate ? new Date(selectedVariant.discountEndDate) : null;
+        const useSale = !!selectedVariant.salePrice && (!discountEnd || discountEnd.getTime() > Date.now());
+
+        const priceExclTax = toNum(selectedVariant.price);
+        const salePriceExclTax = toNum(selectedVariant.salePrice);
+        const taxCategory = getResolvedTaxCategory(product);
+        const taxRate = getTaxRateForCategory(businessDoc?.taxSettings, taxCategory);
+        const taxPricing = buildTaxAwareAmounts({
+            priceExclTax,
+            salePriceExclTax,
+            taxRate,
+        });
+        const selectedSizePrice = useSale
+            ? (taxPricing.salePriceInclTax ?? taxPricing.priceInclTax ?? 0)
+            : (taxPricing.priceInclTax ?? 0);
+        const selectedSizePriceExclTax = useSale
+            ? (taxPricing.salePriceExclTax ?? taxPricing.priceExclTax ?? 0)
+            : (taxPricing.priceExclTax ?? 0);
+        const lineAmounts = extractTaxFromInclusiveAmount({
+            inclusiveAmount: selectedSizePrice * Number(cartItem.quantity || 0),
+            taxRate,
+        });
+        const shipping = getEffectiveShipping(product, variant);
+        const shippingMethod = ['standard', 'overnight', 'local'].includes(cartItem.shippingMethod)
+            ? cartItem.shippingMethod
+            : 'standard';
+        const shippingCharge = (() => {
+            const stored = cartItem.shippingCharge != null ? Number(cartItem.shippingCharge) : null;
+            if (stored !== null && stored > 0) return stored;
+            return Number(shipping[shippingMethod] || 0);
+        })();
+
+        return {
+            cartItemId: cartItem._id,
+            title: product.title,
+            productId: product._id,
+            variantId: variant._id,
+            businessId: cartItem.businessId,
+            quantity: cartItem.quantity,
+            size: selectedVariant.key,
+            color: variant.color || getVariantAttribute(variant, 'color'),
+            label: variant.label || selectedVariant.key,
+            stock: selectedVariant.stock,
+            sku: selectedVariant.sku,
+            salePrice: taxPricing.salePriceInclTax,
+            discountEndDate: selectedVariant.discountEndDate,
+            price: taxPricing.priceInclTax,
+            priceExclTax: taxPricing.priceExclTax,
+            priceInclTax: taxPricing.priceInclTax,
+            salePriceExclTax: taxPricing.salePriceExclTax,
+            salePriceInclTax: taxPricing.salePriceInclTax,
+            selectedSizePrice,
+            selectedSizePriceExclTax,
+            selectedSizePriceInclTax: selectedSizePrice,
+            taxIncluded: true,
+            taxRate,
+            taxCategory,
+            lineBaseAmount: lineAmounts.amountExclTax,
+            lineTaxAmount: lineAmounts.taxAmount,
+            lineTotalAmount: lineAmounts.amountInclTax,
+            shippingMethod,
+            shippingCharge,
+            imageUrl: Array.isArray(variant.images) ? variant.images[0] : null,
+            allowBackorder: selectedVariant.allowBackorder,
+        };
+    });
+
+    const items = cartItems.filter(item => item !== null);
+    const totalItems = items.reduce((sum, item) => sum + (Number(item.quantity) || 0), 0);
+
+    if (invalidItems.length > 0) {
+        await CartItem.deleteMany({ _id: { $in: invalidItems } });
+        await Cart.updateOne(
+            { _id: cart._id },
+            {
+                $pull: { items: { $in: invalidItems } },
+                $set: { totalItems },
+            }
+        );
+    }
+
+    const pricing = await buildCartPricing({
+        cartDoc: cart,
+        items,
+        deliverySpeed,
+        businessDoc,
+        couponCode,
+    });
+
+    if (pricing.error) {
+        return {
+            status: 400,
+            message: pricing.error.message,
+        };
+    }
+
+    const removedForIneligibleVendor = removedItems.some(
+        (item) => item.reason === 'ineligible_vendor'
+    );
+
+    return {
+        status: 200,
+        message: invalidItems.length > 0
+            ? (removedForIneligibleVendor
+                ? 'Some items were removed from the cart because their vendor is no longer approved and active.'
+                : 'Some items were removed from the cart as they were unpublished or deleted.')
+            : 'Cart retrieved successfully',
+        cart: {
+            ...cart.toObject(),
+            items,
+            totalItems,
+            removedItems,
+            pricing,
+        },
+    };
+}
+
 const getCart = async (req, res) => {
     try {
         const deliverySpeed = resolveRequestedDeliverySpeed({
             ...req.query,
             shipping: req.query,
         });
+        const couponCode = req.query.couponCode || null;
 
-        // Fetch the cart for the user and populate CartItems with productId and variantId
-        const cart = await Cart.findOne({ userId: req.user._id })
-            .populate({
-                path: 'items',
-                populate: [
-                    { path: 'productId', select: 'title coverImage shipping taxCategory isPublished isDeleted', match: { isPublished: true, isDeleted: false } },  // Populate product details (name, coverImage) and ensure it's published and not deleted
-                    { path: 'variantId', select: 'attributes sku price salePrice stock color label sizes allowBackorder shipping isPublished isDeleted images', match: { isPublished: true, isDeleted: false } },  // Populate variant details and ensure it's published and not deleted
-                ],
-            });
+        const result = await fetchEnrichedCart(req.user._id, { deliverySpeed, couponCode });
 
-        if (!cart) {
-            return res.status(200).json({
-                message: 'Cart retrieved successfully',
-                cart: null,
-            });
-        }
-
-        const cartBusinessIds = [...new Set(
-            [
-                cart.businessId,
-                ...(Array.isArray(cart.items) ? cart.items.map((item) => item.businessId) : []),
-            ]
-                .filter(Boolean)
-                .map(String)
-        )];
-
-        const businesses = cartBusinessIds.length
-            ? await Business.find({ _id: { $in: cartBusinessIds } })
-                .select('businessName slug shippingSettings taxSettings owner isApproved isActive')
-                .lean()
-            : [];
-
-        const businessById = new Map(
-            businesses.map((business) => [String(business._id), business])
-        );
-        const businessDoc = cart.businessId
-            ? businessById.get(String(cart.businessId)) || null
-            : null;
-
-        const invalidItems = [];
-        const removedItems = [];
-
-        // Map the cart items to include only the necessary data for the frontend
-        const cartItems = cart.items.map(cartItem => {
-            const variant = cartItem.variantId;  // Already populated
-            const product = cartItem.productId;  // Already populated
-
-            // Check if the product and variant are valid (published and not deleted)
-            if (!product || !variant) {
-                // If the product or variant is invalid, remove the cart item
-                invalidItems.push(cartItem._id);  // Track the invalid item
-                removedItems.push({
-                    cartItemId: cartItem._id,
-                    productId: cartItem.productId?._id || cartItem.productId || null,
-                    reason: 'unavailable_listing',
-                });
-                return null; // Return null to exclude this item from the response
-            }
-
-            const itemBusiness = businessById.get(String(cartItem.businessId || cart.businessId));
-            if (!isPublicMarketplaceBusiness(itemBusiness)) {
-                invalidItems.push(cartItem._id);
-                removedItems.push({
-                    cartItemId: cartItem._id,
-                    productId: product._id,
-                    businessId: cartItem.businessId,
-                    reason: 'ineligible_vendor',
-                    message: 'Vendor is not approved and active for the public marketplace.',
-                });
-                return null;
-            }
-
-            const selectedVariant = resolveVariantSelection(variant, cartItem.variant);
-            if (!selectedVariant) {
-                // If size not found in the variant, remove the cart item
-                invalidItems.push(cartItem._id);
-                removedItems.push({
-                    cartItemId: cartItem._id,
-                    productId: product._id,
-                    businessId: cartItem.businessId,
-                    reason: 'unavailable_variant_selection',
-                });
-                return null; // Exclude this item from the response
-            }
-
-            const discountEnd = selectedVariant.discountEndDate ? new Date(selectedVariant.discountEndDate) : null;
-            const useSale = !!selectedVariant.salePrice && (!discountEnd || discountEnd.getTime() > Date.now());
-
-            const priceExclTax = toNum(selectedVariant.price);
-            const salePriceExclTax = toNum(selectedVariant.salePrice);
-            const taxCategory = getResolvedTaxCategory(product);
-            const taxRate = getTaxRateForCategory(businessDoc?.taxSettings, taxCategory);
-            const taxPricing = buildTaxAwareAmounts({
-                priceExclTax,
-                salePriceExclTax,
-                taxRate,
-            });
-            const selectedSizePrice = useSale
-                ? (taxPricing.salePriceInclTax ?? taxPricing.priceInclTax ?? 0)
-                : (taxPricing.priceInclTax ?? 0);
-            const selectedSizePriceExclTax = useSale
-                ? (taxPricing.salePriceExclTax ?? taxPricing.priceExclTax ?? 0)
-                : (taxPricing.priceExclTax ?? 0);
-            const lineAmounts = extractTaxFromInclusiveAmount({
-                inclusiveAmount: selectedSizePrice * Number(cartItem.quantity || 0),
-                taxRate,
-            });
-            const shipping = getEffectiveShipping(product, variant);
-            const shippingMethod = ['standard', 'overnight', 'local'].includes(cartItem.shippingMethod)
-                ? cartItem.shippingMethod
-                : 'standard';
-            const shippingCharge = (() => {
-                const stored = cartItem.shippingCharge != null ? Number(cartItem.shippingCharge) : null;
-                // Only trust a stored value that is genuinely > 0.
-                // A value of 0 usually means the item was synced from a guest cart without a charge.
-                if (stored !== null && stored > 0) return stored;
-                return Number(shipping[shippingMethod] || 0);
-            })();
-
-
-            // Return only necessary details (price is calculated on the frontend)
-            return {
-                title: product.title,
-                productId: product._id,
-                variantId: variant._id,
-                businessId: cartItem.businessId,
-                quantity: cartItem.quantity,
-                size: selectedVariant.key,
-                color: variant.color || getVariantAttribute(variant, 'color'),
-                label: variant.label || selectedVariant.key,
-                stock: selectedVariant.stock,
-                sku: selectedVariant.sku,
-                salePrice: taxPricing.salePriceInclTax,
-                discountEndDate: selectedVariant.discountEndDate,
-                price: taxPricing.priceInclTax,
-                priceExclTax: taxPricing.priceExclTax,
-                priceInclTax: taxPricing.priceInclTax,
-                salePriceExclTax: taxPricing.salePriceExclTax,
-                salePriceInclTax: taxPricing.salePriceInclTax,
-                selectedSizePrice,  // Effective customer-facing tax-inclusive price
-                selectedSizePriceExclTax,
-                selectedSizePriceInclTax: selectedSizePrice,
-                taxIncluded: true,
-                taxRate,
-                taxCategory,
-                lineBaseAmount: lineAmounts.amountExclTax,
-                lineTaxAmount: lineAmounts.taxAmount,
-                lineTotalAmount: lineAmounts.amountInclTax,
-                shippingMethod,
-                shippingCharge,
-                imageUrl: Array.isArray(variant.images) ? variant.images[0] : null,
-                allowBackorder: selectedVariant.allowBackorder,
-            };
-        });
-
-        const items = cartItems.filter(item => item !== null);
-        const totalItems = items.reduce((sum, item) => sum + (Number(item.quantity) || 0), 0);
-
-        // Remove invalid items from the cart
-        if (invalidItems.length > 0) {
-            await CartItem.deleteMany({ _id: { $in: invalidItems } });  // Remove invalid items
-            await Cart.updateOne(
-                { _id: cart._id },
-                {
-                    $pull: { items: { $in: invalidItems } },
-                    $set: { totalItems },
-                }
-            );
-        }
-
-        const pricing = await buildCartPricing({
-            cartDoc: cart,
-            items,
-            deliverySpeed,
-            businessDoc,
-        });
-
-        const removedForIneligibleVendor = removedItems.some(
-            (item) => item.reason === 'ineligible_vendor'
-        );
-
-        return res.status(200).json({
-            message: invalidItems.length > 0
-                ? (removedForIneligibleVendor
-                    ? 'Some items were removed from the cart because their vendor is no longer approved and active.'
-                    : 'Some items were removed from the cart as they were unpublished or deleted.')
-                : 'Cart retrieved successfully',
-            cart: {
-                ...cart.toObject(),
-                items,  // Filter out the null values (removed items)
-                totalItems,
-                removedItems,
-                pricing,
-            },
+        return res.status(result.status).json({
+            message: result.message,
+            cart: result.cart,
         });
     } catch (err) {
         return res.status(500).json({ message: 'Error fetching cart', error: err.message });
     }
+};
+
+const buildCartUpdateResponse = async (req, res, successMessage) => {
+    const deliverySpeed = resolveRequestedDeliverySpeed({
+        ...req.query,
+        shipping: req.query,
+    });
+    const couponCode = req.query.couponCode || null;
+    const result = await fetchEnrichedCart(req.user._id, { deliverySpeed, couponCode });
+
+    if (result.status !== 200) {
+        return res.status(result.status).json({ message: result.message });
+    }
+
+    return res.status(200).json({
+        message: successMessage,
+        cart: result.cart,
+    });
 };
 
 
@@ -620,7 +681,7 @@ const updateCartItem = async (req, res) => {
         cart.totalItems = totalQty;
         await cart.save();
 
-        return res.status(200).json({ message: 'Cart item updated successfully', cart });
+        return buildCartUpdateResponse(req, res, 'Cart item updated successfully');
     } catch (err) {
         console.error(err);
         return res.status(500).json({ message: 'Error updating cart item', error: err.message });
@@ -720,7 +781,7 @@ const updateCartItemByComposite = async (req, res) => {
         cart.totalItems = quantities.reduce((sum, it) => sum + (Number(it.quantity) || 0), 0);
         await cart.save();
 
-        return res.status(200).json({ message: 'Cart item updated successfully', cart });
+        return buildCartUpdateResponse(req, res, 'Cart item updated successfully');
     } catch (err) {
         console.error(err);
         return res.status(500).json({ message: 'Error updating cart item', error: err.message });

--- a/controllers/discountController.js
+++ b/controllers/discountController.js
@@ -1,6 +1,7 @@
 const Discount = require('../models/Discounts');
 const Business = require('../models/Business');
 const mongoose = require('mongoose');
+const { evaluateCouponDiscount } = require('../utils/couponDiscount');
 
 const UPDATABLE_DISCOUNT_FIELDS = [
   'name',
@@ -220,46 +221,22 @@ exports.validateCoupon = async (req, res) => {
   try {
     const { couponCode, businessId, amount } = req.body;
 
-    const discount = await Discount.findOne({
-      couponCode: couponCode.toUpperCase(),
+    const result = await evaluateCouponDiscount({
+      couponCode,
       businessId,
-      isActive: true
+      subtotalAmount: amount,
     });
 
-    if (!discount) {
+    if (!result.ok) {
       return res.status(400).json({
         success: false,
-        message: "Invalid coupon"
-      });
-    }
-
-    // Check expiry
-    if (discount.validTill && new Date() > discount.validTill) {
-      return res.status(400).json({
-        success: false,
-        message: "Coupon expired"
-      });
-    }
-
-    // Check usage limit
-    if (discount.usageLimit && discount.usedCount >= discount.usageLimit) {
-      return res.status(400).json({
-        success: false,
-        message: "Coupon usage limit reached"
-      });
-    }
-
-    // Check minimum amount
-    if (amount < discount.minOrderAmount) {
-      return res.status(400).json({
-        success: false,
-        message: `Minimum order amount is ${discount.minOrderAmount}`
+        message: result.message,
       });
     }
 
     res.json({
       success: true,
-      data: discount
+      data: result.discount,
     });
 
   } catch (error) {
@@ -279,42 +256,27 @@ exports.applyCoupon = async (req, res) => {
   try {
     const { couponCode, businessId, amount } = req.body;
 
-    const discount = await Discount.findOne({
-      couponCode: couponCode.toUpperCase(),
+    const result = await evaluateCouponDiscount({
+      couponCode,
       businessId,
-      isActive: true
+      subtotalAmount: amount,
     });
 
-    if (!discount) {
+    if (!result.ok) {
       return res.status(400).json({
         success: false,
-        message: "Invalid coupon"
+        message: result.message,
       });
     }
-
-    let discountAmount = 0;
-
-    // Calculate discount
-    if (discount.type === "percentage") {
-      discountAmount = (amount * discount.value) / 100;
-
-      if (discount.maxDiscountAmount) {
-        discountAmount = Math.min(discountAmount, discount.maxDiscountAmount);
-      }
-    } else {
-      discountAmount = discount.value;
-    }
-
-    const finalAmount = Math.max(0, amount - discountAmount);
 
     res.json({
       success: true,
       data: {
-        originalAmount: amount,
-        discountAmount,
-        finalAmount,
-        couponCode: discount.couponCode
-      }
+        originalAmount: Number(amount),
+        discountAmount: result.discountAmount,
+        finalAmount: result.discountedSubtotal,
+        couponCode: result.couponCode,
+      },
     });
 
   } catch (error) {

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -116,6 +116,8 @@ const {
   roundCurrency,
 } = require("../utils/vendorTax");
 
+const { evaluateCouponDiscount } = require("../utils/couponDiscount");
+
 const toNum = (value) => {
   if (value && typeof value === "object" && value.$numberDecimal != null) {
     return Number(value.$numberDecimal);
@@ -315,6 +317,36 @@ const resolveRequestedDeliverySpeed = (body) => {
       body?.shipping?.type
   );
 };
+
+const TOTAL_TOLERANCE = 0.01;
+
+function assertClientTotalsMatch(body, serverTotals) {
+  const checks = [
+    ["totalAmount", serverTotals.totalAmount],
+    ["discountAmount", serverTotals.discountAmount],
+    ["expectedTotal", serverTotals.totalAmount],
+    ["finalAmount", serverTotals.totalAmount],
+  ];
+
+  for (const [field, expected] of checks) {
+    if (body[field] === undefined) {
+      continue;
+    }
+
+    const clientValue = Number(body[field]);
+    if (
+      !Number.isFinite(clientValue) ||
+      Math.abs(clientValue - Number(expected || 0)) > TOTAL_TOLERANCE
+    ) {
+      return {
+        ok: false,
+        message: "Client total does not match server-calculated total",
+      };
+    }
+  }
+
+  return { ok: true };
+}
 
 // exports.initiateOrder = async (req, res) => {
 //   try {
@@ -544,7 +576,7 @@ const resolveRequestedDeliverySpeed = (body) => {
 
 exports.initiateOrder = async (req, res) => {
   try {
-    const { items, shippingAddress, userNote } = req.body;
+    const { items, shippingAddress, userNote, couponCode } = req.body;
     const userId = req.user.id;
     const deliverySpeed = resolveRequestedDeliverySpeed(req.body);
 
@@ -781,13 +813,36 @@ exports.initiateOrder = async (req, res) => {
       0
     );
 
+    let discountAmount = 0;
+    let discountedSubtotal = subtotalAmount;
+    let appliedCouponCode = null;
+
+    if (couponCode) {
+      const couponResult = await evaluateCouponDiscount({
+        couponCode,
+        businessId,
+        subtotalAmount,
+      });
+
+      if (!couponResult.ok) {
+        return res.status(400).json({
+          success: false,
+          message: couponResult.message,
+        });
+      }
+
+      discountAmount = couponResult.discountAmount;
+      discountedSubtotal = couponResult.discountedSubtotal;
+      appliedCouponCode = couponResult.couponCode;
+    }
+
     let shippingCalculation;
     try {
       shippingCalculation = calculateShippingForVendor(
         business.shippingSettings,
         {
           deliverySpeed,
-          subtotal: subtotalAmount,
+          subtotal: discountedSubtotal,
           totalQuantity,
         }
       );
@@ -799,7 +854,19 @@ exports.initiateOrder = async (req, res) => {
     }
 
     const totalAmount =
-      subtotalAmount + Number(shippingCalculation.amount || 0);
+      discountedSubtotal + Number(shippingCalculation.amount || 0);
+
+    const tamperCheck = assertClientTotalsMatch(req.body, {
+      totalAmount,
+      discountAmount,
+    });
+
+    if (!tamperCheck.ok) {
+      return res.status(400).json({
+        success: false,
+        message: tamperCheck.message,
+      });
+    }
 
     const groupOrderId = uuidv4();
 
@@ -810,6 +877,8 @@ exports.initiateOrder = async (req, res) => {
       businessId,
       items: vendorItems,
       subtotalAmount,
+      couponCode: appliedCouponCode,
+      discountAmount,
       taxSummary: {
         subtotalExclTaxAmount,
         taxTotal,
@@ -890,6 +959,9 @@ exports.initiateOrder = async (req, res) => {
       totals: {
         subtotalExclTaxAmount,
         subtotalAmount,
+        discountAmount,
+        discountedSubtotal,
+        couponCode: appliedCouponCode,
         taxTotal,
         shippingAmount: Number(shippingCalculation.amount || 0),
         totalAmount,

--- a/models/Order.js
+++ b/models/Order.js
@@ -83,6 +83,13 @@ const orderSchema = new Schema(
       type: Number,
       required: true,
     },
+    couponCode: {
+      type: String,
+    },
+    discountAmount: {
+      type: Number,
+      default: 0,
+    },
     taxSummary: {
       subtotalExclTaxAmount: {
         type: Number,

--- a/tests/discount/coupon-apply-validate.test.js
+++ b/tests/discount/coupon-apply-validate.test.js
@@ -1,0 +1,95 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('../integration/setup/harness');
+const { createAgent } = require('../integration/helpers/client');
+const {
+  registerAndVerify,
+  seedApprovedBusiness,
+  seedDiscount,
+} = require('../integration/helpers/factories');
+const User = require('../../models/User');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+test('POST /api/discounts/validate and /apply share minOrderAmount enforcement', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser);
+  const discount = await seedDiscount(business, {
+    couponCode: 'MIN50',
+    minOrderAmount: 50,
+    type: 'percentage',
+    value: 10,
+  });
+
+  const agent = createAgent(getApp());
+
+  const validateBelow = await agent.post('/api/discounts/validate').send({
+    couponCode: discount.couponCode,
+    businessId: business._id,
+    amount: 40,
+  });
+  assert.equal(validateBelow.status, 400);
+  assert.match(validateBelow.body.message, /Minimum order amount is 50/i);
+
+  const applyBelow = await agent.post('/api/discounts/apply').send({
+    couponCode: discount.couponCode,
+    businessId: business._id,
+    amount: 40,
+  });
+  assert.equal(applyBelow.status, 400);
+  assert.match(applyBelow.body.message, /Minimum order amount is 50/i);
+
+  const validateOk = await agent.post('/api/discounts/validate').send({
+    couponCode: discount.couponCode,
+    businessId: business._id,
+    amount: 50,
+  });
+  assert.equal(validateOk.status, 200);
+  assert.equal(validateOk.body.success, true);
+
+  const applyOk = await agent.post('/api/discounts/apply').send({
+    couponCode: discount.couponCode,
+    businessId: business._id,
+    amount: 50,
+  });
+  assert.equal(applyOk.status, 200);
+  assert.equal(applyOk.body.data.discountAmount, 5);
+  assert.equal(applyOk.body.data.finalAmount, 45);
+});
+
+test('POST /api/discounts/validate rejects missing amount when minOrderAmount is set', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser);
+  const discount = await seedDiscount(business, {
+    couponCode: 'NEEDAMT',
+    minOrderAmount: 25,
+  });
+
+  const agent = createAgent(getApp());
+  const res = await agent.post('/api/discounts/validate').send({
+    couponCode: discount.couponCode,
+    businessId: business._id,
+  });
+
+  assert.equal(res.status, 400);
+  assert.match(res.body.message, /Valid order amount is required/i);
+});

--- a/tests/integration/commerce.integration.test.js
+++ b/tests/integration/commerce.integration.test.js
@@ -109,6 +109,112 @@ test('customer removes cart item by id and keeps quantity-based totalItems', asy
   assert.deepEqual(reloadedCart.items.map(String), [String(lineToKeep._id)]);
 });
 
+test('customer can decrease cart quantity via update by cartItemId', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser, {
+    shippingSettings: { method: 'flat_rate', flatRate: { standard: 5 } },
+  });
+  const product = await seedPublishedProduct(business, vendorUser);
+  const variant = await ProductVariant.create({
+    productId: product._id,
+    businessId: business._id,
+    ownerId: vendorUser._id,
+    attributes: { size: 'M' },
+    sku: `SKU-CART-DEC-${Date.now()}`,
+    price: 25,
+    stock: 10,
+    isPublished: true,
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+  const customerUser = await User.findOne({ email: customer.email });
+
+  const line = await CartItem.create({
+    userId: customerUser._id,
+    productId: product._id,
+    variantId: variant._id,
+    businessId: business._id,
+    quantity: 3,
+    variant: 'M',
+    shippingMethod: 'standard',
+  });
+  await Cart.create({
+    userId: customerUser._id,
+    businessId: business._id,
+    items: [line._id],
+    totalItems: 3,
+  });
+
+  const updateRes = await customerAgent
+    .put(`/api/cart/update/${line._id}`)
+    .send({ quantity: 1 });
+
+  assert.equal(updateRes.status, 200);
+  assert.equal(updateRes.body.cart.totalItems, 1);
+  assert.equal(updateRes.body.cart.items[0].quantity, 1);
+  assert.ok(updateRes.body.cart.pricing);
+  assert.equal(updateRes.body.cart.pricing.subtotalAmount, 25);
+});
+
+test('composite cart quantity update succeeds with mixed-case shippingMethod', async () => {
+  const vendorAgent = createAgent(getApp());
+  const vendor = await registerAndVerify(vendorAgent, { role: 'business_owner' });
+  const vendorUser = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(vendorUser, {
+    shippingSettings: { method: 'flat_rate', flatRate: { standard: 5 } },
+  });
+  const product = await seedPublishedProduct(business, vendorUser);
+  const variant = await ProductVariant.create({
+    productId: product._id,
+    businessId: business._id,
+    ownerId: vendorUser._id,
+    attributes: { size: 'M' },
+    sku: `SKU-CART-COMP-${Date.now()}`,
+    price: 25,
+    stock: 10,
+    isPublished: true,
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+  const customerUser = await User.findOne({ email: customer.email });
+
+  const line = await CartItem.create({
+    userId: customerUser._id,
+    productId: product._id,
+    variantId: variant._id,
+    businessId: business._id,
+    quantity: 3,
+    variant: 'M',
+    shippingMethod: 'standard',
+  });
+  await Cart.create({
+    userId: customerUser._id,
+    businessId: business._id,
+    items: [line._id],
+    totalItems: 3,
+  });
+
+  const updateRes = await customerAgent
+    .put('/api/cart/update-quantity')
+    .send({
+      productId: product._id,
+      variantId: variant._id,
+      size: 'M',
+      quantity: 2,
+      shippingMethod: 'Standard',
+    });
+
+  assert.equal(updateRes.status, 200);
+  assert.equal(updateRes.body.cart.totalItems, 2);
+  assert.equal(updateRes.body.cart.items[0].quantity, 2);
+});
+
 test('order initiate rejects empty cart for customer', async () => {
   const agent = createAgent(getApp());
   const customer = await registerAndVerify(agent, { role: 'customer' });

--- a/tests/stripe/order-initiate-coupon.test.js
+++ b/tests/stripe/order-initiate-coupon.test.js
@@ -1,0 +1,367 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const orderControllerPath = path.resolve(__dirname, '../../controllers/orderController.js');
+
+const vendorId = '507f1f77bcf86cd799439011';
+const businessId = '507f1f77bcf86cd799439012';
+const productId = '507f1f77bcf86cd799439013';
+const variantId = '507f1f77bcf86cd799439014';
+const userId = '507f1f77bcf86cd799439015';
+const connectAccountId = 'acct_test_connect_001';
+
+const defaultShipping = {
+  deliverySpeed: 'standard',
+  amount: 5,
+  method: 'flat_rate',
+  freeShippingApplied: false,
+  freeShippingThreshold: null,
+  matchedTier: null,
+};
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildVariant(overrides = {}) {
+  const owner = overrides.ownerId || vendorId;
+  const biz = overrides.businessId || businessId;
+  return {
+    _id: variantId,
+    ownerId: { toString: () => owner },
+    businessId: biz,
+    sku: 'SKU-TEST',
+    allowBackorder: false,
+    sizes: [
+      {
+        size: 'M',
+        stock: 10,
+        price: overrides.price ?? 25,
+        salePrice: null,
+        sku: 'SKU-M',
+      },
+    ],
+    productId: {
+      _id: { toString: () => productId },
+      title: 'Test Product',
+      ...(overrides.productId || {}),
+    },
+    ...overrides.variantExtra,
+  };
+}
+
+function buildBusiness(overrides = {}) {
+  return {
+    _id: businessId,
+    email: 'vendor@example.com',
+    isApproved: overrides.isApproved ?? true,
+    isActive: overrides.isActive ?? true,
+    stripeConnectAccountId: overrides.stripeConnectAccountId ?? connectAccountId,
+    taxSettings: {},
+    shippingSettings: { method: 'flat_rate', flatRate: { standard: 5 } },
+    save: async function save() {
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function buildStripeAccount(overrides = {}) {
+  return {
+    charges_enabled: overrides.charges_enabled ?? true,
+    payouts_enabled: overrides.payouts_enabled ?? true,
+    capabilities: {
+      card_payments: 'active',
+      transfers: overrides.transfers ?? 'active',
+    },
+  };
+}
+
+function loadInitiateOrder({
+  business = buildBusiness(),
+  stripeAccount = buildStripeAccount(),
+  variants = [buildVariant()],
+  variantById = null,
+  piCreateError = null,
+  shippingResult = defaultShipping,
+  taxPricing = { priceExclTax: 25, priceInclTax: 25 },
+  couponEvaluator = null,
+} = {}) {
+  const piCreateCalls = [];
+  const accountRetrieveCalls = [];
+
+  const stripeMock = {
+    accounts: {
+      retrieve: async (accountId) => {
+        accountRetrieveCalls.push(accountId);
+        return stripeAccount;
+      },
+    },
+    paymentIntents: {
+      create: async (params, options) => {
+        if (piCreateError) {
+          throw piCreateError;
+        }
+        piCreateCalls.push({ params, options });
+        return {
+          id: 'pi_test_001',
+          client_secret: 'pi_test_001_secret_test',
+        };
+      },
+    },
+  };
+
+  let savedOrderPayload = null;
+  let orderIdCounter = 0;
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'stripe' || (request.includes('node_modules') && request.replace(/\\/g, '/').includes('/stripe/'))) {
+      return class Stripe {
+        constructor() {
+          return stripeMock;
+        }
+      };
+    }
+    if (request === 'uuid') {
+      return { v4: () => 'group-order-test-uuid' };
+    }
+    if (request.endsWith('models/Order')) {
+      return class Order {
+        constructor(payload) {
+          Object.assign(this, payload);
+          this._id = { toString: () => `order_${++orderIdCounter}` };
+        }
+        async save() {
+          savedOrderPayload = { ...this };
+          return this;
+        }
+      };
+    }
+    if (request.endsWith('models/ProductVariant')) {
+      return {
+        findById: (id) => ({
+          populate: async () => {
+            if (variantById) {
+              return variantById(id);
+            }
+            const match = variants.find((v) => v._id === id) || variants[0];
+            return match;
+          },
+        }),
+      };
+    }
+    if (request.endsWith('models/Business')) {
+      return {
+        findById: async () => business,
+      };
+    }
+    if (request.endsWith('models/User')) {
+      return {
+        findById: () => ({
+          select: () => ({
+            email: 'customer@example.com',
+          }),
+        }),
+      };
+    }
+    if (request.endsWith('utils/orderPhase')) {
+      return {
+        sendOrderStatusEmail: async () => {},
+        sendOrderUpdateEmail: async () => {},
+        sendOrderLifecycleEmail: async () => {},
+        sendVendorNewOrderEmail: async () => {},
+        sendCustomerOrderPlacedEmail: async () => {},
+      };
+    }
+    if (request.endsWith('utils/vendorShipping')) {
+      return {
+        calculateShippingForVendor: () => shippingResult,
+        normalizeDeliverySpeed: (value) => value || 'standard',
+      };
+    }
+    if (request.endsWith('utils/vendorTax')) {
+      return {
+        getResolvedTaxCategory: () => null,
+        getTaxRateForCategory: () => 0,
+        buildTaxAwareAmounts: () => taxPricing,
+        extractTaxFromInclusiveAmount: ({ inclusiveAmount }) => ({
+          amountExclTax: inclusiveAmount,
+          taxAmount: 0,
+          amountInclTax: inclusiveAmount,
+        }),
+        roundCurrency: (value) => Math.round(Number(value) * 100) / 100,
+      };
+    }
+    if (request.endsWith('utils/couponDiscount')) {
+      if (couponEvaluator) {
+        return couponEvaluator;
+      }
+      return originalLoad(request, parent, isMain);
+    }
+
+    return originalLoad(request, parent, isMain);
+  };
+
+  delete require.cache[orderControllerPath];
+  const controller = require(orderControllerPath);
+  Module._load = originalLoad;
+
+  return {
+    initiateOrder: controller.initiateOrder,
+    getPiCreateCalls: () => piCreateCalls,
+    getSavedOrderPayload: () => savedOrderPayload,
+  };
+}
+
+function baseRequest(overrides = {}) {
+  return {
+    user: { id: userId },
+    body: {
+      items: [
+        {
+          productId,
+          variantId,
+          size: 'M',
+          quantity: overrides.quantity ?? 1,
+          price: overrides.price ?? 25,
+        },
+      ],
+      shippingAddress: {
+        fullName: 'Test Customer',
+        phone: '+15551234567',
+        addressLine1: '123 Main St',
+      },
+      ...overrides.bodyExtra,
+    },
+  };
+}
+
+test('initiateOrder rejects coupon below minimum subtotal', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({
+    couponEvaluator: {
+      evaluateCouponDiscount: async () => ({
+        ok: false,
+        message: 'Minimum order amount is 50',
+      }),
+    },
+  });
+  const res = mockResponse();
+
+  await initiateOrder(
+    baseRequest({
+      bodyExtra: {
+        couponCode: 'MIN50',
+        items: [
+          {
+            productId,
+            variantId,
+            size: 'M',
+            quantity: 1,
+            price: 25,
+          },
+        ],
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Minimum order amount is 50/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder applies coupon to PI amount and persisted order total', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.PLATFORM_FEE_CENTS = '0';
+  const { initiateOrder, getPiCreateCalls, getSavedOrderPayload } = loadInitiateOrder({
+    couponEvaluator: {
+      evaluateCouponDiscount: async ({ subtotalAmount }) => ({
+        ok: true,
+        couponCode: 'SAVE10',
+        discountAmount: 5,
+        discountedSubtotal: subtotalAmount - 5,
+      }),
+    },
+  });
+  const res = mockResponse();
+
+  await initiateOrder(
+    baseRequest({
+      bodyExtra: {
+        couponCode: 'SAVE10',
+        items: [
+          {
+            productId,
+            variantId,
+            size: 'M',
+            quantity: 2,
+            price: 25,
+          },
+        ],
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.totals.subtotalAmount, 50);
+  assert.equal(res.body.totals.discountAmount, 5);
+  assert.equal(res.body.totals.discountedSubtotal, 45);
+  assert.equal(res.body.totals.totalAmount, 50);
+
+  const [{ params }] = getPiCreateCalls();
+  assert.equal(params.amount, 5000);
+
+  const saved = getSavedOrderPayload();
+  assert.equal(saved.couponCode, 'SAVE10');
+  assert.equal(saved.discountAmount, 5);
+  assert.equal(saved.totalAmount, 50);
+});
+
+test('initiateOrder rejects client totalAmount tampering', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  const { initiateOrder, getPiCreateCalls } = loadInitiateOrder({});
+  const res = mockResponse();
+
+  await initiateOrder(
+    baseRequest({
+      bodyExtra: {
+        totalAmount: 1,
+      },
+    }),
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.match(res.body.message, /Client total does not match server-calculated total/i);
+  assert.equal(getPiCreateCalls().length, 0);
+});
+
+test('initiateOrder checkout total matches undiscounted subtotal plus shipping', async () => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mock';
+  process.env.PLATFORM_FEE_CENTS = '0';
+  const { initiateOrder } = loadInitiateOrder({});
+  const res = mockResponse();
+
+  await initiateOrder(baseRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.totals.subtotalAmount, 25);
+  assert.equal(res.body.totals.shippingAmount, 5);
+  assert.equal(res.body.totals.totalAmount, 30);
+});

--- a/tests/utils/coupon-discount.test.js
+++ b/tests/utils/coupon-discount.test.js
@@ -1,0 +1,126 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  evaluateCouponDiscount,
+  computeDiscountAmount,
+  validateDiscountRecord,
+} = require('../../utils/couponDiscount');
+
+function buildDiscount(overrides = {}) {
+  return {
+    couponCode: 'SAVE10',
+    type: 'percentage',
+    value: 10,
+    minOrderAmount: 50,
+    maxDiscountAmount: null,
+    usageLimit: null,
+    usedCount: 0,
+    validFrom: new Date(Date.now() - 86400000),
+    validTill: new Date(Date.now() + 86400000),
+    isActive: true,
+    ...overrides,
+  };
+}
+
+test('evaluateCouponDiscount rejects missing amount', async () => {
+  const result = await evaluateCouponDiscount({
+    couponCode: 'SAVE10',
+    businessId: '507f1f77bcf86cd799439011',
+    subtotalAmount: undefined,
+    discountDoc: buildDiscount(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'INVALID_AMOUNT');
+});
+
+test('evaluateCouponDiscount rejects subtotal below minOrderAmount', async () => {
+  const result = await evaluateCouponDiscount({
+    couponCode: 'SAVE10',
+    businessId: '507f1f77bcf86cd799439011',
+    subtotalAmount: 40,
+    discountDoc: buildDiscount({ minOrderAmount: 50 }),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'MIN_ORDER');
+});
+
+test('evaluateCouponDiscount accepts subtotal at minOrderAmount threshold', async () => {
+  const result = await evaluateCouponDiscount({
+    couponCode: 'SAVE10',
+    businessId: '507f1f77bcf86cd799439011',
+    subtotalAmount: 50,
+    discountDoc: buildDiscount({ minOrderAmount: 50, value: 10, type: 'percentage' }),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.discountAmount, 5);
+  assert.equal(result.discountedSubtotal, 45);
+});
+
+test('evaluateCouponDiscount caps percentage discount with maxDiscountAmount', async () => {
+  const discount = buildDiscount({
+    minOrderAmount: 0,
+    type: 'percentage',
+    value: 50,
+    maxDiscountAmount: 10,
+  });
+
+  const result = await evaluateCouponDiscount({
+    couponCode: 'SAVE10',
+    businessId: '507f1f77bcf86cd799439011',
+    subtotalAmount: 100,
+    discountDoc: discount,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.discountAmount, 10);
+  assert.equal(result.discountedSubtotal, 90);
+});
+
+test('evaluateCouponDiscount applies fixed discount and clamps to subtotal', async () => {
+  const discount = buildDiscount({
+    minOrderAmount: 0,
+    type: 'fixed',
+    value: 75,
+  });
+
+  const result = await evaluateCouponDiscount({
+    couponCode: 'SAVE10',
+    businessId: '507f1f77bcf86cd799439011',
+    subtotalAmount: 50,
+    discountDoc: discount,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.discountAmount, 50);
+  assert.equal(result.discountedSubtotal, 0);
+});
+
+test('validateDiscountRecord rejects expired coupons', () => {
+  const result = validateDiscountRecord(
+    buildDiscount({ validTill: new Date(Date.now() - 1000) }),
+    100
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'EXPIRED');
+});
+
+test('validateDiscountRecord rejects usage limit reached', () => {
+  const result = validateDiscountRecord(
+    buildDiscount({ usageLimit: 5, usedCount: 5 }),
+    100
+  );
+
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'USAGE_LIMIT');
+});
+
+test('computeDiscountAmount never exceeds subtotal', () => {
+  assert.equal(
+    computeDiscountAmount(buildDiscount({ type: 'fixed', value: 200 }), 50),
+    50
+  );
+});

--- a/utils/couponDiscount.js
+++ b/utils/couponDiscount.js
@@ -1,0 +1,127 @@
+const Discount = require('../models/Discounts');
+const mongoose = require('mongoose');
+
+const roundCurrency = (value) => Math.round(Number(value) * 100) / 100;
+
+function computeDiscountAmount(discount, subtotalAmount) {
+  let discountAmount = 0;
+
+  if (discount.type === 'percentage') {
+    discountAmount = (subtotalAmount * discount.value) / 100;
+    if (discount.maxDiscountAmount) {
+      discountAmount = Math.min(discountAmount, discount.maxDiscountAmount);
+    }
+  } else {
+    discountAmount = discount.value;
+  }
+
+  discountAmount = roundCurrency(Math.min(discountAmount, subtotalAmount));
+  return Math.max(0, discountAmount);
+}
+
+function validateDiscountRecord(discount, subtotalAmount) {
+  const now = new Date();
+
+  if (discount.validFrom && now < new Date(discount.validFrom)) {
+    return {
+      ok: false,
+      errorCode: 'NOT_YET_VALID',
+      message: 'Coupon is not yet valid',
+    };
+  }
+
+  if (discount.validTill && now > new Date(discount.validTill)) {
+    return {
+      ok: false,
+      errorCode: 'EXPIRED',
+      message: 'Coupon expired',
+    };
+  }
+
+  if (discount.usageLimit && discount.usedCount >= discount.usageLimit) {
+    return {
+      ok: false,
+      errorCode: 'USAGE_LIMIT',
+      message: 'Coupon usage limit reached',
+    };
+  }
+
+  const minOrderAmount = Number(discount.minOrderAmount || 0);
+  if (subtotalAmount < minOrderAmount) {
+    return {
+      ok: false,
+      errorCode: 'MIN_ORDER',
+      message: `Minimum order amount is ${minOrderAmount}`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Evaluate a coupon against merchandise subtotal (before shipping).
+ * @param {{ couponCode: string, businessId: string, subtotalAmount: number, discountDoc?: object }} params
+ */
+async function evaluateCouponDiscount({ couponCode, businessId, subtotalAmount, discountDoc = null }) {
+  if (!couponCode || !String(couponCode).trim()) {
+    return {
+      ok: false,
+      errorCode: 'INVALID_INPUT',
+      message: 'Coupon code is required',
+    };
+  }
+
+  if (!businessId || !mongoose.Types.ObjectId.isValid(String(businessId))) {
+    return {
+      ok: false,
+      errorCode: 'INVALID_INPUT',
+      message: 'Valid businessId is required',
+    };
+  }
+
+  const normalizedSubtotal = Number(subtotalAmount);
+  if (!Number.isFinite(normalizedSubtotal) || normalizedSubtotal < 0) {
+    return {
+      ok: false,
+      errorCode: 'INVALID_AMOUNT',
+      message: 'Valid order amount is required',
+    };
+  }
+
+  const discount = discountDoc || await Discount.findOne({
+    couponCode: String(couponCode).trim().toUpperCase(),
+    businessId,
+    isActive: true,
+  });
+
+  if (!discount) {
+    return {
+      ok: false,
+      errorCode: 'INVALID_COUPON',
+      message: 'Invalid coupon',
+    };
+  }
+
+  const validation = validateDiscountRecord(discount, normalizedSubtotal);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  const discountAmount = computeDiscountAmount(discount, normalizedSubtotal);
+  const discountedSubtotal = roundCurrency(Math.max(0, normalizedSubtotal - discountAmount));
+
+  return {
+    ok: true,
+    discount,
+    discountAmount,
+    discountedSubtotal,
+    couponCode: discount.couponCode,
+  };
+}
+
+module.exports = {
+  evaluateCouponDiscount,
+  computeDiscountAmount,
+  validateDiscountRecord,
+  roundCurrency,
+};


### PR DESCRIPTION
## Summary
- Add shared coupon evaluator and enforce min-order, expiry, and usage rules on validate/apply, cart pricing, and checkout.
- Fix cart quantity decrease via normalized shippingMethod lookup, cartItemId in GET cart, and enriched update responses.
- Wire coupons into initiateOrder with server-derived totals, tamper rejection, and persisted order discount fields.

## Test plan
- [x] npm test (512 passed)
- [ ] npm run test:integration
- [ ] Manual cart -> coupon -> checkout smoke on staging

## Notes
- Does not merge or deploy.
- Webhook handlers and Connect/subscription flows unchanged.