### PR TITLE
Fix service draft persistence and public DTO fields (UAT-SERVICE-001–005)

### DIFF
--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -8,6 +8,11 @@ const {
   normalizeChildServices,
   normalizeServicePayload,
   normalizeStringList,
+  normalizeBusinessHoursForStorage,
+  normalizeBusinessHoursForOwnerResponse,
+  normalizeFaqList,
+  normalizeAmenitiesList,
+  resolveTaxonomyIdFromBody,
   validateChildServices,
   validatePublishRequest,
   getMinimumChildServicePrice,
@@ -135,7 +140,7 @@ exports.createParentService = async (req, res) => {
       coverImage: coverImage || '',
       images: Array.isArray(images) ? images.filter(Boolean) : [],
       location: location?.address || '',
-      businessHours: businessHours || [],
+      businessHours: normalizeBusinessHoursForStorage(businessHours || []),
       bookingToolLink: bookingToolLink || '',
 
       // Empty arrays for child services to be added later
@@ -153,9 +158,9 @@ exports.createParentService = async (req, res) => {
       isPublished: false, // Keep unpublished until child services are added
       maxBookingsPerSlot: 1,
       features: normalizeStringList(req.body.features),
-      amenities: [],
+      amenities: normalizeAmenitiesList(req.body.amenities),
       videos: [],
-      faq: []
+      faq: normalizeFaqList(req.body.faq)
     });
 
     await service.save();
@@ -276,7 +281,7 @@ exports.createService = async (req, res) => {
       coverImage: coverImage || '',
       images: images || [],
       isPublished,
-      businessHours: businessHours || [],
+      businessHours: normalizeBusinessHoursForStorage(businessHours || []),
       location: location?.address || '',
 
       contact: {
@@ -290,9 +295,9 @@ exports.createService = async (req, res) => {
       minorityType: business.minorityType,
       maxBookingsPerSlot: 1,
       features,
-      amenities: [],
+      amenities: normalizeAmenitiesList(req.body.amenities),
       videos: [],
-      faq: []
+      faq: normalizeFaqList(req.body.faq)
     });
 
     await service.save();
@@ -785,7 +790,7 @@ exports.updateService = async (req, res) => {
     }
 
     const updatableFields = [
-      'title', 'description', 'coverImage', 'images', 'amenities', 'businessHours',
+      'title', 'description', 'coverImage', 'images',
       'bookingToolLink', 'maxBookingsPerSlot', 'location', 'contact'
     ];
 
@@ -793,6 +798,28 @@ exports.updateService = async (req, res) => {
       if (req.body[field] !== undefined) {
         service[field] = req.body[field];
       }
+    }
+
+    if (req.body.amenities !== undefined) {
+      service.amenities = normalizeAmenitiesList(req.body.amenities);
+    }
+
+    if (req.body.businessHours !== undefined) {
+      service.businessHours = normalizeBusinessHoursForStorage(req.body.businessHours);
+    }
+
+    if (req.body.faq !== undefined) {
+      service.faq = normalizeFaqList(req.body.faq);
+    }
+
+    const nextCategoryId = resolveTaxonomyIdFromBody(req.body, 'categoryId', 'category');
+    if (nextCategoryId) {
+      service.categoryId = nextCategoryId;
+    }
+
+    const nextSubcategoryId = resolveTaxonomyIdFromBody(req.body, 'subcategoryId', 'subcategory');
+    if (nextSubcategoryId) {
+      service.subcategoryId = nextSubcategoryId;
     }
 
     if (req.body.features !== undefined) {
@@ -838,8 +865,12 @@ exports.updateService = async (req, res) => {
 
     await service.save();
 
+    const refreshedService = await Service.findById(service._id)
+      .populate('categoryId', 'name')
+      .populate('subcategoryId', 'name');
+
     return res.status(200).json(
-      formatOwnerServiceResponse(service, business, 'Service updated successfully')
+      formatOwnerServiceResponse(refreshedService, business, 'Service updated successfully')
     );
 
   } catch (error) {
@@ -972,30 +1003,7 @@ exports.getBusinessServiceById = async (req, res) => {
     const childServices = Array.isArray(service.services) ? service.services : [];
     const hasChildServices = childServices.length > 0;
 
-    const mappedBusinessHours = (Array.isArray(service.businessHours) ? service.businessHours : []).map((slot) => {
-      let openTime = slot.openTime || '';
-      let closeTime = slot.closeTime || '';
-      let isOpen = typeof slot.isOpen === 'boolean' ? slot.isOpen : true;
-
-      if ((!openTime || !closeTime) && typeof slot.hours === 'string') {
-        const parts = slot.hours.split('-').map((part) => part.trim());
-        if (parts.length === 2) {
-          openTime = openTime || parts[0];
-          closeTime = closeTime || parts[1];
-        }
-      }
-
-      if (typeof slot.closed === 'boolean') {
-        isOpen = !slot.closed;
-      }
-
-      return {
-        day: slot.day || '',
-        openTime,
-        closeTime,
-        isOpen
-      };
-    });
+    const mappedBusinessHours = normalizeBusinessHoursForOwnerResponse(service.businessHours);
 
     const serviceImages = normalizeImages({
       coverImage: service.coverImage,
@@ -1035,6 +1043,8 @@ exports.getBusinessServiceById = async (req, res) => {
       businessHours: mappedBusinessHours,
       bookingToolLink: service.bookingToolLink || '',
       features: Array.isArray(service.features) ? service.features : [],
+      amenities: Array.isArray(service.amenities) ? service.amenities : [],
+      faq: Array.isArray(service.faq) ? service.faq : [],
       services: childServices.map((item) => ({
         name: item.name || '',
         price: typeof item.price === 'number' ? item.price : 0,

--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -25,6 +25,8 @@ const CARD_LEGACY_FIELDS = [
   'bookingToolLink',
   'location',
   'features',
+  'amenities',
+  'faq',
 ];
 
 const LISTING_DETAIL_PATHS = {

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -47,6 +47,114 @@ const normalizeStringList = (value = []) => {
     .filter(Boolean);
 };
 
+const OBJECT_ID_PATTERN = /^[a-fA-F0-9]{24}$/;
+
+const isValidObjectIdString = (value) =>
+  typeof value === 'string' && OBJECT_ID_PATTERN.test(value);
+
+const resolveTaxonomyIdFromBody = (body = {}, fieldName, aliasFieldName) => {
+  const direct = body[fieldName];
+  if (isValidObjectIdString(direct)) return direct;
+  if (direct && typeof direct === 'object' && direct._id) {
+    const id = String(direct._id);
+    if (isValidObjectIdString(id)) return id;
+  }
+
+  const alias = body[aliasFieldName];
+  if (alias && typeof alias === 'object' && alias._id) {
+    const id = String(alias._id);
+    if (isValidObjectIdString(id)) return id;
+  }
+  if (isValidObjectIdString(alias)) return alias;
+
+  return null;
+};
+
+const normalizeBusinessHoursForStorage = (slots) => {
+  if (!Array.isArray(slots)) return [];
+
+  return slots
+    .map((slot) => {
+      const day = String(slot?.day ?? '').trim();
+      if (!day) return null;
+
+      let hours = typeof slot?.hours === 'string' ? slot.hours.trim() : '';
+      let closed = typeof slot?.closed === 'boolean' ? slot.closed : false;
+
+      const openTime = slot?.openTime ? String(slot.openTime).trim() : '';
+      const closeTime = slot?.closeTime ? String(slot.closeTime).trim() : '';
+
+      if (!hours && openTime && closeTime) {
+        hours = `${openTime}-${closeTime}`;
+      }
+
+      if (typeof slot?.closed === 'boolean') {
+        closed = slot.closed;
+      } else if (typeof slot?.isOpen === 'boolean') {
+        closed = !slot.isOpen;
+      }
+
+      if (!hours) {
+        hours = 'Closed';
+        closed = true;
+      }
+
+      return { day, hours, closed };
+    })
+    .filter(Boolean);
+};
+
+const normalizeBusinessHoursForOwnerResponse = (slots) => {
+  if (!Array.isArray(slots)) return [];
+
+  return slots.map((slot) => {
+    let openTime = slot?.openTime ? String(slot.openTime).trim() : '';
+    let closeTime = slot?.closeTime ? String(slot.closeTime).trim() : '';
+    let isOpen = typeof slot?.isOpen === 'boolean' ? slot.isOpen : true;
+
+    if ((!openTime || !closeTime) && typeof slot?.hours === 'string') {
+      const parts = slot.hours.split('-').map((part) => part.trim());
+      if (parts.length === 2) {
+        openTime = openTime || parts[0];
+        closeTime = closeTime || parts[1];
+      }
+    }
+
+    if (typeof slot?.closed === 'boolean') {
+      isOpen = !slot.closed;
+    }
+
+    return {
+      day: slot?.day ? String(slot.day).trim() : '',
+      openTime,
+      closeTime,
+      isOpen,
+    };
+  });
+};
+
+const normalizeFaqList = (value) => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => ({
+      question: String(item?.question ?? '').trim(),
+      answer: String(item?.answer ?? '').trim(),
+    }))
+    .filter((item) => item.question && item.answer);
+};
+
+const normalizeAmenitiesList = (value) => {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .map((item) => ({
+      label: String(item?.label ?? '').trim(),
+      available: Boolean(item?.available),
+    }))
+    .filter((item) => item.label);
+};
+
 const childMissingPrice = (item) =>
   item.price === undefined || item.price === null || item.price === '';
 
@@ -252,8 +360,35 @@ const toPlainService = (service) => {
   return service;
 };
 
+const formatOwnerServiceForResponse = (plainService) => {
+  if (!plainService) return plainService;
+
+  const formatted = { ...plainService };
+
+  if (formatted.categoryId && typeof formatted.categoryId === 'object' && formatted.categoryId._id) {
+    formatted.categoryId = {
+      _id: formatted.categoryId._id,
+      name: formatted.categoryId.name || '',
+    };
+  }
+
+  if (formatted.subcategoryId && typeof formatted.subcategoryId === 'object' && formatted.subcategoryId._id) {
+    formatted.subcategoryId = {
+      _id: formatted.subcategoryId._id,
+      name: formatted.subcategoryId.name || '',
+    };
+  }
+
+  formatted.businessHours = normalizeBusinessHoursForOwnerResponse(formatted.businessHours);
+  formatted.faq = Array.isArray(formatted.faq) ? formatted.faq : [];
+  formatted.amenities = Array.isArray(formatted.amenities) ? formatted.amenities : [];
+  formatted.features = Array.isArray(formatted.features) ? formatted.features : [];
+
+  return formatted;
+};
+
 const formatOwnerServiceResponse = (service, business, message) => {
-  const plainService = toPlainService(service);
+  const plainService = formatOwnerServiceForResponse(toPlainService(service));
   const publication = evaluateServicePublication({ service: plainService, business });
 
   return {
@@ -278,6 +413,12 @@ module.exports = {
   parseDurationMinutes,
   parsePrice,
   normalizeStringList,
+  isValidObjectIdString,
+  resolveTaxonomyIdFromBody,
+  normalizeBusinessHoursForStorage,
+  normalizeBusinessHoursForOwnerResponse,
+  normalizeFaqList,
+  normalizeAmenitiesList,
   normalizeChildService,
   normalizeChildServices,
   normalizeServicePayload,
@@ -287,6 +428,7 @@ module.exports = {
   PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
   getMinimumChildServicePrice,
   evaluateServicePublication,
+  formatOwnerServiceForResponse,
   formatOwnerServiceResponse,
   formatValidationErrorResponse,
 };

--- a/tests/marketplace/public-listing-dto.test.js
+++ b/tests/marketplace/public-listing-dto.test.js
@@ -181,6 +181,50 @@ test('toPublicListingDetail preserves service features on detail payloads', () =
   assert.deepEqual(detail.features, ['Mobile appointments']);
 });
 
+test('toPublicListingDetail preserves amenities and faq on service detail payloads', () => {
+  const detail = toPublicListingDetail(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Consulting',
+      amenities: [{ label: 'Parking', available: true }],
+      faq: [{ question: 'Hours?', answer: '9-5' }],
+      services: [{ _id: 'svc-child-1', name: 'Planning', price: 50, durationMinutes: 30 }],
+    },
+    { listingType: 'service' }
+  );
+
+  assert.deepEqual(detail.amenities, [{ label: 'Parking', available: true }]);
+  assert.deepEqual(detail.faq, [{ question: 'Hours?', answer: '9-5' }]);
+});
+
+test('toPublicListingCard preserves amenities on service list payloads', () => {
+  const card = toPublicListingCard(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Consulting',
+      amenities: [{ label: 'WiFi', available: true }],
+      services: [{ _id: 'svc-child-1', name: 'Planning', price: 50, durationMinutes: 30 }],
+    },
+    { listingType: 'service' }
+  );
+
+  assert.deepEqual(card.amenities, [{ label: 'WiFi', available: true }]);
+});
+
+test('toPublicListingCard omits amenities and faq when absent for backward compatibility', () => {
+  const card = toPublicListingCard(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Legacy Service',
+      services: [{ _id: 'svc-child-1', name: 'Planning', price: 50, durationMinutes: 30 }],
+    },
+    { listingType: 'service' }
+  );
+
+  assert.equal(card.amenities, undefined);
+  assert.equal(card.faq, undefined);
+});
+
 test('toPublicBusinessCard normalizes vendor browse card fields', () => {
   const card = toPublicBusinessCard({
     _id: '507f1f77bcf86cd799439011',

--- a/tests/service/service-draft-lookup-contract.test.js
+++ b/tests/service/service-draft-lookup-contract.test.js
@@ -205,3 +205,49 @@ test('public business-service lookup returns persisted features for published se
   assert.equal(res.statusCode, 200);
   assert.deepEqual(res.body.service.features, ['Online Booking', 'Offers Available']);
 });
+
+test('private business service lookup returns owner-shaped business hours and persisted faq', async () => {
+  const controller = loadController({
+    service: buildService({
+      isPublished: false,
+      services: [],
+      businessHours: [{ day: 'Monday', hours: '09:00-17:00', closed: false }],
+      faq: [{ question: 'Hours?', answer: '9 to 5' }],
+      amenities: [{ label: 'WiFi', available: true }],
+    }),
+  });
+  const res = mockResponse();
+
+  await controller.getPrivateBusinessServiceByBusinessId(
+    { user: { _id: ownerId }, params: { businessId } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.service.businessHours, [{
+    day: 'Monday',
+    openTime: '09:00',
+    closeTime: '17:00',
+    isOpen: true,
+  }]);
+  assert.deepEqual(res.body.service.faq, [{ question: 'Hours?', answer: '9 to 5' }]);
+  assert.equal(res.body.service.categoryId.name, 'Beauty');
+});
+
+test('public business-service lookup returns amenities and faq for published service', async () => {
+  const controller = loadController({
+    service: buildService({
+      isPublished: true,
+      amenities: [{ label: 'Parking', available: true }],
+      faq: [{ question: 'Refund policy?', answer: '48 hours' }],
+      services: [{ name: 'Cut', price: 45, durationMinutes: 60 }],
+    }),
+  });
+  const res = mockResponse();
+
+  await controller.getBusinessServiceById({ params: { id: businessId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.service.amenities, [{ label: 'Parking', available: true }]);
+  assert.deepEqual(res.body.service.faq, [{ question: 'Refund policy?', answer: '48 hours' }]);
+});

--- a/tests/service/service-payload-contract.test.js
+++ b/tests/service/service-payload-contract.test.js
@@ -2,6 +2,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   normalizeStringList,
+  normalizeBusinessHoursForStorage,
+  normalizeBusinessHoursForOwnerResponse,
+  normalizeFaqList,
+  normalizeAmenitiesList,
+  resolveTaxonomyIdFromBody,
+  formatOwnerServiceForResponse,
   normalizeServicePayload,
   PUBLISH_CHILD_SERVICE_REQUIRED_MESSAGE,
   validateChildServices,
@@ -55,6 +61,79 @@ test('normalizeStringList accepts arrays and single strings', () => {
   );
   assert.deepEqual(normalizeStringList(' One feature '), ['One feature']);
   assert.deepEqual(normalizeStringList({ label: 'nope' }), []);
+});
+
+test('normalizeBusinessHoursForStorage accepts FE open/close shape', () => {
+  assert.deepEqual(
+    normalizeBusinessHoursForStorage([
+      { day: 'Monday', openTime: '09:00', closeTime: '17:00', isOpen: true },
+    ]),
+    [{ day: 'Monday', hours: '09:00-17:00', closed: false }]
+  );
+});
+
+test('normalizeBusinessHoursForOwnerResponse maps stored hours to FE shape', () => {
+  assert.deepEqual(
+    normalizeBusinessHoursForOwnerResponse([
+      { day: 'Tuesday', hours: '10:00-18:00', closed: false },
+    ]),
+    [{ day: 'Tuesday', openTime: '10:00', closeTime: '18:00', isOpen: true }]
+  );
+});
+
+test('normalizeFaqList trims and drops incomplete entries', () => {
+  assert.deepEqual(
+    normalizeFaqList([
+      { question: ' Q ', answer: ' A ' },
+      { question: 'Missing answer', answer: '' },
+    ]),
+    [{ question: 'Q', answer: 'A' }]
+  );
+});
+
+test('normalizeAmenitiesList trims labels and coerces availability', () => {
+  assert.deepEqual(
+    normalizeAmenitiesList([
+      { label: ' WiFi ', available: 'true' },
+      { label: '', available: true },
+    ]),
+    [{ label: 'WiFi', available: true }]
+  );
+});
+
+test('resolveTaxonomyIdFromBody accepts direct ids and nested category aliases', () => {
+  assert.equal(
+    resolveTaxonomyIdFromBody({ categoryId: '507f1f77bcf86cd799439014' }, 'categoryId', 'category'),
+    '507f1f77bcf86cd799439014'
+  );
+  assert.equal(
+    resolveTaxonomyIdFromBody(
+      { category: { _id: '507f1f77bcf86cd799439020' } },
+      'categoryId',
+      'category'
+    ),
+    '507f1f77bcf86cd799439020'
+  );
+});
+
+test('formatOwnerServiceForResponse maps stored business hours for owner reopen', () => {
+  const formatted = formatOwnerServiceForResponse({
+    _id: '507f1f77bcf86cd799439011',
+    categoryId: { _id: '507f1f77bcf86cd799439014', name: 'Beauty' },
+    businessHours: [{ day: 'Wednesday', hours: '08:00-12:00', closed: false }],
+    faq: [{ question: 'Q', answer: 'A' }],
+    amenities: [{ label: 'Parking', available: true }],
+    features: ['Online Booking'],
+  });
+
+  assert.equal(formatted.categoryId.name, 'Beauty');
+  assert.deepEqual(formatted.businessHours, [{
+    day: 'Wednesday',
+    openTime: '08:00',
+    closeTime: '12:00',
+    isOpen: true,
+  }]);
+  assert.deepEqual(formatted.faq, [{ question: 'Q', answer: 'A' }]);
 });
 
 test('normalizeServicePayload backfills single name-only child from top-level price and duration', () => {

--- a/tests/service/service-publication-visibility.test.js
+++ b/tests/service/service-publication-visibility.test.js
@@ -139,7 +139,14 @@ function loadServiceController(options = {}) {
         return chain;
       };
       ServiceExport.find = Service.find;
-      ServiceExport.findById = Service.findById;
+      ServiceExport.findById = () => {
+        const refreshed = existingService || buildServiceDoc();
+        return {
+          populate: () => ({
+            populate: async () => refreshed,
+          }),
+        };
+      };
       ServiceExport.findByIdAndUpdate = Service.findByIdAndUpdate;
       return ServiceExport;
     }
@@ -530,4 +537,101 @@ test('updateService normalizes invalid feature values to empty array', async () 
   assert.equal(res.statusCode, 200);
   assert.deepEqual(draft.features, []);
   assert.deepEqual(res.body.data.service.features, []);
+});
+
+test('updateService persists category, faq, amenities, and business hours on draft save', async () => {
+  const draft = buildServiceDoc({
+    isPublished: false,
+    categoryId: '507f1f77bcf86cd799439014',
+    subcategoryId: '507f1f77bcf86cd799439015',
+    faq: [],
+    amenities: [],
+    businessHours: [],
+  });
+  draft.categoryId = { _id: '507f1f77bcf86cd799439014', name: 'Beauty' };
+  draft.subcategoryId = { _id: '507f1f77bcf86cd799439015', name: 'Hair' };
+
+  const { controller } = loadServiceController({
+    existingService: draft,
+  });
+  const res = mockResponse();
+
+  await controller.updateService(
+    {
+      user: { _id: ownerId },
+      params: { id: serviceId },
+      body: {
+        categoryId: '507f1f77bcf86cd799439020',
+        subcategoryId: '507f1f77bcf86cd799439021',
+        faq: [{ question: ' What hours? ', answer: ' 9-5 ' }, { question: '', answer: 'nope' }],
+        amenities: [{ label: ' WiFi ', available: true }, { label: '', available: true }],
+        businessHours: [{ day: 'Monday', openTime: '09:00', closeTime: '17:00', isOpen: true }],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(String(draft.categoryId), '507f1f77bcf86cd799439020');
+  assert.equal(String(draft.subcategoryId), '507f1f77bcf86cd799439021');
+  assert.deepEqual(draft.faq, [{ question: 'What hours?', answer: '9-5' }]);
+  assert.deepEqual(draft.amenities, [{ label: 'WiFi', available: true }]);
+  assert.deepEqual(draft.businessHours, [{ day: 'Monday', hours: '09:00-17:00', closed: false }]);
+  assert.deepEqual(res.body.data.service.businessHours, [{
+    day: 'Monday',
+    openTime: '09:00',
+    closeTime: '17:00',
+    isOpen: true,
+  }]);
+});
+
+test('updateService leaves faq, amenities, and business hours unchanged when omitted', async () => {
+  const draft = buildServiceDoc({
+    isPublished: false,
+    faq: [{ question: 'Q1', answer: 'A1' }],
+    amenities: [{ label: 'Parking', available: true }],
+    businessHours: [{ day: 'Tuesday', hours: '10:00-18:00', closed: false }],
+  });
+  const { controller } = loadServiceController({ existingService: draft });
+  const res = mockResponse();
+
+  await controller.updateService(
+    {
+      user: { _id: ownerId },
+      params: { id: serviceId },
+      body: { title: 'Updated title only' },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(draft.faq, [{ question: 'Q1', answer: 'A1' }]);
+  assert.deepEqual(draft.amenities, [{ label: 'Parking', available: true }]);
+  assert.deepEqual(draft.businessHours, [{ day: 'Tuesday', hours: '10:00-18:00', closed: false }]);
+});
+
+test('createParentService persists faq, amenities, and normalized business hours', async () => {
+  const { controller, savedDocs } = loadServiceController({ existingService: null });
+  const res = mockResponse();
+
+  await controller.createParentService(
+    {
+      user: { _id: ownerId },
+      body: {
+        businessId,
+        categoryId: '507f1f77bcf86cd799439014',
+        subcategoryId: '507f1f77bcf86cd799439015',
+        title: 'Draft Service',
+        faq: [{ question: 'Q', answer: 'A' }],
+        amenities: [{ label: 'Parking', available: false }],
+        businessHours: [{ day: 'Friday', openTime: '08:00', closeTime: '16:00', isOpen: true }],
+      },
+    },
+    res
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.deepEqual(savedDocs[0].faq, [{ question: 'Q', answer: 'A' }]);
+  assert.deepEqual(savedDocs[0].amenities, [{ label: 'Parking', available: false }]);
+  assert.deepEqual(savedDocs[0].businessHours, [{ day: 'Friday', hours: '08:00-16:00', closed: false }]);
 });


### PR DESCRIPTION
## Summary
- Fixes UAT-SERVICE-001 through UAT-SERVICE-005 in service create/update/parent-create, owner reopen responses, and public service DTOs
- Tracks #226; related #211, #214, #215

## UAT fixes
| ID | Fix |
|----|-----|
| UAT-SERVICE-001 | Persist category/subcategory on draft save; populated owner response after PUT |
| UAT-SERVICE-002 | Persist FAQ on create/update |
| UAT-SERVICE-003 | Normalize business hours FE shape on write; owner reopen FE shape on read |
| UAT-SERVICE-004 | Features already on public reads in f44acda; regression tests retained |
| UAT-SERVICE-005 | Expose amenities (and faq) on public detail/card + business-service endpoint |

## Files changed
- lib/service/serviceContract.js
- controllers/serviceController.js
- lib/listing/publicListingDto.js
- tests/service/*, tests/marketplace/public-listing-dto.test.js

## Test plan
- [x] Focused node tests: 64/64 pass
- [x] npm test: 556/556 pass
- [x] npm run test:integration: 75/75 pass

## Risks / limitations
- `faqs` alias not accepted (only `faq`)
- `createParentService` still returns raw Mongoose doc (not canonical owner DTO)
- Nested `category`/`subcategory` objects accepted on update only, not create
- Public list/search `.select()` omits metadata fields; detail/slug routes load full documents

## Rollback
- Pre-deploy: close or revert this PR on `staging` — production (`f44acda`) unchanged
- Post-staging merge: revert merge commit on `staging` before promotion to `main`
- Post-production: redeploy prior EB version per PRODUCTION_ROLLBACK_RUNBOOK

## Deployment
**No deploy performed.** PR targets `staging` only. Do not merge to `main` until Lionel approves the production UAT batch.
