### PR TITLE
[codex] fix: count service offerings in listing snapshots

### DIFF
--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -242,6 +242,21 @@ function trimImagesForCard(fullImages) {
   };
 }
 
+function normalizeServiceOfferings(services) {
+  if (!Array.isArray(services)) return [];
+  return services
+    .map((service) => ({
+      id: normalizeId(service?._id ?? service?.id),
+      name: service?.name ? String(service.name).trim() : null,
+      price: normalizePrice(service?.price),
+      durationMinutes:
+        service?.durationMinutes != null && Number.isFinite(Number(service.durationMinutes))
+          ? Number(service.durationMinutes)
+          : null,
+    }))
+    .filter((service) => service.id || service.name);
+}
+
 function toPublicListingCard(raw, options = {}) {
   const listingType = options.listingType || 'product';
   const doc = raw && typeof raw.toObject === 'function' ? raw.toObject() : { ...raw };
@@ -264,6 +279,8 @@ function toPublicListingCard(raw, options = {}) {
   const { location, city, state } = normalizeLocation(doc, businessSource);
   const priceLabel = normalizePriceLabel(price);
   const vendorLogo = businessSource?.logo ?? vendor.business?.logo ?? null;
+  const serviceOfferings =
+    listingType === 'service' ? normalizeServiceOfferings(doc.services) : undefined;
 
   const cardBase = {
     ...pickLegacyCardFields(doc),
@@ -296,6 +313,9 @@ function toPublicListingCard(raw, options = {}) {
     badge: vendor.badge,
     verified,
     contact: vendor.contact,
+    serviceOfferingCount: serviceOfferings?.length,
+    serviceOfferingNames: serviceOfferings?.map((service) => service.name).filter(Boolean),
+    serviceOfferings,
     detailPath: null,
   };
 
@@ -388,5 +408,6 @@ module.exports = {
   toPublicListingCard,
   toPublicListingDetail,
   toPublicBusinessCard,
+  normalizeServiceOfferings,
   truncateDescription,
 };

--- a/tests/integration/business-storefront-publication.integration.test.js
+++ b/tests/integration/business-storefront-publication.integration.test.js
@@ -109,6 +109,7 @@ test('GET /api/business/my returns zero listing counts and readiness blockers wh
   assert.equal(returnedBusiness.foods.length, 0);
   assert.equal(returnedBusiness.listingCounts.products, 0);
   assert.equal(returnedBusiness.listingCounts.services, 0);
+  assert.equal(returnedBusiness.listingCounts.serviceListings, 0);
   assert.equal(returnedBusiness.listingCounts.foods, 0);
   assert.equal(returnedBusiness.listingCounts.total, 0);
   assert.equal(returnedBusiness.onboardingReadiness.hasListing, false);
@@ -159,7 +160,7 @@ test('GET /api/business/my reports draft and published listing status counts fro
   assert.equal(publicProduct.status, 200, JSON.stringify(publicProduct.body));
 });
 
-test('GET /api/business/my counts product service and food records by business', async () => {
+test('GET /api/business/my counts product records, service offerings, and food records by business', async () => {
   const agent = createAgent(getApp());
   const vendor = await registerAndVerify(agent, { role: 'business_owner' });
   const user = await User.findOne({ email: vendor.email });
@@ -190,13 +191,17 @@ test('GET /api/business/my counts product service and food records by business',
   });
   await Service.create({
     title: 'Counted Service',
-    description: 'Service counted from Service collection.',
+    description: 'Service offerings counted from Service collection.',
     categoryId: category._id,
     subcategoryId: subcategory._id,
     ownerId: user._id,
     businessId: serviceBusiness._id,
     coverImage: 'https://example.test/counted-service.png',
-    services: [{ name: 'Session', durationMinutes: 45, price: 75 }],
+    services: [
+      { name: 'Session', durationMinutes: 45, price: 75 },
+      { name: 'Follow-up', durationMinutes: 30, price: 45 },
+      { name: 'Planning', durationMinutes: 60, price: 95 },
+    ],
     isPublished: false,
   });
   await Food.create({
@@ -221,8 +226,13 @@ test('GET /api/business/my counts product service and food records by business',
   const byId = new Map(res.body.businesses.map((item) => [String(item._id), item]));
   assert.equal(byId.get(String(productBusiness._id)).listingCounts.products, 1);
   assert.equal(byId.get(String(productBusiness._id)).listingCounts.total, 1);
-  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.services, 1);
-  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.total, 1);
+  assert.equal(byId.get(String(serviceBusiness._id)).services.length, 1);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.services, 3);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.serviceListings, 1);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.draftServices, 3);
+  assert.equal(byId.get(String(serviceBusiness._id)).listingCounts.total, 3);
+  assert.equal(byId.get(String(serviceBusiness._id)).publication.requiredListingCount, 3);
+  assert.equal(byId.get(String(serviceBusiness._id)).onboardingReadiness.requiredListingCount, 3);
   assert.equal(byId.get(String(foodBusiness._id)).listingCounts.foods, 1);
   assert.equal(byId.get(String(foodBusiness._id)).listingCounts.total, 1);
 });
@@ -300,7 +310,10 @@ test('vendor publish-storefront publishes draft service listings', async () => {
     ownerId: user._id,
     businessId: business._id,
     coverImage: 'https://example.test/storefront-service.png',
-    services: [{ name: 'Consultation', durationMinutes: 30, price: 50 }],
+    services: [
+      { name: 'Consultation', durationMinutes: 30, price: 50 },
+      { name: 'Implementation', durationMinutes: 60, price: 125 },
+    ],
     isPublished: false,
   });
 
@@ -313,7 +326,9 @@ test('vendor publish-storefront publishes draft service listings', async () => {
 
   const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
   assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
-  assert.equal(publishRes.body.publication.published.services, 1);
+  assert.equal(publishRes.body.publication.requiredListingCount, 2);
+  assert.equal(publishRes.body.publication.published.services, 2);
+  assert.equal(publishRes.body.publication.published.serviceListings, 1);
 
   const reloadedService = await Service.findById(service._id).lean();
   assert.equal(reloadedService.isPublished, true);

--- a/tests/marketplace/public-listing-dto.test.js
+++ b/tests/marketplace/public-listing-dto.test.js
@@ -8,6 +8,7 @@ const {
   normalizeImages,
   normalizeListingStatus,
   normalizeLocation,
+  normalizeServiceOfferings,
   toPublicListingCard,
   toPublicListingDetail,
   toPublicBusinessCard,
@@ -126,6 +127,30 @@ test('toPublicListingCard handles service businessDetails legacy shape', () => {
   assert.equal(card.vendorName, 'Consult LLC');
   assert.equal(card.businessDetails.businessName, 'Consult LLC');
   assert.equal(card.imageUrl, 'https://cdn.example.com/logo.jpg');
+});
+
+test('toPublicListingCard exposes service offering summaries', () => {
+  const card = toPublicListingCard(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Consulting',
+      services: [
+        { _id: 'svc-child-1', name: 'Planning', price: 50, durationMinutes: 30 },
+        { _id: 'svc-child-2', name: 'Build', price: 150, durationMinutes: 90 },
+        { name: 'Review' },
+      ],
+    },
+    { listingType: 'service' }
+  );
+
+  assert.equal(card.serviceOfferingCount, 3);
+  assert.deepEqual(card.serviceOfferingNames, ['Planning', 'Build', 'Review']);
+  assert.equal(card.serviceOfferings[0].price, 50);
+  assert.equal(card.serviceOfferings[1].durationMinutes, 90);
+  assert.deepEqual(
+    normalizeServiceOfferings([{ name: 'Valid' }, {}, null]),
+    [{ id: null, name: 'Valid', price: null, durationMinutes: null }]
+  );
 });
 
 test('toPublicBusinessCard normalizes vendor browse card fields', () => {

--- a/utils/businessListingVisibility.js
+++ b/utils/businessListingVisibility.js
@@ -51,11 +51,31 @@ function countDraft(items = []) {
   return items.filter((item) => item.isPublished !== true).length;
 }
 
+function getServiceOfferings(service) {
+  if (!Array.isArray(service?.services)) return [];
+  return service.services.filter((item) => item && (item._id || item.name));
+}
+
+function countServiceOfferings(services = []) {
+  return services.reduce((sum, service) => sum + getServiceOfferings(service).length, 0);
+}
+
+function countPublishedServiceOfferings(services = []) {
+  return countServiceOfferings(services.filter((service) => service.isPublished === true));
+}
+
+function countDraftServiceOfferings(services = []) {
+  return countServiceOfferings(services.filter((service) => service.isPublished !== true));
+}
+
 function summarizeCounts(snapshot) {
   const products = snapshot.products || [];
   const services = snapshot.services || [];
   const foods = snapshot.foods || [];
   const productVariants = products.flatMap((product) => product.variants || []);
+  const serviceOfferings = countServiceOfferings(services);
+  const publishedServiceOfferings = countPublishedServiceOfferings(services);
+  const draftServiceOfferings = countDraftServiceOfferings(services);
 
   return {
     products: products.length,
@@ -64,21 +84,22 @@ function summarizeCounts(snapshot) {
     productVariants: productVariants.length,
     publishedProductVariants: countPublished(productVariants),
     draftProductVariants: countDraft(productVariants),
-    services: services.length,
-    publishedServices: countPublished(services),
-    draftServices: countDraft(services),
+    services: serviceOfferings,
+    serviceListings: services.length,
+    publishedServices: publishedServiceOfferings,
+    draftServices: draftServiceOfferings,
     foods: foods.length,
     publishedFoods: countPublished(foods),
     draftFoods: countDraft(foods),
-    total: products.length + services.length + foods.length,
+    total: products.length + serviceOfferings + foods.length,
     statusBreakdown: {
       products: {
         draft: countDraft(products),
         published: countPublished(products),
       },
       services: {
-        draft: countDraft(services),
-        published: countPublished(services),
+        draft: draftServiceOfferings,
+        published: publishedServiceOfferings,
       },
       foods: {
         draft: countDraft(foods),
@@ -119,6 +140,13 @@ function getEligibleListingsForBusiness(business, snapshot) {
   }
 
   return { type: listingType, listings: [] };
+}
+
+function countRequiredListings(eligible) {
+  if (eligible?.type === 'service') {
+    return countServiceOfferings(eligible.listings || []);
+  }
+  return eligible?.listings?.length || 0;
 }
 
 function resolveOnboardingForBusiness(business, onboardingRows = []) {
@@ -202,6 +230,7 @@ function attachListingSnapshotToBusiness(business, snapshot, onboarding = null) 
   const plain = toPlain(business);
   const listingSnapshot = snapshot || { products: [], services: [], foods: [] };
   const eligible = getEligibleListingsForBusiness(plain, listingSnapshot);
+  const requiredListingCount = countRequiredListings(eligible);
   const onboardingReadiness = buildOnboardingReadiness({
     business: plain,
     onboarding,
@@ -218,7 +247,7 @@ function attachListingSnapshotToBusiness(business, snapshot, onboarding = null) 
       listingType: plain?.listingType || null,
       publicMarketplaceEligible: isPublicMarketplaceBusiness(plain),
       hasRequiredListing: eligible.listings.length > 0,
-      requiredListingCount: eligible.listings.length,
+      requiredListingCount,
     },
     onboardingReadiness,
   };
@@ -300,13 +329,14 @@ function buildPublicationBlockers({ business, onboarding, snapshot }) {
 function buildOnboardingReadiness({ business, onboarding, snapshot }) {
   const eligible = getEligibleListingsForBusiness(business, snapshot);
   const hasListing = eligible.listings.length > 0;
+  const requiredListingCount = countRequiredListings(eligible);
   const payoutComplete = Boolean(business?.chargesEnabled && business?.payoutsEnabled);
   const blockers = buildPublicationBlockers({ business, onboarding, snapshot });
 
   return {
     listingType: business?.listingType || null,
     hasListing,
-    requiredListingCount: eligible.listings.length,
+    requiredListingCount,
     payoutComplete,
     vendorVerificationStatus: onboarding?.status || null,
     canFinalReview: hasListing && payoutComplete,
@@ -329,6 +359,8 @@ async function publishBusinessListings({ business, userId }) {
     ],
   }).select('status applicationId businessId').sort({ updatedAt: -1 }).lean();
   const blockers = buildPublicationBlockers({ business, onboarding, snapshot });
+  const eligibleBeforePublication = getEligibleListingsForBusiness(business, snapshot);
+  const requiredListingCount = countRequiredListings(eligibleBeforePublication);
 
   if (blockers.length) {
     return {
@@ -340,18 +372,20 @@ async function publishBusinessListings({ business, userId }) {
       publication: {
         listingType: business.listingType,
         publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
-        hasRequiredListing: getEligibleListingsForBusiness(business, snapshot).listings.length > 0,
+        hasRequiredListing: eligibleBeforePublication.listings.length > 0,
+        requiredListingCount,
         blockers,
       },
     };
   }
 
-  const eligible = getEligibleListingsForBusiness(business, snapshot);
+  const eligible = eligibleBeforePublication;
   const listingIds = eligible.listings.map((item) => item._id).filter(Boolean);
   const published = {
     products: 0,
     productVariants: 0,
     services: 0,
+    serviceListings: 0,
     foods: 0,
   };
 
@@ -379,7 +413,8 @@ async function publishBusinessListings({ business, userId }) {
       { _id: { $in: listingIds }, businessId: business._id, ownerId: userId },
       { $set: { isPublished: true } }
     );
-    published.services = serviceResult.modifiedCount ?? serviceResult.nModified ?? 0;
+    published.services = countRequiredListings(eligible);
+    published.serviceListings = serviceResult.modifiedCount ?? serviceResult.nModified ?? 0;
   }
 
   if (eligible.type === 'food') {
@@ -403,7 +438,7 @@ async function publishBusinessListings({ business, userId }) {
       listingType: business.listingType,
       publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
       hasRequiredListing: true,
-      requiredListingCount: eligible.listings.length,
+      requiredListingCount: countRequiredListings(eligible),
       published,
       blockers: [],
     },


### PR DESCRIPTION
## Summary
- Counts bookable service offerings, not only the parent service document, in `GET /api/business/my` listing snapshots.
- Preserves the parent service listing count separately as `listingCounts.serviceListings`.
- Reports service `requiredListingCount` and publish summaries using child-offering counts.
- Adds public service card DTO fields for `serviceOfferingCount`, `serviceOfferingNames`, and normalized `serviceOfferings`.

## Scope
- Backend business listing snapshot counts, storefront publication summary counts, and public service listing DTOs.
- Service offering display contract for the frontend marketplace UI.
- Includes conflict-resolution merge from current `staging` on the PR branch before merge.

## Files changed
- `lib/listing/publicListingDto.js`
- `tests/integration/business-storefront-publication.integration.test.js`
- `tests/marketplace/public-listing-dto.test.js`
- `utils/businessListingVisibility.js`

## Verification
- `node --test tests/marketplace/public-listing-dto.test.js`: passed, 22 tests.
- `node --test tests/integration/business-storefront-publication.integration.test.js`: passed, 7 tests.
- `npm test`: passed, 529 tests.
- `npm run test:contract`: passed, 20 tests.
- `npm run test:integration`: passed, 74 tests.
- `git diff --check`: passed before commit.
- GitHub CI `Test`: success.
- GitHub CI `build`: success.

## Risks
- Medium contract risk because downstream UI may now display service offering counts rather than parent service listing counts.
- Legacy consumers still have `serviceListings` available for parent listing counts.
- Marketplace cards should be checked in UAT with vendors that have multiple service offerings.

## Rollback
- Revert this PR's merge commit from `staging` to restore parent-service-only counts.
- No data migration rollback is required.

## What was not tested
- Browser screenshot/UAT of the frontend marketplace service card is covered separately by frontend PR #332.
- Live production data with large service catalogs was not tested.
- Payment, Connect, webhook, and checkout behavior were not tested because they are out of scope.

## Dependency notes
- Depends on backend docs PR #201 and service feature persistence PR #202.
- Frontend service offering display PR #332 depends on this backend DTO/count contract.
- Intended merge order: backend #206 before frontend #332.

## Safety checks
- No secrets committed.
- No deploy performed during this PR-description polish pass.
- No PR/base-branch merge performed during this polish pass; GitHub shows this PR was already merged before the polish pass.
- `GET /api/featured-products` preserved.
- `/api/products/featured` not introduced.
- Backend `app.js` middleware not reordered.
- Stripe webhook order not changed.
- Payment/webhook logic not touched.

## Launch/UAT status
Fixed / Ready for Review. GitHub currently shows this PR already merged to `staging`; integrated UAT remains pending and this is not client acceptance.