### PR TITLE
fix: persist service features on create

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -200,7 +200,7 @@ exports.createService = async (req, res) => {
 
     const userId = req.user._id;
     const payload = normalizeServicePayload(req.body);
-    const { title, description, isPublished, normalizedServices, parentPrice, parentDuration } = payload;
+    const { title, description, isPublished, normalizedServices, parentPrice, parentDuration, features } = payload;
 
     const business = await Business.findOne({ _id: businessId, owner: userId });
     if (!business)
@@ -288,7 +288,7 @@ exports.createService = async (req, res) => {
       ownerId: userId,
       minorityType: business.minorityType,
       maxBookingsPerSlot: 1,
-      features: [],
+      features,
       amenities: [],
       videos: [],
       faq: []

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -37,6 +37,16 @@ const parsePrice = (value) => {
   return price;
 };
 
+const normalizeStringList = (value = []) => {
+  const items = Array.isArray(value)
+    ? value
+    : (typeof value === 'string' ? [value] : []);
+
+  return items
+    .map((item) => String(item ?? '').trim())
+    .filter(Boolean);
+};
+
 const childMissingPrice = (item) =>
   item.price === undefined || item.price === null || item.price === '';
 
@@ -117,6 +127,7 @@ const normalizeServicePayload = (body = {}) => {
     description: body.description ? String(body.description).trim() : '',
     isPublished: body.isPublished === true || body.isPublished === 'true',
     normalizedServices,
+    features: normalizeStringList(body.features),
     parentPrice: getMinimumChildServicePrice(normalizedServices, 0),
     parentDuration: normalizedServices.length > 0 ? '' : (body.duration ? String(body.duration).trim() : ''),
   };
@@ -266,6 +277,7 @@ const formatValidationErrorResponse = (fieldErrors, message = 'Validation failed
 module.exports = {
   parseDurationMinutes,
   parsePrice,
+  normalizeStringList,
   normalizeChildService,
   normalizeChildServices,
   normalizeServicePayload,

--- a/tests/integration/service-publication.integration.test.js
+++ b/tests/integration/service-publication.integration.test.js
@@ -33,6 +33,7 @@ const canonicalChildPayload = {
   description: 'Full salon menu for integration proof',
   price: 45,
   duration: '60',
+  features: ['Mobile appointments', 'Consultation included'],
   services: [{ name: 'Basic Cut' }],
 };
 
@@ -117,6 +118,10 @@ test('service publication flow: draft private, publish public list + detail, unp
   assert.equal(createRes.body.data.service.title, 'Integration Hair Styling');
   assert.equal(createRes.body.data.service.services[0].price, 45);
   assert.equal(createRes.body.data.service.services[0].durationMinutes, 60);
+  assert.deepEqual(createRes.body.data.service.features, [
+    'Mobile appointments',
+    'Consultation included',
+  ]);
 
   const privateList = await agent.get('/api/private/services/list').query({
     businessId: String(business._id),
@@ -127,6 +132,10 @@ test('service publication flow: draft private, publish public list + detail, unp
   const myServicesDraft = await agent.get('/api/service/my-services');
   assert.equal(myServicesDraft.status, 200);
   assert.ok(myServicesDraft.body.services.some((entry) => String(entry._id) === serviceId));
+  assert.deepEqual(
+    myServicesDraft.body.services.find((entry) => String(entry._id) === serviceId).features,
+    ['Mobile appointments', 'Consultation included']
+  );
   assert.equal(myServicesDraft.body.publicationByServiceId[serviceId].isPublished, false);
 
   await assertPublicSurfacesExcludeService(agent, serviceId, slug);

--- a/tests/service/service-payload-contract.test.js
+++ b/tests/service/service-payload-contract.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
+  normalizeStringList,
   normalizeServicePayload,
   PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
   validateChildServices,
@@ -31,6 +32,7 @@ test('normalizeServicePayload persists canonical parent and child fields', () =>
   const payload = normalizeServicePayload({
     title: 'Hair Styling',
     description: 'Full salon menu',
+    features: [' Mobile appointments ', '', null, 'Consultation included'],
     services: [{
       name: 'Basic Cut',
       price: 45,
@@ -43,6 +45,16 @@ test('normalizeServicePayload persists canonical parent and child fields', () =>
   assert.equal(payload.parentPrice, 45);
   assert.equal(payload.normalizedServices[0].price, 45);
   assert.equal(payload.normalizedServices[0].durationMinutes, 60);
+  assert.deepEqual(payload.features, ['Mobile appointments', 'Consultation included']);
+});
+
+test('normalizeStringList accepts arrays and single strings', () => {
+  assert.deepEqual(
+    normalizeStringList(['  One ', '', undefined, 'Two']),
+    ['One', 'Two']
+  );
+  assert.deepEqual(normalizeStringList(' One feature '), ['One feature']);
+  assert.deepEqual(normalizeStringList({ label: 'nope' }), []);
 });
 
 test('normalizeServicePayload backfills single name-only child from top-level price and duration', () => {

--- a/tests/service/service-publication-visibility.test.js
+++ b/tests/service/service-publication-visibility.test.js
@@ -319,6 +319,30 @@ test('createService returns field errors for frontend name-only child without to
   assert.ok(res.body.fieldErrors['services[0].durationMinutes']);
 });
 
+test('createService persists normalized listing features on first save', async () => {
+  const { controller, savedDocs } = loadServiceController({ existingService: null });
+  const res = mockResponse();
+
+  await controller.createService(
+    {
+      user: { _id: ownerId },
+      body: {
+        businessId,
+        categoryId: '507f1f77bcf86cd799439014',
+        subcategoryId: '507f1f77bcf86cd799439015',
+        title: 'Hair Styling',
+        features: [' Mobile appointments ', '', 'Consultation included'],
+        services: [{ name: 'Cut', price: 45, durationMinutes: 60 }],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(savedDocs[0].features, ['Mobile appointments', 'Consultation included']);
+  assert.deepEqual(res.body.data.service.features, ['Mobile appointments', 'Consultation included']);
+});
+
 test('public getServiceById excludes unpublished services', async () => {
   const { controller } = loadPublicListingController({
     service: buildServiceDoc({ isPublished: false }),


### PR DESCRIPTION
## Summary
- Persists normalized service listing `features` during `POST /api/service/` create instead of overwriting them with an empty array.
- Adds shared string-list normalization for service payloads.
- Adds service contract, controller, and integration coverage proving features survive create and vendor service retrieval.

## Scope
- Backend service create payload normalization and persistence.
- Tests for service contract, publication visibility, and vendor retrieval.
- No frontend UI changes in this PR.

## Files changed
- `controllers/serviceController.js`
- `lib/service/serviceContract.js`
- `tests/integration/service-publication.integration.test.js`
- `tests/service/service-payload-contract.test.js`
- `tests/service/service-publication-visibility.test.js`

## Verification
- `node --test tests/service/service-payload-contract.test.js tests/service/service-publication-visibility.test.js`: passed, 17 tests.
- `npm run test:integration`: passed, 72 tests.
- `npm test`: passed, 524 tests.
- GitHub CI `Test`: success.
- GitHub CI `build`: success.

## Risks
- Low backend risk; payload normalization can affect malformed service feature inputs.
- Existing clients that send feature-like values should now persist normalized strings rather than being discarded.

## Rollback
- Revert this PR's merge commit from `staging` to return service create behavior to the previous feature persistence behavior.
- No migration or data cleanup is required.

## What was not tested
- Manual vendor UI editing was not tested in this backend PR.
- Production data backfill was not tested or required.
- File upload behavior was not tested because it is out of scope.

## Dependency notes
- Depends on backend docs PR #201 for traceability.
- Should precede service offering count PR #206 in the July 6 merge sequence.
- Supports frontend service feature/edit follow-up validation, but does not require a frontend PR to run.

## Safety checks
- No secrets committed.
- No deploy performed during this PR-description polish pass.
- No PR/base-branch merge performed during this polish pass; GitHub shows this PR was already merged before the polish pass.
- `GET /api/featured-products` preserved.
- `/api/products/featured` not introduced.
- Backend `app.js` middleware not reordered.
- Stripe webhook order not changed.
- Payment/webhook logic not touched.

## Launch/UAT status
Fixed / Ready for Review. GitHub currently shows this PR already merged to `staging`; integrated UAT remains pending and this is not client acceptance.