### PR TITLE
fix: add admin application status filters

### DIFF
--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -23,8 +23,21 @@ const {
 // submission and are waiting for stage-1 review. Rejected resubmissions re-enter
 // the queue by transitioning back to `submitted` in vendorOnboarding.controller.
 const PENDING_REVIEW_STATUSES = Object.freeze(['submitted']);
+const APPLICATION_STATUS_FILTERS = Object.freeze([
+  'draft',
+  'payment_pending',
+  'submitted',
+  'verified',
+  'rejected',
+]);
+const APPLICATION_STATUS_ALIASES = Object.freeze({
+  pending: PENDING_REVIEW_STATUSES,
+  under_review: PENDING_REVIEW_STATUSES,
+  approved: ['verified'],
+});
 
 exports.PENDING_REVIEW_STATUSES = PENDING_REVIEW_STATUSES;
+exports.APPLICATION_STATUS_FILTERS = APPLICATION_STATUS_FILTERS;
 
 const VERIFICATION_GUIDANCE_OUTCOMES = Object.freeze({
   missing_documents: {
@@ -195,6 +208,56 @@ const autoVerifyMinorityDocsIfMissing = async (application) => {
   return 10;
 };
 
+const buildApplicationStatusQuery = (rawStatus) => {
+  if (rawStatus === undefined || rawStatus === null || rawStatus === '') {
+    return {
+      query: { status: { $in: [...PENDING_REVIEW_STATUSES] } },
+      statusFilter: 'pending',
+      statuses: [...PENDING_REVIEW_STATUSES],
+    };
+  }
+
+  const values = (Array.isArray(rawStatus) ? rawStatus : String(rawStatus).split(','))
+    .map((value) => String(value || '').trim().toLowerCase())
+    .filter(Boolean);
+
+  if (values.length === 0 || values.includes('all')) {
+    return {
+      query: {},
+      statusFilter: 'all',
+      statuses: [...APPLICATION_STATUS_FILTERS],
+    };
+  }
+
+  const statuses = [];
+  const invalidStatuses = [];
+
+  for (const value of values) {
+    const mapped = APPLICATION_STATUS_ALIASES[value] || [value];
+    for (const status of mapped) {
+      if (!APPLICATION_STATUS_FILTERS.includes(status)) {
+        invalidStatuses.push(value);
+      } else if (!statuses.includes(status)) {
+        statuses.push(status);
+      }
+    }
+  }
+
+  if (invalidStatuses.length > 0 || statuses.length === 0) {
+    return {
+      error: `Invalid application status filter: ${[...new Set(invalidStatuses)].join(', ')}`,
+    };
+  }
+
+  return {
+    query: { status: { $in: statuses } },
+    statusFilter: values.join(','),
+    statuses,
+  };
+};
+
+exports.buildApplicationStatusQuery = buildApplicationStatusQuery;
+
 /* =====================================================
    GET PENDING APPLICATIONS
 ===================================================== */
@@ -202,19 +265,36 @@ const autoVerifyMinorityDocsIfMissing = async (application) => {
 
 exports.getPendingApplications = async (req, res) => {
   try {
-    const applications = await VendorOnboarding.find({
-      status: { $in: PENDING_REVIEW_STATUSES }
-    })
+    const statusQuery = buildApplicationStatusQuery(req.query?.status);
+
+    if (statusQuery.error) {
+      return res.status(400).json({
+        success: false,
+        message: statusQuery.error,
+        fieldErrors: {
+          status: statusQuery.error,
+        },
+      });
+    }
+
+    const applications = await VendorOnboarding.find(statusQuery.query)
       .populate('userId', 'name email')
       .sort({ submittedAt: -1, createdAt: -1 });
 
     await Promise.all(
-      applications.map((application) => autoVerifyMinorityDocsIfMissing(application))
+      applications
+        .filter((application) => PENDING_REVIEW_STATUSES.includes(application.status))
+        .map((application) => autoVerifyMinorityDocsIfMissing(application))
     );
 
     return res.status(200).json({
       success: true,
-      data: applications
+      data: applications,
+      meta: {
+        statusFilter: statusQuery.statusFilter,
+        statuses: statusQuery.statuses,
+        availableStatuses: [...APPLICATION_STATUS_FILTERS],
+      },
     });
   } catch (error) {
     console.error('Get all applications error:', error);

--- a/tests/admin/vendorOnboardVerifyStage1.pending-applications.test.js
+++ b/tests/admin/vendorOnboardVerifyStage1.pending-applications.test.js
@@ -124,12 +124,85 @@ test('getPendingApplications returns only submitted applications for admin revie
   assert.equal(res.statusCode, 200);
   assert.equal(res.body.success, true);
   assert.deepEqual(queryLog.query, { status: { $in: ['submitted'] } });
+  assert.deepEqual(res.body.meta.statuses, ['submitted']);
   assert.deepEqual(queryLog.populate, { path: 'userId', select: 'name email' });
   assert.deepEqual(queryLog.sort, { submittedAt: -1, createdAt: -1 });
   assert.deepEqual(
     res.body.data.map((application) => application.status),
     ['submitted']
   );
+});
+
+test('getPendingApplications status=all returns every application status', async () => {
+  const applications = [
+    buildApplication('draft'),
+    buildApplication('payment_pending'),
+    buildApplication('submitted'),
+    buildApplication('rejected'),
+    buildApplication('verified'),
+  ];
+  const { controller, queryLog } = loadControllerWithMocks(applications);
+  const res = createResponse();
+
+  await controller.getPendingApplications({ query: { status: 'all' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(queryLog.query, {});
+  assert.equal(res.body.meta.statusFilter, 'all');
+  assert.deepEqual(
+    res.body.data.map((application) => application.status),
+    ['draft', 'payment_pending', 'submitted', 'rejected', 'verified']
+  );
+});
+
+test('getPendingApplications filters specific statuses and maps approved alias to verified', async () => {
+  const applications = [
+    buildApplication('submitted'),
+    buildApplication('rejected'),
+    buildApplication('verified'),
+  ];
+  const { controller, queryLog } = loadControllerWithMocks(applications);
+  const res = createResponse();
+
+  await controller.getPendingApplications({ query: { status: 'rejected,approved' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(queryLog.query, { status: { $in: ['rejected', 'verified'] } });
+  assert.deepEqual(res.body.meta.statuses, ['rejected', 'verified']);
+  assert.deepEqual(
+    res.body.data.map((application) => application.status),
+    ['rejected', 'verified']
+  );
+});
+
+test('getPendingApplications maps under_review and pending aliases to submitted queue', async () => {
+  const applications = [
+    buildApplication('draft'),
+    buildApplication('submitted'),
+  ];
+  const { controller, queryLog } = loadControllerWithMocks(applications);
+  const res = createResponse();
+
+  await controller.getPendingApplications({ query: { status: ['under_review', 'pending'] } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(queryLog.query, { status: { $in: ['submitted'] } });
+  assert.deepEqual(res.body.meta.statuses, ['submitted']);
+  assert.deepEqual(
+    res.body.data.map((application) => application.status),
+    ['submitted']
+  );
+});
+
+test('getPendingApplications rejects invalid status filters', async () => {
+  const { controller } = loadControllerWithMocks([buildApplication('submitted')]);
+  const res = createResponse();
+
+  await controller.getPendingApplications({ query: { status: 'archived' } }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.ok(res.body.fieldErrors.status.includes('archived'));
 });
 
 test('getPendingApplications includes resubmitted applications once they return to submitted status', async () => {
@@ -185,8 +258,15 @@ test('getPendingApplications excludes payment_pending applications with failed v
 });
 
 test('getPendingApplications uses submitted-only allowlist constant', () => {
-  const { PENDING_REVIEW_STATUSES } = require(controllerPath);
+  const { APPLICATION_STATUS_FILTERS, PENDING_REVIEW_STATUSES } = require(controllerPath);
   assert.deepEqual(PENDING_REVIEW_STATUSES, ['submitted']);
+  assert.deepEqual(APPLICATION_STATUS_FILTERS, [
+    'draft',
+    'payment_pending',
+    'submitted',
+    'verified',
+    'rejected',
+  ]);
 });
 
 test('vendor onboarding pending route blocks non-admin users', () => {

--- a/tests/integration/vendor-onboarding.integration.test.js
+++ b/tests/integration/vendor-onboarding.integration.test.js
@@ -142,3 +142,66 @@ test('rejected application state is readable by admin', async () => {
   assert.equal(detail.status, 200);
   assert.equal(detail.body.data.status, 'rejected');
 });
+
+test('admin can list vendor applications by status filter', async () => {
+  const vendorAgent = createAgent(getApp());
+  const submittedVendor = await registerAndVerify(vendorAgent, {
+    role: 'business_owner',
+  });
+  const submittedUser = await User.findOne({ email: submittedVendor.email });
+  await seedVendorOnboarding(submittedUser, {
+    applicationId: 'MBH-INT-SUBMITTED-FILTER',
+    status: 'submitted',
+  });
+
+  const rejectedVendor = await registerAndVerify(createAgent(getApp()), {
+    role: 'business_owner',
+  });
+  const rejectedUser = await User.findOne({ email: rejectedVendor.email });
+  await seedVendorOnboarding(rejectedUser, {
+    applicationId: 'MBH-INT-REJECTED-FILTER',
+    status: 'rejected',
+    rejectionReason: 'Integration rejected filter proof',
+  });
+
+  const verifiedVendor = await registerAndVerify(createAgent(getApp()), {
+    role: 'business_owner',
+  });
+  const verifiedUser = await User.findOne({ email: verifiedVendor.email });
+  await seedVendorOnboarding(verifiedUser, {
+    applicationId: 'MBH-INT-VERIFIED-FILTER',
+    status: 'verified',
+  });
+
+  const { email, password } = await createAdminDirect();
+  const adminAgent = createAgent(getApp());
+  await login(adminAgent, email, password);
+
+  const all = await adminAgent.get('/api/vendor-onboarding/pending').query({ status: 'all' });
+  assert.equal(all.status, 200);
+  assert.deepEqual(all.body.meta.statuses, [
+    'draft',
+    'payment_pending',
+    'submitted',
+    'verified',
+    'rejected',
+  ]);
+  assert.ok(all.body.data.some((application) => application.applicationId === 'MBH-INT-SUBMITTED-FILTER'));
+  assert.ok(all.body.data.some((application) => application.applicationId === 'MBH-INT-REJECTED-FILTER'));
+  assert.ok(all.body.data.some((application) => application.applicationId === 'MBH-INT-VERIFIED-FILTER'));
+
+  const rejected = await adminAgent.get('/api/vendor-onboarding/pending').query({ status: 'rejected' });
+  assert.equal(rejected.status, 200);
+  assert.deepEqual(
+    rejected.body.data.map((application) => application.applicationId),
+    ['MBH-INT-REJECTED-FILTER']
+  );
+
+  const approvedAlias = await adminAgent.get('/api/vendor-onboarding/pending').query({ status: 'approved' });
+  assert.equal(approvedAlias.status, 200);
+  assert.deepEqual(approvedAlias.body.meta.statuses, ['verified']);
+  assert.deepEqual(
+    approvedAlias.body.data.map((application) => application.applicationId),
+    ['MBH-INT-VERIFIED-FILTER']
+  );
+});


### PR DESCRIPTION
## Summary
- Adds an explicit status-filter contract to `GET /api/vendor-onboarding/pending`.
- Supports `all`, canonical application statuses, and legacy aliases including `pending`, `under_review`, and `approved`.
- Keeps the default admin review queue submitted-only and scopes the minority-document auto-verify helper to submitted applications only.
- Adds unit and integration coverage for filtered admin application lists.

## Scope
- Backend admin vendor onboarding application list API.
- Status filter parsing, alias mapping, and submitted-only default behavior.
- No frontend UI change in this PR.

## Files changed
- `controllers/admin/vendorOnboardVerifyStage1.js`
- `tests/admin/vendorOnboardVerifyStage1.pending-applications.test.js`
- `tests/integration/vendor-onboarding.integration.test.js`

## Verification
- `node --test tests/admin/vendorOnboardVerifyStage1.pending-applications.test.js tests/integration/vendor-onboarding.integration.test.js`: completed successfully.
- `npm test`: completed successfully.
- `npm run test:integration`: completed successfully.
- GitHub CI `Test`: success.
- GitHub CI `build`: success.

## Risks
- Medium-low API risk because admin filtering changes query behavior.
- Default behavior remains submitted-only to avoid surprising existing admin views.
- Alias support reduces frontend/backward-compatibility risk.

## Rollback
- Revert this PR's merge commit from `staging` to remove backend status filtering and restore the submitted-only pending endpoint behavior.
- No data migration rollback is required.

## What was not tested
- Manual admin browser filtering was not tested in this backend PR.
- Frontend status-filter UI is covered separately by frontend PR #326.
- No email delivery or payment flow was tested because those are out of scope.

## Dependency notes
- Depends on backend docs PR #201 for traceability.
- Frontend admin filters UI PR #326 depends on this backend API contract.
- Intended merge order: backend #203 before frontend #326.

## Safety checks
- No secrets committed.
- No deploy performed during this PR-description polish pass.
- No PR/base-branch merge performed during this polish pass; GitHub shows this PR was already merged before the polish pass.
- `GET /api/featured-products` preserved.
- `/api/products/featured` not introduced.
- Backend `app.js` middleware not reordered.
- Stripe webhook order not changed.
- Payment/webhook logic not touched.

## Launch/UAT status
Fixed / Ready for Review. GitHub currently shows this PR already merged to `staging`; integrated UAT remains pending and this is not client acceptance.