### PR TITLE
[codex] fix: make connect optional for service and food publication

### DIFF
--- a/tests/integration/business-storefront-publication.integration.test.js
+++ b/tests/integration/business-storefront-publication.integration.test.js
@@ -284,8 +284,8 @@ test('vendor publish-storefront publishes draft service listings', async () => {
   const vendor = await registerAndVerify(agent, { role: 'business_owner' });
   const user = await User.findOne({ email: vendor.email });
   const business = await seedServiceBusiness(user, {
-    chargesEnabled: true,
-    payoutsEnabled: true,
+    chargesEnabled: false,
+    payoutsEnabled: false,
   });
   const { category, subcategory } = await seedServiceCategories();
   await seedVendorOnboarding(user, {
@@ -313,6 +313,8 @@ test('vendor publish-storefront publishes draft service listings', async () => {
 
   const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
   assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+  assert.equal(publishRes.body.publication.payoutRequired, false);
+  assert.equal(publishRes.body.publication.payoutComplete, true);
   assert.equal(publishRes.body.publication.published.services, 1);
 
   const reloadedService = await Service.findById(service._id).lean();
@@ -328,8 +330,8 @@ test('vendor publish-storefront publishes draft food listings and public food de
   const user = await User.findOne({ email: vendor.email });
   const business = await seedApprovedBusiness(user, {
     listingType: 'food',
-    chargesEnabled: true,
-    payoutsEnabled: true,
+    chargesEnabled: false,
+    payoutsEnabled: false,
   });
   await seedVendorOnboarding(user, {
     businessId: business._id,
@@ -356,6 +358,8 @@ test('vendor publish-storefront publishes draft food listings and public food de
 
   const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
   assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+  assert.equal(publishRes.body.publication.payoutRequired, false);
+  assert.equal(publishRes.body.publication.payoutComplete, true);
   assert.equal(publishRes.body.publication.published.foods, 1);
 
   const reloadedFood = await Food.findById(food._id).lean();

--- a/utils/businessListingVisibility.js
+++ b/utils/businessListingVisibility.js
@@ -8,6 +8,20 @@ const {
 } = require('../lib/marketplace/businessEligibility');
 
 const LISTING_TYPES = new Set(['product', 'service', 'food']);
+const PAYOUT_REQUIRED_LISTING_TYPES = new Set(['product']);
+
+function normalizeListingType(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function requiresPayoutSetupForBusiness(business) {
+  return PAYOUT_REQUIRED_LISTING_TYPES.has(normalizeListingType(business?.listingType));
+}
+
+function isPayoutCompleteForBusiness(business) {
+  if (!requiresPayoutSetupForBusiness(business)) return true;
+  return Boolean(business?.chargesEnabled === true && business?.payoutsEnabled === true);
+}
 
 function normalizeId(value) {
   if (!value) return null;
@@ -251,7 +265,7 @@ async function enrichBusinessesWithListingSnapshots(businesses = []) {
 
 function buildPublicationBlockers({ business, onboarding, snapshot }) {
   const blockers = [];
-  const listingType = String(business?.listingType || '').trim().toLowerCase();
+  const listingType = normalizeListingType(business?.listingType);
   const eligible = getEligibleListingsForBusiness(business, snapshot);
 
   if (!onboarding || onboarding.status !== 'verified') {
@@ -275,7 +289,7 @@ function buildPublicationBlockers({ business, onboarding, snapshot }) {
     });
   }
 
-  if (business?.chargesEnabled !== true || business?.payoutsEnabled !== true) {
+  if (requiresPayoutSetupForBusiness(business) && !isPayoutCompleteForBusiness(business)) {
     blockers.push({
       code: 'PAYOUT_SETUP_REQUIRED',
       message: 'Complete payout setup before publishing.',
@@ -300,13 +314,15 @@ function buildPublicationBlockers({ business, onboarding, snapshot }) {
 function buildOnboardingReadiness({ business, onboarding, snapshot }) {
   const eligible = getEligibleListingsForBusiness(business, snapshot);
   const hasListing = eligible.listings.length > 0;
-  const payoutComplete = Boolean(business?.chargesEnabled && business?.payoutsEnabled);
+  const payoutRequired = requiresPayoutSetupForBusiness(business);
+  const payoutComplete = isPayoutCompleteForBusiness(business);
   const blockers = buildPublicationBlockers({ business, onboarding, snapshot });
 
   return {
     listingType: business?.listingType || null,
     hasListing,
     requiredListingCount: eligible.listings.length,
+    payoutRequired,
     payoutComplete,
     vendorVerificationStatus: onboarding?.status || null,
     canFinalReview: hasListing && payoutComplete,
@@ -341,6 +357,8 @@ async function publishBusinessListings({ business, userId }) {
         listingType: business.listingType,
         publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
         hasRequiredListing: getEligibleListingsForBusiness(business, snapshot).listings.length > 0,
+        payoutRequired: requiresPayoutSetupForBusiness(business),
+        payoutComplete: isPayoutCompleteForBusiness(business),
         blockers,
       },
     };
@@ -404,6 +422,8 @@ async function publishBusinessListings({ business, userId }) {
       publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
       hasRequiredListing: true,
       requiredListingCount: eligible.listings.length,
+      payoutRequired: requiresPayoutSetupForBusiness(business),
+      payoutComplete: isPayoutCompleteForBusiness(business),
       published,
       blockers: [],
     },
@@ -417,4 +437,5 @@ module.exports = {
   getEligibleListingsForBusiness,
   loadListingSnapshotsByBusinessIds,
   publishBusinessListings,
+  requiresPayoutSetupForBusiness,
 };


### PR DESCRIPTION
## Summary
- Requires Stripe Connect/payout setup only for product storefront publication.
- Treats service and food businesses as payout-complete for publication readiness while preserving product payout blockers.
- Returns `payoutRequired`/`payoutComplete` in publication payloads and covers service/food no-Connect publication in integration tests.

## Scope
- Backend storefront publication readiness and publication payload metadata for listing-type-specific payout requirements.
- Product vendor payout/Connect blockers are preserved.
- Does not change Stripe account-link, payment intent, subscription, checkout, or webhook logic.

## Files changed
- `tests/integration/business-storefront-publication.integration.test.js`
- `utils/businessListingVisibility.js`

## Verification
- `node --test tests/integration/business-storefront-publication.integration.test.js`: completed successfully.
- `npm test`: completed successfully.
- `npm run test:integration`: completed successfully.
- `git diff --check`: completed before merge.
- GitHub CI `Test`: success.
- GitHub CI `build`: success.

## Risks
- Medium policy/flow risk because payout requirements differ by vendor listing type.
- Product vendors remain on the existing payout path; service/food vendors should be verified in integrated UAT to ensure no server-side final-review blocker remains.

## Rollback
- Revert this PR's merge commit from `staging` to restore the previous payout-required-for-publication behavior.
- No data migration rollback is required.

## What was not tested
- Live Stripe Connect onboarding was not tested because account-link/payment behavior is out of scope.
- Frontend messaging/step gating is covered separately by frontend PR #330.
- Integrated service/food vendor final-review UAT remains pending.

## Dependency notes
- Original release plan said this PR should remain blocked until rebased/resolved after backend #206.
- GitHub now shows this PR was already merged before this post-merge polish note was added, so it cannot be kept draft.
- Frontend PR #330 depends on this backend publication rule.

## Safety checks
- No secrets committed.
- No deploy performed during this PR-description polish pass.
- No PR/base-branch merge performed during this polish pass; GitHub shows this PR was already merged before the polish pass.
- `GET /api/featured-products` preserved.
- `/api/products/featured` not introduced.
- Backend `app.js` middleware not reordered.
- Stripe webhook order not changed.
- Payment/webhook/account-link logic not touched.

## Launch/UAT status
Pending UAT. This PR was supposed to remain draft in the release plan, but GitHub shows it already merged to `staging` at `2026-07-06T17:29:34Z`. This is not client acceptance.