### PR TITLE
docs: cross-link July 6 issue control board and add agent context index

### DIFF
--- a/docs/AGENT_CONTEXT_INDEX.md
+++ b/docs/AGENT_CONTEXT_INDEX.md
@@ -1,0 +1,57 @@
+# Agent Context Index — Techware-Hut/mosaic-backend
+
+- Last updated: 2026-07-07
+- Purpose: the first document any agent or developer should read before working in this repo during the July 6 Controlled Production UAT window.
+
+## Read this first
+
+- **Release posture: Controlled Production UAT.** Production promotion already occurred (backend `main` `ad9ddd1`, frontend `main` `b3a86cb4`) because no true isolated staging environment exists. QA is testing in production under safeguards.
+- **This is not final launch approval.** Lionel technical approval and Bryan written business approval are both pending.
+- Allowed status vocabulary: `Controlled Production UAT`, `Implemented / Ready for QA`, `Evidence Needed`, `Pending Client Input`, `Regression Risk`. Do not mark anything Accepted or launch-ready without written client/UAT approval.
+
+## July 6 Controlled Production UAT
+
+### Issue control board
+
+Backend parent epic: [#211 — Epic: July 6 Controlled Production UAT backend follow-up control board](https://github.com/Techware-Hut/mosaic-backend/issues/211)
+
+| Issue | Title | Status language |
+|---|---|---|
+| [#212](https://github.com/Techware-Hut/mosaic-backend/issues/212) | P1: Formalize local shipping eligibility contract (FW-2/FW-6) | Regression Risk / Evidence Needed |
+| [#213](https://github.com/Techware-Hut/mosaic-backend/issues/213) | P1: Add server-side local shipping eligibility guard or document client-only temporary rule (FW-6) | Regression Risk |
+| [#214](https://github.com/Techware-Hut/mosaic-backend/issues/214) | P1: Normalize service update features consistently with service create (FW-7) | Implemented / Ready for QA with Regression Risk |
+| [#215](https://github.com/Techware-Hut/mosaic-backend/issues/215) | P1: Fix onboarding service creation path dropping features (FW-9) | Regression Risk |
+| [#216](https://github.com/Techware-Hut/mosaic-backend/issues/216) | Evidence Needed: Hosted shipment tracking email proof (item 11) | Evidence Needed |
+| [#217](https://github.com/Techware-Hut/mosaic-backend/issues/217) | Evidence Needed: Hosted PDF/JPEG vendor document upload proof (item 12) | Evidence Needed |
+| [#218](https://github.com/Techware-Hut/mosaic-backend/issues/218) | Decision Needed: Service/restaurant Stripe Connect policy wording and requirement (items 5/15) | Pending Client Input |
+| [#219](https://github.com/Techware-Hut/mosaic-backend/issues/219) | Decision Needed: Local delivery eligibility rule (item 7) | Pending Client Input |
+| [#220](https://github.com/Techware-Hut/mosaic-backend/issues/220) | P3: Index July 6 UAT and audit docs in backend docs index (FW-8) | Implemented / Ready for QA (this document) |
+
+Frontend parent epic: [Digital-Builders-757/mosaic-biz-frontend-launch#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337)
+
+### Source audit PRs
+
+- Backend docs-to-code conformance audit: [PR #210](https://github.com/Techware-Hut/mosaic-backend/pull/210)
+- Frontend docs-to-code conformance audit: [PR #336](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/pull/336)
+
+### Key documents
+
+| Document | What it is |
+|---|---|
+| [`docs/uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md`](uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md) | Tester steps, safeguards, and evidence requirements for all 15 QA items |
+| [`docs/audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md`](audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md) | Docs-to-code conformance findings, checklist matrix, follow-up work orders FW-1..FW-9 |
+| [`docs/audit/JULY_6_BACKEND_IMPLEMENTATION_TRACE.md`](audit/JULY_6_BACKEND_IMPLEMENTATION_TRACE.md) | Per-area backend implementation evidence (routes, controllers, tests) |
+| [`docs/audit/JULY_6_CROSS_REPO_ROUTE_CONTRACT_TRACE.md`](audit/JULY_6_CROSS_REPO_ROUTE_CONTRACT_TRACE.md) | Cross-repo route/API contract table (canonical) |
+| [`docs/release/STAGING_ENVIRONMENT_AUDIT.md`](release/STAGING_ENVIRONMENT_AUDIT.md) | Why no true staging exists and why production UAT is controlled |
+| [`docs/release/JULY_6_CONTROLLED_PRODUCTION_UAT_PLAN.md`](release/JULY_6_CONTROLLED_PRODUCTION_UAT_PLAN.md) | Controlled production UAT plan and safeguards |
+
+## How future agents should use this
+
+1. Read this index first, then the release posture docs above.
+2. Read the linked GitHub issue in full before making any change; the issue defines scope, acceptance criteria, and verification commands.
+3. Make one branch per issue; do not bundle unrelated fixes.
+4. Do not touch flows unrelated to your issue.
+5. Preserve `GET /api/featured-products` as the canonical featured route. Never introduce `/api/products/featured`.
+6. Do not touch Stripe, webhook mounting order, payment intent, Connect payout, or subscription logic unless the issue explicitly requires it.
+7. Never commit secrets, env values, tokens, keys, DSNs, or signed URLs. Env variables may be referenced by name only.
+8. After your PR, update the issue (evidence, status language) and any affected docs in the same pass.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Mosaic Backend - Documentation Home
 
 **Audience:** backend engineers, QA, release control, AI agents
-**Last updated:** 2026-06-28
+**Last updated:** 2026-07-07
 
 This is the entry point for current backend documentation. Older sprint, smoke, and proof-pack docs are retained as evidence, but the living docs below are the source of truth for current behavior.
 
@@ -21,6 +21,24 @@ Repository root: [README.md](../README.md). Deployment entry point: [../DEPLOYME
 | Payments | Stripe test-mode flows are allowed for controlled QA; do not present as unrestricted live commerce |
 | Release evidence | Exact deployed SHA, EB version, and latest promotion live in [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) and dated proof packs |
 | Main status hub | [MVP_BACKEND_PROGRAM_STATUS.md](MVP_BACKEND_PROGRAM_STATUS.md) |
+
+---
+
+## July 6 Controlled Production UAT (Current)
+
+**Agents: read [AGENT_CONTEXT_INDEX.md](AGENT_CONTEXT_INDEX.md) first.** It maps the July 6 Controlled Production UAT posture, the GitHub issue control board (parent epic [#211](https://github.com/Techware-Hut/mosaic-backend/issues/211), child issues #212–#220), the audit PRs, and the key documents:
+
+| Document | Use for |
+| --- | --- |
+| [AGENT_CONTEXT_INDEX.md](AGENT_CONTEXT_INDEX.md) | Entry point: issue board, agent rules, release posture |
+| [uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md](uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md) | Tester steps and evidence requirements for the 15 QA items |
+| [audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md](audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md) | Docs-to-code conformance findings and follow-up work orders |
+| [audit/JULY_6_BACKEND_IMPLEMENTATION_TRACE.md](audit/JULY_6_BACKEND_IMPLEMENTATION_TRACE.md) | Backend implementation evidence per QA area |
+| [audit/JULY_6_CROSS_REPO_ROUTE_CONTRACT_TRACE.md](audit/JULY_6_CROSS_REPO_ROUTE_CONTRACT_TRACE.md) | Cross-repo route/API contract table |
+| [release/STAGING_ENVIRONMENT_AUDIT.md](release/STAGING_ENVIRONMENT_AUDIT.md) | Why UAT runs in controlled production |
+| [release/JULY_6_CONTROLLED_PRODUCTION_UAT_PLAN.md](release/JULY_6_CONTROLLED_PRODUCTION_UAT_PLAN.md) | Controlled production UAT plan and safeguards |
+
+Status: Controlled Production UAT — **not final launch approval**. Lionel technical and Bryan written business approvals are pending.
 
 ---
 

--- a/docs/audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md
+++ b/docs/audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md
@@ -7,6 +7,19 @@
 - Frontend counterpart: `mosaic-biz-frontend-launch` `main` tip `b3a86cb4` (PR #335, `develop` -> `main`); develop candidate `8163a3b3` is an ancestor of `main`.
 - Scope: documentation-to-implementation conformance for the 15 July 6 QA items. **Docs-only pass. No runtime code changed, no merges, no deploys.**
 
+## Issue control board
+
+Follow-up work from this audit is tracked on the GitHub issue control board — parent epic [#211](https://github.com/Techware-Hut/mosaic-backend/issues/211) (frontend epic: [mosaic-biz-frontend-launch#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337)). Start at [`docs/AGENT_CONTEXT_INDEX.md`](../AGENT_CONTEXT_INDEX.md).
+
+Checklist-item evidence and decision issues:
+
+| Finding | Tracking issue |
+|---|---|
+| Item 11 — hosted shipment tracking email proof | [#216](https://github.com/Techware-Hut/mosaic-backend/issues/216) |
+| Item 12 — hosted PDF/JPEG vendor document upload proof | [#217](https://github.com/Techware-Hut/mosaic-backend/issues/217) |
+| Items 5/15 — service/restaurant Stripe Connect policy wording (Pending Client Input) | [#218](https://github.com/Techware-Hut/mosaic-backend/issues/218) |
+| Item 7 — local delivery eligibility rule (Pending Client Input) | [#219](https://github.com/Techware-Hut/mosaic-backend/issues/219) |
+
 ## Status vocabulary
 
 Only these statuses are used: `Implemented / Ready for QA`, `Evidence Needed`, `Documentation Mismatch`, `Code Mismatch`, `Regression Risk`, `Pending Client Input`, `Deferred / Future Phase`, `Blocked`. Nothing is marked Accepted; no written client/UAT approval exists as of this audit.
@@ -134,17 +147,17 @@ Route invariants (featured products, webhook mount order) are additionally cover
 
 ## Code mismatches found (follow-up work orders — NOT fixed in this pass)
 
-| ID | Repo | Finding | Suggested owner |
-|---|---|---|---|
-| FW-1 | frontend | Legacy product edit route `app/(partner)/partners/[businessid]/inventory/edit/[id]/EditProduct.tsx` manages cover image only while `EditProductModal` handles the full gallery; both are reachable. Likely source of QA item 3. Consolidate or add gallery support. | frontend |
-| FW-2 | backend | Cart contract does not emit `localDeliveryEligible`; either add the computed field to `GET /api/cart` items or keep the doc-corrected `vendorState`-only contract permanently. | backend + business decision |
-| FW-3 | frontend | Buy-now checkout (`checkout/buy-now/page.tsx`) computes subtotal/shipping locally and applies coupons via `POST /api/discounts/apply` instead of the backend-authoritative cart pricing path; order initiate still protects final totals, but displayed totals can drift. | frontend |
-| FW-4 | frontend | `/partners/payout-setup` shows unconditional "Connect your Stripe account to receive payouts." copy when visited directly by service/food vendors, contradicting the optional-Connect policy messaging. | frontend + business decision |
-| FW-5 | frontend | Pre-existing lint errors (6 react-hooks errors) in `app/(home)/product/[id]/page.tsx`; unrelated to July 6 fixes; not a blocker for this docs audit. | frontend |
-| FW-6 | backend | Local delivery same-state rule is enforced client-side only; `PUT /api/cart` / order initiate will price `deliverySpeed=local` for any state if requested directly. Decide whether server-side gating is required. | backend + business decision |
-| FW-7 | backend | `PUT /api/service/:id` assigns `features` raw from the request body without the create-path normalization (`normalizeStringList`); harmless for the FE client but inconsistent. | backend |
-| FW-8 | both | `docs/README.md` (both repos) does not index the July 6 doc set; July 6 docs are orphaned from navigation. | docs |
-| FW-9 | both | Onboarding service-create path drops features: `POST /api/service/parent` hardcodes `features: []` (`serviceController.js` L154) and the frontend onboarding flow (`app/(home)/partners/add-service/hooks/useServiceForm.ts`) never collects/sends features. The inventory create path (`POST /api/service`) and the edit path both persist features correctly. | both |
+| ID | Repo | Finding | Suggested owner | Tracking issue |
+|---|---|---|---|---|
+| FW-1 | frontend | Legacy product edit route `app/(partner)/partners/[businessid]/inventory/edit/[id]/EditProduct.tsx` manages cover image only while `EditProductModal` handles the full gallery; both are reachable. Likely source of QA item 3. Consolidate or add gallery support. | frontend | Frontend epic [#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337) |
+| FW-2 | backend | Cart contract does not emit `localDeliveryEligible`; either add the computed field to `GET /api/cart` items or keep the doc-corrected `vendorState`-only contract permanently. | backend + business decision | [#212](https://github.com/Techware-Hut/mosaic-backend/issues/212) |
+| FW-3 | frontend | Buy-now checkout (`checkout/buy-now/page.tsx`) computes subtotal/shipping locally and applies coupons via `POST /api/discounts/apply` instead of the backend-authoritative cart pricing path; order initiate still protects final totals, but displayed totals can drift. | frontend | Frontend epic [#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337) |
+| FW-4 | frontend | `/partners/payout-setup` shows unconditional "Connect your Stripe account to receive payouts." copy when visited directly by service/food vendors, contradicting the optional-Connect policy messaging. | frontend + business decision | Frontend epic [#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337) |
+| FW-5 | frontend | Pre-existing lint errors (6 react-hooks errors) in `app/(home)/product/[id]/page.tsx`; unrelated to July 6 fixes; not a blocker for this docs audit. | frontend | Frontend epic [#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337) |
+| FW-6 | backend | Local delivery same-state rule is enforced client-side only; `PUT /api/cart` / order initiate will price `deliverySpeed=local` for any state if requested directly. Decide whether server-side gating is required. | backend + business decision | [#213](https://github.com/Techware-Hut/mosaic-backend/issues/213) (rule decision: [#219](https://github.com/Techware-Hut/mosaic-backend/issues/219)) |
+| FW-7 | backend | `PUT /api/service/:id` assigns `features` raw from the request body without the create-path normalization (`normalizeStringList`); harmless for the FE client but inconsistent. | backend | [#214](https://github.com/Techware-Hut/mosaic-backend/issues/214) |
+| FW-8 | both | `docs/README.md` (both repos) does not index the July 6 doc set; July 6 docs are orphaned from navigation. | docs | [#220](https://github.com/Techware-Hut/mosaic-backend/issues/220) |
+| FW-9 | both | Onboarding service-create path drops features: `POST /api/service/parent` hardcodes `features: []` (`serviceController.js` L154) and the frontend onboarding flow (`app/(home)/partners/add-service/hooks/useServiceForm.ts`) never collects/sends features. The inventory create path (`POST /api/service`) and the edit path both persist features correctly. | both | [#215](https://github.com/Techware-Hut/mosaic-backend/issues/215) |
 
 ## Phase 10 — Verification results (backend `main` `ad9ddd1`)
 

--- a/docs/uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md
+++ b/docs/uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md
@@ -6,6 +6,8 @@ Audited production SHAs: backend `ad9ddd14`, frontend `b3a86cb4`
 
 **This is not final launch approval.** Do not mark any item Accepted without written client/UAT approval from Bryan.
 
+Issue control board: parent epic [#211](https://github.com/Techware-Hut/mosaic-backend/issues/211) (see [`docs/AGENT_CONTEXT_INDEX.md`](../AGENT_CONTEXT_INDEX.md) for the full issue map).
+
 ---
 
 ## Before You Start
@@ -23,23 +25,23 @@ See also: [`JULY_6_CONTROLLED_PRODUCTION_UAT_PLAN.md`](../release/JULY_6_CONTROL
 
 ## Checklist
 
-| # | Area | Steps | Expected | Status | Screenshot |
-| --- | --- | --- | --- | --- | --- |
-| 1 | Image upload limit | Open vendor upload UI for tier allowing 6 images; attempt max selection | Correct limit message; no stale "3 only" copy | Evidence Needed | Upload UI |
-| 2 | Service offering count | Add/verify 3 offerings; check dashboard + public profile | All offerings/counts visible | Evidence Needed | Dashboard + public |
-| 3 | Edit image gallery | Edit listing with multiple images; save; reopen | All images preserved | Evidence Needed | Before/after edit |
-| 4 | Service features | Create/edit features; save; reopen | Features persist (test both create paths if possible) | Evidence Needed | Feature form + reopen |
-| 5 | Service/food payout messaging | Open final review as service and food vendor | Payout not forced for onboarding; messaging accurate | Evidence Needed | Final review |
-| 6 | Product description | Open product with HTML-like description | No raw tags; no unsafe HTML | Evidence Needed | Product detail |
-| 7 | Local shipping | Same-state and different-state cart if data exists | Local only when eligible | Evidence Needed | Cart shipping chips |
-| 8 | Cart quantity decrease | Increase then decrease qty in cart | Qty and totals update | Evidence Needed | Cart totals |
-| 9 | Coupon minimum | Apply below-minimum coupon; then valid coupon | Backend rejection below min; discount above min | Evidence Needed | Coupon messages |
-| 10 | Cart vs checkout total | Compare cart, checkout, order initiate | Totals match or explained recalculation | Evidence Needed | Cart + checkout |
-| 11 | Tracking email | Ship order with tracking URL; check customer view | Tracking visible; safe provider/log shows sent/skipped | Evidence Needed | Order + log summary |
-| 12 | PDF/JPEG upload | Upload JPEG and PDF vendor documents | Both succeed or document exact blocker (no signed URLs) | Evidence Needed | Upload result |
-| 13 | Admin filters/profile | Filter by status; open detail | Filters work; logo, bio, docs, badge visible | Evidence Needed | Admin list + detail |
-| 14 | Approve/reject/finalize | Reject with reason + next action; vendor view; resubmit; approve | Clear next steps both sides | Evidence Needed | Admin + vendor screens |
-| 15 | Restaurant/service Connect | Final review + attempt paid checkout for service/food if applicable | Messaging not overpromising; note checkout Connect requirement | Evidence Needed | Final review + checkout |
+| # | Area | Steps | Expected | Status | Screenshot | Tracking issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | Image upload limit | Open vendor upload UI for tier allowing 6 images; attempt max selection | Correct limit message; no stale "3 only" copy | Evidence Needed | Upload UI | — |
+| 2 | Service offering count | Add/verify 3 offerings; check dashboard + public profile | All offerings/counts visible | Evidence Needed | Dashboard + public | — |
+| 3 | Edit image gallery | Edit listing with multiple images; save; reopen | All images preserved | Evidence Needed | Before/after edit | Frontend epic [#337](https://github.com/Digital-Builders-757/mosaic-biz-frontend-launch/issues/337) (FW-1) |
+| 4 | Service features | Create/edit features; save; reopen | Features persist (test both create paths if possible) | Evidence Needed | Feature form + reopen | [#214](https://github.com/Techware-Hut/mosaic-backend/issues/214), [#215](https://github.com/Techware-Hut/mosaic-backend/issues/215) |
+| 5 | Service/food payout messaging | Open final review as service and food vendor | Payout not forced for onboarding; messaging accurate | Evidence Needed | Final review | [#218](https://github.com/Techware-Hut/mosaic-backend/issues/218) |
+| 6 | Product description | Open product with HTML-like description | No raw tags; no unsafe HTML | Evidence Needed | Product detail | — |
+| 7 | Local shipping | Same-state and different-state cart if data exists | Local only when eligible | Evidence Needed | Cart shipping chips | [#212](https://github.com/Techware-Hut/mosaic-backend/issues/212), [#213](https://github.com/Techware-Hut/mosaic-backend/issues/213), [#219](https://github.com/Techware-Hut/mosaic-backend/issues/219) |
+| 8 | Cart quantity decrease | Increase then decrease qty in cart | Qty and totals update | Evidence Needed | Cart totals | — |
+| 9 | Coupon minimum | Apply below-minimum coupon; then valid coupon | Backend rejection below min; discount above min | Evidence Needed | Coupon messages | — |
+| 10 | Cart vs checkout total | Compare cart, checkout, order initiate | Totals match or explained recalculation | Evidence Needed | Cart + checkout | — |
+| 11 | Tracking email | Ship order with tracking URL; check customer view | Tracking visible; safe provider/log shows sent/skipped | Evidence Needed | Order + log summary | [#216](https://github.com/Techware-Hut/mosaic-backend/issues/216) |
+| 12 | PDF/JPEG upload | Upload JPEG and PDF vendor documents | Both succeed or document exact blocker (no signed URLs) | Evidence Needed | Upload result | [#217](https://github.com/Techware-Hut/mosaic-backend/issues/217) |
+| 13 | Admin filters/profile | Filter by status; open detail | Filters work; logo, bio, docs, badge visible | Evidence Needed | Admin list + detail | — |
+| 14 | Approve/reject/finalize | Reject with reason + next action; vendor view; resubmit; approve | Clear next steps both sides | Evidence Needed | Admin + vendor screens | — |
+| 15 | Restaurant/service Connect | Final review + attempt paid checkout for service/food if applicable | Messaging not overpromising; note checkout Connect requirement | Evidence Needed | Final review + checkout | [#218](https://github.com/Techware-Hut/mosaic-backend/issues/218) |
 
 ---
 


### PR DESCRIPTION
﻿## Summary

Docs-only pass that cross-links the July 6 GitHub issue control board into the backend documentation. Stacked on PR #210 (base: `audit/july6-docs-code-conformance`) because the July 6 audit docs are not on `main` yet.

- New `docs/AGENT_CONTEXT_INDEX.md`: entry point mapping the Controlled Production UAT posture, epic #211 + child issues #212-#220, frontend epic Digital-Builders-757/mosaic-biz-frontend-launch#337, audit PRs #210/#336, and the key July 6 documents, plus "How future agents should use this" rules.
- `docs/audit/JULY_6_DOCS_TO_CODE_CONFORMANCE_AUDIT.md`: added issue control board section; FW work-order table now has a Tracking issue column (FW-2 -> #212, FW-6 -> #213, FW-7 -> #214, FW-8 -> #220, FW-9 -> #215; item 11 -> #216, item 12 -> #217, Connect policy -> #218, local delivery rule -> #219).
- `docs/uat/JULY_6_PRODUCTION_UAT_CHECKLIST.md`: epic reference in header; checklist rows link to their tracking issues.
- `docs/README.md`: new "July 6 Controlled Production UAT (Current)" section pointing agents to AGENT_CONTEXT_INDEX first (addresses FW-8 / #220).

## Safety

- Documentation only; no runtime code, middleware, Stripe/webhook/Connect, or package changes.
- No secrets or env values.
- `GET /api/featured-products` remains canonical; `/api/products/featured` is not introduced.
- Nothing marked Accepted or launch-ready. This is Controlled Production UAT, not final launch approval.

## Test plan

- [x] `git diff --stat` confirms only `docs/` files changed
- [x] Issue/PR links verified against the live board (#211-#220, #337, #210, #336)
- [ ] Lionel review of #220 acceptance criteria before closing that issue
