### PR TITLE
Fix P0 vendor application approval/disapproval/finalize state flow

### DIFF
--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -829,10 +829,42 @@ exports.sendVerificationGuidanceNotification = async (req, res) => {
 /* =====================================================
    FINALIZE VERIFICATION (APPROVE/REJECT)
 ===================================================== */
-// only checks for required documents and approves/rejects based on that. Points are not a factor in approval decision, but badge is still assigned based on points.  
+// Decision source:
+// - Explicit: request body `decision: 'approve' | 'reject'` (admin intent).
+//   Approve still requires the required-documents checklist; reject is always
+//   allowed and may carry an admin-supplied rejectionReason.
+// - Auto (no `decision` in body, legacy contract): approves when required
+//   documents are verified, rejects otherwise.
+// Points are never a factor in the approval decision; badge is still assigned
+// from points.
+const DEFAULT_REQUIRED_NEXT_ACTION = 'Update your application and resubmit for review.';
+
 exports.finalizeVerification = async (req, res) => {
   try {
     const { applicationId } = req.params;
+    const body = req.body || {};
+
+    let explicitDecision;
+    if (body.decision !== undefined && body.decision !== null && body.decision !== '') {
+      const normalized = String(body.decision).trim().toLowerCase();
+      if (normalized !== 'approve' && normalized !== 'reject') {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid decision. Expected 'approve' or 'reject'.",
+        });
+      }
+      explicitDecision = normalized;
+    }
+
+    const adminRejectionReason = typeof body.rejectionReason === 'string'
+      ? body.rejectionReason.trim()
+      : '';
+    const adminNotes = typeof body.adminNotes === 'string'
+      ? body.adminNotes.trim()
+      : '';
+    const requestedNextAction = typeof body.requiredNextAction === 'string'
+      ? body.requiredNextAction.trim()
+      : '';
 
     const application = await VendorOnboarding.findOne({ applicationId })
       .populate('userId', 'name email');
@@ -897,8 +929,32 @@ exports.finalizeVerification = async (req, res) => {
       missingRequiredDocuments.push('minority proof document');
     }
 
-    const rejectionReason = ` ${missingRequiredDocuments.join(', ')}.`;
+    const autoRejectionReason = missingRequiredDocuments.length
+      ? `Missing required documents: ${missingRequiredDocuments.join(', ')}.`
+      : '';
     const previousStatus = 'submitted';
+
+    // ❌ Explicit approve requested but required docs are not verified —
+    // fail loudly instead of silently rejecting against admin intent.
+    if (explicitDecision === 'approve' && !hasRequiredDocsVerified) {
+      await recordAdminAuditFailure(req, {
+        actionCode: ADMIN_AUDIT_ACTIONS.VENDOR_APPLICATION_FINALIZE_FAILED,
+        targetType: ADMIN_AUDIT_TARGET_TYPES.VENDOR_APPLICATION,
+        targetId: application.applicationId,
+        note: `Cannot approve: required documents not verified (${missingRequiredDocuments.join(', ')})`,
+      });
+      return res.status(400).json({
+        success: false,
+        message: 'Cannot approve application: required documents are not verified',
+        data: {
+          currentStatus: application.status,
+          missingRequiredDocuments,
+        },
+      });
+    }
+
+    const decision = explicitDecision
+      || (hasRequiredDocsVerified ? 'approve' : 'reject');
 
     // ✅ Badge logic (kept as-is)
     const totalPoints = application.totalVerificationPoints;
@@ -909,13 +965,31 @@ exports.finalizeVerification = async (req, res) => {
     else if (totalPoints >= 40) badge = 'Gold';
     else if (totalPoints >= 30) badge = 'Silver';
 
-    // ✅ FINAL DECISION
-    if (hasRequiredDocsVerified) {
+    const reviewerId = req.user?._id || req.user?.id;
+    const reviewedAt = new Date();
+
+    // ✅ FINAL DECISION + persisted review metadata
+    application.badge = badge;
+    application.reviewedBy = reviewerId;
+    application.reviewedAt = reviewedAt;
+    application.adminReviewNotes = adminNotes || undefined;
+
+    if (decision === 'approve') {
       application.status = 'verified';
-      application.badge = badge;
+      application.reviewDecision = 'approved';
+      application.verifiedAt = reviewedAt;
+      application.rejectedAt = undefined;
+      application.rejectionReason = undefined;
+      application.requiredNextAction = undefined;
     } else {
       application.status = 'rejected';
-      application.badge = badge;
+      application.reviewDecision = 'rejected';
+      application.rejectedAt = reviewedAt;
+      application.verifiedAt = undefined;
+      application.rejectionReason = adminRejectionReason
+        || autoRejectionReason
+        || 'Application did not meet verification requirements.';
+      application.requiredNextAction = requestedNextAction || DEFAULT_REQUIRED_NEXT_ACTION;
     }
 
     await application.save();
@@ -963,6 +1037,7 @@ exports.finalizeVerification = async (req, res) => {
           { status: application.status, badge },
           ['status', 'badge']
         ),
+        note: explicitDecision ? 'Explicit admin decision: approve' : 'Auto decision: required documents verified',
       });
 
       return res.status(200).json({
@@ -970,7 +1045,12 @@ exports.finalizeVerification = async (req, res) => {
         message: 'Application approved successfully',
         data: {
           status: 'approved',
+          applicationStatus: application.status,
           badge,
+          reviewedBy: reviewerId,
+          reviewedAt,
+          verifiedAt: application.verifiedAt,
+          adminReviewNotes: application.adminReviewNotes || null,
           emailSent: emailDelivery.emailSent,
           emailSkipped: emailDelivery.emailSkipped,
           emailFailed: emailDelivery.emailFailed,
@@ -980,6 +1060,8 @@ exports.finalizeVerification = async (req, res) => {
 
     // ❌ REJECTED
     if (application.status === 'rejected') {
+      const rejectionReason = application.rejectionReason;
+
       const emailDelivery = await deliverVendorOnboardingEmails([
         {
           label: 'vendor_rejection',
@@ -989,7 +1071,7 @@ exports.finalizeVerification = async (req, res) => {
             businessName: application.businessName,
             applicationId: application.applicationId,
             currentStatus: application.status,
-            rejectionReason: missingRequiredDocuments.join(', '),
+            rejectionReason,
             documentsNeeded: missingRequiredDocuments,
           }),
         },
@@ -998,7 +1080,7 @@ exports.finalizeVerification = async (req, res) => {
       const rejectionFingerprint = buildGuidanceFingerprint({
         outcome: 'missing_documents',
         applicationStatus: application.status,
-        reasons: [rejectionReason.trim()],
+        reasons: [rejectionReason],
         documentsNeeded: missingRequiredDocuments,
         fieldsNeeded: [],
       });
@@ -1006,11 +1088,11 @@ exports.finalizeVerification = async (req, res) => {
       const notificationLog = await appendVerificationNotificationLog(application, {
         outcome: 'missing_documents',
         fingerprint: rejectionFingerprint,
-        reasons: [rejectionReason.trim()],
+        reasons: [rejectionReason],
         documentsNeeded: missingRequiredDocuments,
         fieldsNeeded: [],
         emailDelivery,
-        triggeredBy: req.user?._id || req.user?.id,
+        triggeredBy: reviewerId,
       });
 
       await recordAdminAuditSuccess(req, {
@@ -1022,20 +1104,26 @@ exports.finalizeVerification = async (req, res) => {
           { status: application.status, badge },
           ['status', 'badge']
         ),
-        note: `${rejectionReason.trim()} ${buildGuidanceAuditNote('missing_documents', emailDelivery, notificationLog)}`,
+        note: `${rejectionReason} ${explicitDecision ? '(explicit admin decision)' : '(auto decision)'} ${buildGuidanceAuditNote('missing_documents', emailDelivery, notificationLog)}`,
       });
 
       return res.status(200).json({
         success: true,
         data: {
           status: 'rejected',
+          applicationStatus: application.status,
           badge,
+          reviewedBy: reviewerId,
+          reviewedAt,
+          rejectedAt: application.rejectedAt,
+          adminReviewNotes: application.adminReviewNotes || null,
+          requiredNextAction: application.requiredNextAction,
           emailSent: emailDelivery.emailSent,
           emailSkipped: emailDelivery.emailSkipped,
           emailFailed: emailDelivery.emailFailed,
           notificationLogged: notificationLog.logged,
           missingRequiredDocuments,
-          rejectionReason: rejectionReason.trim(),
+          rejectionReason,
         }
       });
     }

--- a/controllers/vendorOnboarding.controller.js
+++ b/controllers/vendorOnboarding.controller.js
@@ -1347,7 +1347,8 @@ exports.getStatusByApplicationId = async (req, res) => {
 
       case 'rejected':
         status = 'Stage 1 - Rejected';
-        nextAction = 'Your application did not meet verification criteria. Our team will contact you for further assistance.';
+        nextAction = onboarding.requiredNextAction
+          || 'Update your application and resubmit for review.';
         break;
 
       default:
@@ -1369,7 +1370,15 @@ exports.getStatusByApplicationId = async (req, res) => {
             status: onboarding.status,
             points: onboarding.totalVerificationPoints || 0,
             submittedAt: onboarding.submittedAt,
-            paymentStatus: onboarding.verificationPayment?.status || 'not_started'
+            paymentStatus: onboarding.verificationPayment?.status || 'not_started',
+            // Admin review outcome (present after finalize; vendor-visible)
+            rejectionReason: onboarding.status === 'rejected'
+              ? (onboarding.rejectionReason || null)
+              : null,
+            requiredNextAction: onboarding.status === 'rejected'
+              ? (onboarding.requiredNextAction || 'Update your application and resubmit for review.')
+              : null,
+            reviewedAt: onboarding.reviewedAt || null
           },
           stage2: {
             status: subscription?.status || 'not_started',

--- a/docs/VENDOR_LIFECYCLE.md
+++ b/docs/VENDOR_LIFECYCLE.md
@@ -99,8 +99,11 @@ stateDiagram-v2
 | `draft` / `payment_pending` / `rejected` | `submitForReview` (paid) | `submitForReview` | `submitted` | Sets `submittedAt`; emails admin + vendor |
 | `submitted` | `submitForReview` again | `submitForReview` | `submitted` | Idempotent `200` — no error |
 | `rejected` | `saveDraft` | `saveDraft` | `draft` | **Does not** auto-resubmit |
-| `submitted` | `finalizeVerification` (docs OK) | `finalizeVerification` | `verified` | Badge from points; approval email |
-| `submitted` | `finalizeVerification` (docs missing) | `finalizeVerification` | `rejected` | Rejection email with reason |
+| `submitted` | `finalizeVerification` (explicit `decision: 'approve'`, docs OK) | `finalizeVerification` | `verified` | Badge from points; approval email; review metadata persisted |
+| `submitted` | `finalizeVerification` (explicit `decision: 'approve'`, docs missing) | `finalizeVerification` | — | **Blocked** `400` with `missingRequiredDocuments` — never silently rejects against admin intent |
+| `submitted` | `finalizeVerification` (explicit `decision: 'reject'`) | `finalizeVerification` | `rejected` | Always allowed; admin `rejectionReason` takes precedence; rejection email |
+| `submitted` | `finalizeVerification` (no `decision`, docs OK) | `finalizeVerification` | `verified` | Legacy auto behavior preserved |
+| `submitted` | `finalizeVerification` (no `decision`, docs missing) | `finalizeVerification` | `rejected` | Legacy auto behavior; generated missing-docs reason persisted |
 | `verified` | `saveDraft` | `saveDraft` | — | **Blocked** `400` |
 
 ---
@@ -194,6 +197,21 @@ Admin approval is a two-step process:
 **Route:** `POST /api/vendor-onboarding/:applicationId/finalize` (admin)  
 **Handler:** `finalizeVerification`
 
+**Request body (all optional — omitting `decision` preserves the legacy auto-decide contract):**
+
+| Field | Meaning |
+|-------|---------|
+| `decision` | `'approve'` or `'reject'` — explicit admin intent |
+| `rejectionReason` | Vendor-visible rejection reason (falls back to generated missing-docs list) |
+| `adminNotes` | Internal review notes (persisted, not emailed) |
+| `requiredNextAction` | Vendor-visible next step (defaults to "Update your application and resubmit for review.") |
+
+**Decision rules:**
+
+- `decision: 'approve'` — requires the document checklist below; if docs are missing, returns `400` with `missingRequiredDocuments` (never silently rejects against admin intent).
+- `decision: 'reject'` — always allowed from `submitted`.
+- No `decision` — auto: approve when required docs verified, reject otherwise.
+
 **Approval criteria (launch-critical):** Required **document checklist** flags, not point total:
 
 | Check | Required when |
@@ -202,7 +220,9 @@ Admin approval is a two-step process:
 | `verificationChecklist.businessLicense` | Always |
 | `verificationChecklist.minorityDocs` | Only if `isMinorityOwned === true` |
 
-If all required → `status = 'verified'`. Else → `status = 'rejected'`.
+If approved → `status = 'verified'`. If rejected → `status = 'rejected'`.
+
+**Persisted review metadata (on `VendorOnboardingStage1`):** `reviewDecision`, `rejectionReason`, `adminReviewNotes`, `requiredNextAction`, `reviewedBy`, `reviewedAt`, `verifiedAt` / `rejectedAt`. All are vendor-write-protected (stripped by `saveDraft`). The response includes `data.applicationStatus` with the real stored enum value alongside the legacy `data.status` (`approved`/`rejected`).
 
 **Badge assignment (does not affect approve/reject):**
 
@@ -242,12 +262,13 @@ There is no Stage-1 stalled/deactivated application workflow in the current mode
 
 ## Phase 6: Rejected state
 
-When `finalizeVerification` finds missing required documents:
+When `finalizeVerification` rejects (explicit `decision: 'reject'` or missing required documents):
 
-- `status = 'rejected'`
-- `sendVendorRejectionEmail` with `rejectionReason` listing missing docs
+- `status = 'rejected'`, plus persisted `rejectionReason`, `requiredNextAction`, `adminReviewNotes`, `reviewedBy`, `reviewedAt`, `rejectedAt`
+- `sendVendorRejectionEmail` with the persisted `rejectionReason`
 - Application **leaves** admin queue (queue is `submitted` only)
 - Badge may still be assigned based on points at rejection time
+- `GET /status/:applicationId` surfaces `rejectionReason` and `requiredNextAction` in `details.stage1`, and `nextAction` directs the vendor to revise and resubmit
 
 ### Resubmission path (launch-critical)
 
@@ -359,7 +380,7 @@ From [`utils/vendorOnboardingUploadMimeAllowlist.js`](../utils/vendorOnboardingU
 
 From `VENDOR_PROTECTED_ONBOARDING_FIELDS`:
 
-`verificationPayment`, `status`, `applicationId`, `badge`, `totalVerificationPoints`, `verificationChecklist`, `businessId`, `submittedAt`, `profileCompletionNotifiedAt`, `userId`, `trustScore`, `isApproved`, `isVerified`, `role`, `adminNotes`
+`verificationPayment`, `status`, `applicationId`, `badge`, `totalVerificationPoints`, `verificationChecklist`, `businessId`, `submittedAt`, `profileCompletionNotifiedAt`, `userId`, `trustScore`, `isApproved`, `isVerified`, `role`, `adminNotes`, `reviewDecision`, `rejectionReason`, `adminReviewNotes`, `requiredNextAction`, `reviewedBy`, `reviewedAt`, `verifiedAt`, `rejectedAt`
 
 `saveDraft` calls `stripProtectedVendorFields` before applying payload. Tests confirm protected fields are not applied even on rejected resubmit.
 

--- a/models/VendorOnboardingStage1.js
+++ b/models/VendorOnboardingStage1.js
@@ -163,6 +163,31 @@ const VendorOnboardingStage1Schema = new mongoose.Schema(
 
     submittedAt: Date,
 
+    /* ADMIN REVIEW METADATA (set by finalizeVerification only) */
+    reviewDecision: {
+      type: String,
+      enum: ["approved", "rejected"],
+    },
+    rejectionReason: {
+      type: String,
+      trim: true,
+    },
+    adminReviewNotes: {
+      type: String,
+      trim: true,
+    },
+    requiredNextAction: {
+      type: String,
+      trim: true,
+    },
+    reviewedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+    },
+    reviewedAt: Date,
+    verifiedAt: Date,
+    rejectedAt: Date,
+
     profileCompletionNotifiedAt: Date,
 
     verificationNotificationLog: [

--- a/tests/admin/vendor-onboarding-finalize.test.js
+++ b/tests/admin/vendor-onboarding-finalize.test.js
@@ -180,6 +180,149 @@ test('finalizeVerification rejects when required docs missing', async () => {
   assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
 });
 
+test('finalizeVerification explicit approve persists reviewer identity and timestamps', async () => {
+  const application = buildApplication();
+  const { controller } = loadController({ application });
+  const res = createResponse();
+
+  await controller.finalizeVerification(
+    {
+      params: { applicationId: application.applicationId },
+      body: { decision: 'approve', adminNotes: 'All documents check out' },
+      user: { _id: 'admin-user-id' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(application.status, 'verified');
+  assert.equal(application.reviewDecision, 'approved');
+  assert.equal(application.reviewedBy, 'admin-user-id');
+  assert.ok(application.reviewedAt instanceof Date);
+  assert.ok(application.verifiedAt instanceof Date);
+  assert.equal(application.rejectionReason, undefined);
+  assert.equal(application.adminReviewNotes, 'All documents check out');
+  assert.equal(res.body.data.status, 'approved');
+  assert.equal(res.body.data.applicationStatus, 'verified');
+  assert.equal(res.body.data.reviewedBy, 'admin-user-id');
+  assert.equal(res.body.data.adminReviewNotes, 'All documents check out');
+});
+
+test('finalizeVerification explicit approve fails with 400 when required docs missing', async () => {
+  const application = buildApplication({
+    verificationChecklist: {
+      taxDocs: false,
+      businessLicense: true,
+      minorityDocs: false,
+    },
+  });
+  const { controller, mailerCalls, auditEvents } = loadController({ application });
+  const res = createResponse();
+
+  await controller.finalizeVerification(
+    {
+      params: { applicationId: application.applicationId },
+      body: { decision: 'approve' },
+      user: { _id: 'admin-user-id' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(application.status, 'submitted');
+  assert.deepEqual(res.body.data.missingRequiredDocuments, ['EIN document']);
+  assert.equal(mailerCalls.rejection, undefined);
+  assert.equal(mailerCalls.approved, undefined);
+  assert.equal(auditEvents.at(-1).outcome, 'failure');
+});
+
+test('finalizeVerification explicit reject stores reason, notes, next action, and reviewer', async () => {
+  // Docs are fully verified — auto behavior would approve, but admin rejects.
+  const application = buildApplication();
+  const { controller, mailerCalls, businessUpdates } = loadController({ application });
+  const res = createResponse();
+
+  await controller.finalizeVerification(
+    {
+      params: { applicationId: application.applicationId },
+      body: {
+        decision: 'reject',
+        rejectionReason: 'Business license appears expired',
+        adminNotes: 'Verify renewal before approving',
+        requiredNextAction: 'Upload a current business license and resubmit.',
+      },
+      user: { _id: 'admin-user-id' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(application.status, 'rejected');
+  assert.equal(application.reviewDecision, 'rejected');
+  assert.equal(application.rejectionReason, 'Business license appears expired');
+  assert.equal(application.adminReviewNotes, 'Verify renewal before approving');
+  assert.equal(application.requiredNextAction, 'Upload a current business license and resubmit.');
+  assert.equal(application.reviewedBy, 'admin-user-id');
+  assert.ok(application.rejectedAt instanceof Date);
+  assert.equal(application.verifiedAt, undefined);
+  assert.equal(res.body.data.status, 'rejected');
+  assert.equal(res.body.data.applicationStatus, 'rejected');
+  assert.equal(res.body.data.rejectionReason, 'Business license appears expired');
+  assert.equal(res.body.data.requiredNextAction, 'Upload a current business license and resubmit.');
+  assert.equal(mailerCalls.rejection.rejectionReason, 'Business license appears expired');
+  assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
+});
+
+test('finalizeVerification auto reject persists default review metadata', async () => {
+  const application = buildApplication({
+    verificationChecklist: {
+      taxDocs: false,
+      businessLicense: false,
+      minorityDocs: false,
+    },
+  });
+  const { controller } = loadController({ application });
+  const res = createResponse();
+
+  await controller.finalizeVerification(
+    {
+      params: { applicationId: application.applicationId },
+      user: { _id: 'admin-user-id' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(application.status, 'rejected');
+  assert.equal(
+    application.rejectionReason,
+    'Missing required documents: EIN document, business license document.'
+  );
+  assert.equal(application.requiredNextAction, 'Update your application and resubmit for review.');
+  assert.equal(application.reviewedBy, 'admin-user-id');
+  assert.ok(application.rejectedAt instanceof Date);
+  assert.equal(res.body.data.requiredNextAction, 'Update your application and resubmit for review.');
+});
+
+test('finalizeVerification rejects invalid decision values', async () => {
+  const application = buildApplication();
+  const { controller } = loadController({ application });
+  const res = createResponse();
+
+  await controller.finalizeVerification(
+    {
+      params: { applicationId: application.applicationId },
+      body: { decision: 'maybe' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(application.status, 'submitted');
+});
+
 test('finalizeVerification blocks non-submitted applications', async () => {
   const application = buildApplication({ status: 'verified' });
   const { controller } = loadController({ application });

--- a/tests/vendor/rejected-application-resubmit.test.js
+++ b/tests/vendor/rejected-application-resubmit.test.js
@@ -225,3 +225,43 @@ test('saveDraft on rejected application still strips protected vendor fields', a
   assert.equal(onboarding.totalVerificationPoints, 0);
   assert.equal(onboarding.status, 'draft');
 });
+
+test('saveDraft strips admin review metadata fields from vendor payload', async () => {
+  const onboarding = buildOnboarding({
+    status: 'rejected',
+    rejectionReason: 'Missing required documents: EIN document.',
+    adminReviewNotes: 'Internal note',
+    requiredNextAction: 'Update your application and resubmit for review.',
+    reviewDecision: 'rejected',
+    reviewedBy: 'admin-user-id',
+  });
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.saveDraft(
+    {
+      user: { _id: userId },
+      body: {
+        businessName: 'Revised Name',
+        rejectionReason: 'vendor-forged reason',
+        adminReviewNotes: 'vendor-forged notes',
+        requiredNextAction: 'vendor-forged action',
+        reviewDecision: 'approved',
+        reviewedBy: userId,
+        reviewedAt: new Date(),
+        verifiedAt: new Date(),
+        rejectedAt: null,
+      },
+    },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(onboarding.businessName, 'Revised Name');
+  assert.equal(onboarding.rejectionReason, 'Missing required documents: EIN document.');
+  assert.equal(onboarding.adminReviewNotes, 'Internal note');
+  assert.equal(onboarding.requiredNextAction, 'Update your application and resubmit for review.');
+  assert.equal(onboarding.reviewDecision, 'rejected');
+  assert.equal(onboarding.reviewedBy, 'admin-user-id');
+  assert.equal(onboarding.status, 'draft');
+});

--- a/tests/vendor/vendor-onboarding-business-sync.test.js
+++ b/tests/vendor/vendor-onboarding-business-sync.test.js
@@ -84,7 +84,7 @@ function buildBusinessMocks({ existingBusiness = null, saveError = null } = {}) 
 
 test('syncBusinessFromOnboarding creates Business when none exists', async () => {
   const { syncBusinessFromOnboarding } = require(syncUtilPath);
-  const onboarding = buildOnboarding();
+  const onboarding = buildOnboarding({ status: 'verified' });
   const { Business, Subscription, getCreatedBusiness } = buildBusinessMocks();
 
   const business = await syncBusinessFromOnboarding({
@@ -98,7 +98,30 @@ test('syncBusinessFromOnboarding creates Business when none exists', async () =>
   assert.equal(created.businessName, 'Synced Business');
   assert.equal(created.owner, userId);
   assert.equal(created.subscriptionId, subscriptionId);
+  assert.equal(created.isApproved, true);
   assert.equal(onboarding.businessId, business._id);
+});
+
+test('syncBusinessFromOnboarding does not grant marketplace approval before Stage-1 verification', async () => {
+  const { syncBusinessFromOnboarding } = require(syncUtilPath);
+
+  for (const status of ['draft', 'payment_pending', 'submitted', 'rejected']) {
+    const onboarding = buildOnboarding({ status });
+    const { Business, Subscription, getCreatedBusiness } = buildBusinessMocks();
+
+    await syncBusinessFromOnboarding({
+      userId,
+      onboarding,
+      Business,
+      Subscription,
+    });
+
+    assert.equal(
+      getCreatedBusiness().isApproved,
+      false,
+      `Business created from '${status}' onboarding must not be approved`
+    );
+  }
 });
 
 test('syncBusinessFromOnboarding updates existing Business', async () => {

--- a/tests/vendor/vendor-onboarding-status-next-step.test.js
+++ b/tests/vendor/vendor-onboarding-status-next-step.test.js
@@ -1,0 +1,180 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const profileFieldsPath = path.resolve(
+  __dirname,
+  '../../utils/vendorOnboardingProfileFields.js'
+);
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/vendorOnboarding.controller.js'
+);
+
+const userId = '507f1f77bcf86cd799439011';
+
+function mockResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildOnboarding(overrides = {}) {
+  return {
+    userId,
+    applicationId: 'MBH-APP-STATUS-001',
+    businessName: 'Status Test Business',
+    status: 'rejected',
+    totalVerificationPoints: 20,
+    verificationPayment: { status: 'paid' },
+    submittedAt: new Date('2026-07-01T00:00:00Z'),
+    businessProfileImage: { url: '' },
+    businessBio: '',
+    ...overrides,
+  };
+}
+
+function loadController(onboarding) {
+  process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
+
+  const vendorOnboardingMock = {
+    findOne: async () => onboarding,
+  };
+
+  const subscriptionMock = {
+    findOne: () => ({
+      sort: () => ({
+        populate: async () => null,
+      }),
+    }),
+  };
+
+  const originalLoad = Module._load;
+
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'stripe') {
+      return () => ({ paymentIntents: { create: async () => ({ id: 'pi_test' }) } });
+    }
+    if (request === '../models/VendorOnboardingStage1') {
+      return vendorOnboardingMock;
+    }
+    if (request === '../models/Subscription') {
+      return subscriptionMock;
+    }
+    if (request === '../models/User') {
+      return {};
+    }
+    if (request === '../utils/WellcomeMailer') {
+      return {};
+    }
+    if (request === '../utils/vendorOnboardingProfileFields') {
+      return require(profileFieldsPath);
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const vendorOnboardingPath = path.resolve(
+    __dirname,
+    '../../models/VendorOnboardingStage1.js'
+  );
+  const subscriptionPath = path.resolve(__dirname, '../../models/Subscription.js');
+
+  delete require.cache[controllerPath];
+  delete require.cache[vendorOnboardingPath];
+  delete require.cache[subscriptionPath];
+
+  const loaded = require(controllerPath);
+  Module._load = originalLoad;
+
+  require.cache[vendorOnboardingPath] = {
+    id: vendorOnboardingPath,
+    filename: vendorOnboardingPath,
+    loaded: true,
+    exports: vendorOnboardingMock,
+  };
+  require.cache[subscriptionPath] = {
+    id: subscriptionPath,
+    filename: subscriptionPath,
+    loaded: true,
+    exports: subscriptionMock,
+  };
+
+  return loaded;
+}
+
+test('rejected application status returns stored rejection reason and next action', async () => {
+  const onboarding = buildOnboarding({
+    rejectionReason: 'Missing required documents: EIN document.',
+    requiredNextAction: 'Upload your EIN document and resubmit.',
+    reviewedAt: new Date('2026-07-05T12:00:00Z'),
+  });
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.getStatusByApplicationId(
+    { params: { applicationId: onboarding.applicationId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.status, 'Stage 1 - Rejected');
+  assert.equal(res.body.data.nextAction, 'Upload your EIN document and resubmit.');
+  assert.equal(
+    res.body.data.details.stage1.rejectionReason,
+    'Missing required documents: EIN document.'
+  );
+  assert.equal(
+    res.body.data.details.stage1.requiredNextAction,
+    'Upload your EIN document and resubmit.'
+  );
+  assert.ok(res.body.data.details.stage1.reviewedAt);
+});
+
+test('rejected application without stored review metadata gets resubmit default next action', async () => {
+  const onboarding = buildOnboarding();
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.getStatusByApplicationId(
+    { params: { applicationId: onboarding.applicationId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.nextAction, 'Update your application and resubmit for review.');
+  assert.equal(res.body.data.details.stage1.rejectionReason, null);
+  assert.equal(
+    res.body.data.details.stage1.requiredNextAction,
+    'Update your application and resubmit for review.'
+  );
+});
+
+test('non-rejected application does not expose rejection metadata', async () => {
+  const onboarding = buildOnboarding({
+    status: 'submitted',
+    rejectionReason: 'stale reason from a previous review',
+    requiredNextAction: 'stale action',
+  });
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.getStatusByApplicationId(
+    { params: { applicationId: onboarding.applicationId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.status, 'Stage 1 - Under Admin Review');
+  assert.equal(res.body.data.details.stage1.rejectionReason, null);
+  assert.equal(res.body.data.details.stage1.requiredNextAction, null);
+});

--- a/utils/syncBusinessFromOnboarding.js
+++ b/utils/syncBusinessFromOnboarding.js
@@ -30,7 +30,9 @@ async function syncBusinessFromOnboarding({
     business = new Business({
       owner: userId,
       ...businessData,
-      isApproved: true,
+      // Public marketplace approval mirrors the Stage-1 application decision;
+      // never grant visibility before admin verification.
+      isApproved: onboarding.status === 'verified',
       isActive: true,
       usage: {
         totalProducts: 0,

--- a/utils/vendorOnboardingProfileFields.js
+++ b/utils/vendorOnboardingProfileFields.js
@@ -42,6 +42,15 @@ const VENDOR_PROTECTED_ONBOARDING_FIELDS = [
   'isVerified',
   'role',
   'adminNotes',
+  // Admin review metadata — set only by finalizeVerification
+  'reviewDecision',
+  'rejectionReason',
+  'adminReviewNotes',
+  'requiredNextAction',
+  'reviewedBy',
+  'reviewedAt',
+  'verifiedAt',
+  'rejectedAt',
 ];
 
 const VENDOR_MEDIA_SUBDOC_FIELDS = new Set([


### PR DESCRIPTION
## Summary
- `finalizeVerification` now honors explicit admin intent via optional body `{ decision: 'approve' | 'reject', rejectionReason, adminNotes, requiredNextAction }`. Explicit approve with unverified required docs fails loudly with 400 + `missingRequiredDocuments` instead of silently rejecting; explicit reject is always allowed with an admin-supplied reason. Omitting `decision` preserves the legacy auto-decide contract.
- Rejection/approval now persists real review state on `VendorOnboardingStage1`: `reviewDecision`, `rejectionReason`, `adminReviewNotes`, `requiredNextAction`, `reviewedBy`, `reviewedAt`, `verifiedAt`/`rejectedAt`. All new fields are vendor-write-protected (stripped by `saveDraft`).
- Rejected vendors get a clear next step: `GET /status/:applicationId` returns the stored rejection reason and required next action (default: "Update your application and resubmit for review.") instead of "Our team will contact you."
- `syncBusinessFromOnboarding` derives `Business.isApproved` from `onboarding.status === 'verified'` instead of hardcoding `true`, so public marketplace visibility is never granted before backend approval.
- Email warning metadata (`emailSent`/`emailSkipped`/`emailFailed`) behavior preserved; finalize response additively includes `applicationStatus` (real DB enum) alongside legacy `data.status`.

## Test plan
- [x] `npm test` — 508 pass, 0 fail (includes new finalize decision tests, review-metadata persistence, protected-field stripping, business-sync approval gating, status next-step tests)
- [x] `npm run test:contract` — 20 pass (health endpoints, canonical `/api/featured-products`, route guards, webhook raw-body order)
- [ ] Staging smoke: vendor submit -> admin reject with reason -> vendor sees reason + next action -> vendor resubmits -> admin approve/finalize -> vendor verified