### PR TITLE
Complete vendor go-live backend support for onboarding and dashboard sync

### DIFF
--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -22,6 +22,13 @@ const {
   enrichBusinessesWithListingSnapshots,
   publishBusinessListings,
 } = require("../utils/businessListingVisibility");
+const {
+  syncBusinessFromOnboarding,
+  needsProfileBackfillFromOnboarding,
+} = require("../utils/syncBusinessFromOnboarding");
+const { sendVendorStorefrontPublishedEmail } = require("../utils/WellcomeMailer");
+const { deliverVendorOnboardingEmail } = require("../utils/vendorOnboardingEmailDelivery");
+const User = require("../models/User");
 
 exports.createBusiness = async (req, res) => {
   try {
@@ -160,7 +167,7 @@ exports.createBusiness = async (req, res) => {
       coverImage: coverUrl,
       owner: user._id,
       isApproved: true,
-      isActive: true,
+      isActive: false, // Stays inactive until Stage 6 publish-storefront completes.
       subscriptionId: subscription._id,
       stripeSubscriptionId,
       minorityType: user.minorityType,
@@ -220,6 +227,8 @@ exports.publishStorefront = async (req, res) => {
       });
     }
 
+    const wasActive = business.isActive === true;
+
     const publication = await publishBusinessListings({
       business,
       userId: req.user._id,
@@ -239,6 +248,26 @@ exports.publishStorefront = async (req, res) => {
       });
     }
 
+    let emailDelivery = null;
+    if (!wasActive) {
+      const user = await User.findById(req.user._id).select("name email").lean();
+      const recipient = String(business.email || user?.email || "").trim();
+
+      if (recipient) {
+        emailDelivery = await deliverVendorOnboardingEmail({
+          label: "vendor_storefront_published",
+          send: () =>
+            sendVendorStorefrontPublishedEmail({
+              to: recipient,
+              vendorName: user?.name || business.businessName,
+              businessName: business.businessName,
+              listingType: business.listingType,
+              businessSlug: business.slug,
+            }),
+        });
+      }
+    }
+
     return res.status(200).json({
       success: true,
       message: "Storefront and eligible listings published successfully.",
@@ -248,6 +277,9 @@ exports.publishStorefront = async (req, res) => {
         publication.snapshot,
         publication.onboarding
       ),
+      emailSent: emailDelivery?.sent ?? false,
+      emailSkipped: emailDelivery?.skipped ?? false,
+      emailFailed: emailDelivery ? !emailDelivery.sent && !emailDelivery.skipped : false,
     });
   } catch (error) {
     console.error("Storefront publish error:", {
@@ -797,7 +829,7 @@ exports.retryCreateBusiness = async (req, res) => {
       coverImage: formData.coverImage || "", // Same for coverImage
       minorityType: subscription.userId.minorityType,
       isApproved: true,
-      isActive: true, // Default to active; admin can deactivate later if needed
+      isActive: false, // Stays inactive until Stage 6 publish-storefront completes.
       subscriptionId: subscription._id,
       stripeSubscriptionId: subscription.stripeSubscriptionId,
     });
@@ -907,24 +939,46 @@ exports.getBusinessBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
 
-    const business = await Business.findOne({
-      slug,
-      owner: req.user._id,
-    })
-      .populate({
+    const businessQuery = () =>
+      Business.findOne({
+        slug,
+        owner: req.user._id,
+      }).populate({
         path: "subscriptionId",
         populate: {
           path: "subscriptionPlanId",
           model: "SubscriptionPlan",
         },
-      })
-      .lean();
+      });
+
+    let business = await businessQuery().lean();
 
     if (!business) {
       return res.status(404).json({
         success: false,
         message: "Business not found or you are not authorized",
       });
+    }
+
+    // Backfill address/logo/banner for vendors onboarded before profile sync included address.
+    const onboarding = await VendorOnboardingStage1.findOne({
+      userId: req.user._id,
+    });
+    if (onboarding && needsProfileBackfillFromOnboarding(business, onboarding)) {
+      try {
+        await syncBusinessFromOnboarding({
+          userId: req.user._id,
+          onboarding,
+          Business,
+          Subscription,
+        });
+        business = await businessQuery().lean();
+      } catch (backfillError) {
+        console.error(
+          "[getBusinessBySlug] profile backfill sync failed:",
+          backfillError.message
+        );
+      }
     }
 
     // ✅ Separate subscriptionId & subscriptionPlanId from business
@@ -950,6 +1004,34 @@ exports.getBusinessBySlug = async (req, res) => {
       success: false,
       message: "Server error",
     });
+  }
+};
+
+exports.updateBusinessVisibility = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { isActive } = req.body;
+
+    if (typeof isActive !== 'boolean') {
+      return res.status(400).json({ success: false, message: '`isActive` must be a boolean' });
+    }
+
+    const business = await Business.findOne({ _id: id, owner: req.user._id });
+    if (!business) {
+      return res.status(404).json({ success: false, message: 'Business not found or unauthorized' });
+    }
+
+    business.isActive = isActive;
+    await business.save();
+
+    return res.status(200).json({
+      success: true,
+      message: isActive ? 'Your listing is now visible on the marketplace' : 'Your listing has been hidden from the marketplace',
+      isActive,
+    });
+  } catch (err) {
+    console.error('[updateBusinessVisibility]', err);
+    return res.status(500).json({ success: false, message: 'Server error' });
   }
 };
 

--- a/controllers/privateListing.js
+++ b/controllers/privateListing.js
@@ -215,16 +215,18 @@ exports.getAllFood = async (req, res) => {
 
     // Fetching food items based on filters
     const foodItems = await Food.find(filters)
-      .select('title description price slug coverImage')
+      .select('title description price slug coverImage isPublished')
       .sort(sortOption)
       .skip(skip)
       .limit(parseInt(limit));
 
     const total = await Food.countDocuments(filters);
+    const unpublishedCount = await Food.countDocuments({ ...filters, isPublished: false });
 
     res.json({
       success: true,
       total,
+      unpublishedCount,
       page: parseInt(page),
       totalPages: Math.ceil(total / limit),
       data: foodItems,

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -147,10 +147,10 @@ exports.createParentService = async (req, res) => {
       services: [],
 
       contact: {
-        phone: '',
-        email: '',
-        address: location?.address || '',
-        website: ''
+        phone: req.body.contact?.phone || '',
+        email: req.body.contact?.email || '',
+        address: req.body.contact?.address || location?.address || '',
+        website: req.body.contact?.website || ''
       },
 
       ownerId: userId,

--- a/controllers/stripeController.js
+++ b/controllers/stripeController.js
@@ -164,7 +164,7 @@ exports.handleStripeWebhook = async (req, res) => {
         coverImage: draft.formData.coverImage || "",
         minorityType: draft.minorityType, // Use minorityType from the draft
         isApproved: true,
-        isActive: true, // Default to active; admin can deactivate later if needed
+        isActive: false, // Stays inactive until Stage 6 publish-storefront completes.
         subscriptionId: newSubscription._id,
         stripeSubscriptionId,
         stripeCustomerId: stripeCustomerId ? String(stripeCustomerId) : undefined,

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -473,3 +473,93 @@ exports.logout = (req, res) => {
 
     res.status(200).json({ message: 'Logged out successfully' });
 };
+
+// ── Vendor Settings ────────────────────────────────────────────────────────────
+
+exports.changePassword = async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ success: false, errors: errors.array() });
+    }
+
+    try {
+        const user = await User.findById(req.user._id).select('+passwordHash');
+        if (!user) {
+            return res.status(404).json({ success: false, message: 'User not found' });
+        }
+
+        if (!user.passwordHash) {
+            return res.status(400).json({ success: false, message: 'Password change is not available for social login accounts' });
+        }
+
+        const { currentPassword, newPassword } = req.body;
+
+        const isMatch = await bcrypt.compare(currentPassword, user.passwordHash);
+        if (!isMatch) {
+            return res.status(401).json({ success: false, message: 'Current password is incorrect' });
+        }
+
+        if (currentPassword === newPassword) {
+            return res.status(400).json({ success: false, message: 'New password must be different from current password' });
+        }
+
+        user.passwordHash = await bcrypt.hash(newPassword, 12);
+        await user.save();
+
+        return res.status(200).json({ success: true, message: 'Password updated successfully' });
+    } catch (err) {
+        console.error('[changePassword]', err);
+        return res.status(500).json({ success: false, message: 'Server error' });
+    }
+};
+
+exports.getNotificationPreferences = async (req, res) => {
+    try {
+        const user = await User.findById(req.user._id).select('notificationPreferences');
+        if (!user) {
+            return res.status(404).json({ success: false, message: 'User not found' });
+        }
+
+        const prefs = user.notificationPreferences ?? {};
+        return res.status(200).json({
+            success: true,
+            preferences: {
+                newBookingOrOrder: prefs.newBookingOrOrder ?? true,
+                newReview:         prefs.newReview         ?? true,
+                paymentReceived:   prefs.paymentReceived   ?? true,
+                marketingEmails:   prefs.marketingEmails   ?? false,
+            },
+        });
+    } catch (err) {
+        console.error('[getNotificationPreferences]', err);
+        return res.status(500).json({ success: false, message: 'Server error' });
+    }
+};
+
+exports.updateNotificationPreferences = async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ success: false, errors: errors.array() });
+    }
+
+    try {
+        const { newBookingOrOrder, newReview, paymentReceived, marketingEmails } = req.body;
+
+        const update = {};
+        if (newBookingOrOrder !== undefined) update['notificationPreferences.newBookingOrOrder'] = newBookingOrOrder;
+        if (newReview         !== undefined) update['notificationPreferences.newReview']         = newReview;
+        if (paymentReceived   !== undefined) update['notificationPreferences.paymentReceived']   = paymentReceived;
+        if (marketingEmails   !== undefined) update['notificationPreferences.marketingEmails']   = marketingEmails;
+
+        if (Object.keys(update).length === 0) {
+            return res.status(400).json({ success: false, message: 'No preferences provided' });
+        }
+
+        await User.findByIdAndUpdate(req.user._id, { $set: update }, { new: true });
+
+        return res.status(200).json({ success: true, message: 'Notification preferences updated' });
+    } catch (err) {
+        console.error('[updateNotificationPreferences]', err);
+        return res.status(500).json({ success: false, message: 'Server error' });
+    }
+};

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -94,7 +94,9 @@ const normalizeBusinessHoursForStorage = (slots) => {
         closed = !slot.isOpen;
       }
 
-      if (!hours) {
+      // Treat both an empty hours string AND an explicit "Closed" value as closed.
+      // This ensures `closed` is always true when the day is not open.
+      if (!hours || hours === 'Closed') {
         hours = 'Closed';
         closed = true;
       }
@@ -120,7 +122,11 @@ const normalizeBusinessHoursForOwnerResponse = (slots) => {
       }
     }
 
-    if (typeof slot?.closed === 'boolean') {
+    // Check the `hours` string first — "Closed" is a definitive signal regardless
+    // of what the `closed` flag says (handles data saved before the storage fix).
+    if (slot?.hours === 'Closed') {
+      isOpen = false;
+    } else if (typeof slot?.closed === 'boolean') {
       isOpen = !slot.closed;
     }
 

--- a/models/Business.js
+++ b/models/Business.js
@@ -148,7 +148,7 @@ const businessSchema = new mongoose.Schema(
     },
     isActive: {
       type: Boolean,
-      default: true,
+      default: false, // Stays false until Stage 6 publish-storefront completes.
     },
     approvalDate: Date,
     adminStatusRemark: {
@@ -194,6 +194,13 @@ const businessSchema = new mongoose.Schema(
     
     // ===== TAGS FOR SEARCH =====
     tags: [String],
+
+    // ===== VENDOR PROFILE (synced from onboarding) =====
+    language: {
+      type: String,
+      trim: true,
+    },
+    minorityCategories: [String],
     
     // ===== MINORITY TYPE (REFERENCE) =====
     minorityType: {

--- a/models/User.js
+++ b/models/User.js
@@ -97,7 +97,13 @@ verificationStatus: {
     // }
     minorityType: {
       type: String,
-    }
+    },
+    notificationPreferences: {
+      newBookingOrOrder: { type: Boolean, default: true  },
+      newReview:         { type: Boolean, default: true  },
+      paymentReceived:   { type: Boolean, default: true  },
+      marketingEmails:   { type: Boolean, default: false },
+    },
   },
   { timestamps: true }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,7 +1001,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1023,7 +1022,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
       "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1039,7 +1037,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
       "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
@@ -1073,7 +1070,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
       "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.8.0",
         "@opentelemetry/resources": "2.8.0",
@@ -1091,7 +1087,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2035,7 +2030,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2798,8 +2792,7 @@
       "version": "0.0.1475386",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -3027,7 +3020,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3425,6 +3417,7 @@
       "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "gaxios": "^5.0.0",
         "json-bigint": "^1.0.0"
@@ -3439,6 +3432,7 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3452,6 +3446,7 @@
       "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
@@ -3468,6 +3463,7 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -3482,6 +3478,7 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3502,14 +3499,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gcp-metadata/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3517,6 +3516,7 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3965,6 +3965,7 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -5518,7 +5519,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"

--- a/routes/businessRoutes.js
+++ b/routes/businessRoutes.js
@@ -118,6 +118,9 @@ router.delete(
 
 router.post('/draft', authenticate, isBusinessOwner, businessController.createBusinessDraft);
 
+// Vendor-controlled listing visibility toggle
+router.patch('/:id/visibility', authenticate, isBusinessOwner, businessController.updateBusinessVisibility);
+
 
 
 

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -122,4 +122,30 @@ router.get('/auth/check', authenticate, (req, res) => {
   res.json({ loggedIn: true, user: toAuthCheckUser(req.user) });
 });
 
+// ── Vendor Settings ────────────────────────────────────────────────────────────
+
+router.post(
+  '/change-password',
+  authenticate,
+  [
+    body('currentPassword').notEmpty().withMessage('Current password is required'),
+    body('newPassword').isLength({ min: 6 }).withMessage('New password must be at least 6 characters'),
+  ],
+  userController.changePassword
+);
+
+router.get('/notification-preferences', authenticate, userController.getNotificationPreferences);
+
+router.patch(
+  '/notification-preferences',
+  authenticate,
+  [
+    body('newBookingOrOrder').optional().isBoolean(),
+    body('newReview').optional().isBoolean(),
+    body('paymentReceived').optional().isBoolean(),
+    body('marketingEmails').optional().isBoolean(),
+  ],
+  userController.updateNotificationPreferences
+);
+
 module.exports = router;

--- a/tests/auth/auth-check-payload.test.js
+++ b/tests/auth/auth-check-payload.test.js
@@ -86,6 +86,9 @@ test('GET /auth/check response uses toPublicAuthUser whitelist', async () => {
     resendOtp() {},
     forgotPassword() {},
     resetPassword() {},
+    changePassword() {},
+    getNotificationPreferences() {},
+    updateNotificationPreferences() {},
   };
 
   const router = (() => {

--- a/tests/auth/password-reset-abuse-protection.test.js
+++ b/tests/auth/password-reset-abuse-protection.test.js
@@ -252,6 +252,9 @@ test('userRoutes applies rate limiting before forgot and reset password handlers
     resendOtp() {},
     forgotPassword() {},
     resetPassword() {},
+    changePassword() {},
+    getNotificationPreferences() {},
+    updateNotificationPreferences() {},
   };
 
   const router = withMocks(userRoutesPath, {

--- a/tests/email/vendor-storefront-published-mail.test.js
+++ b/tests/email/vendor-storefront-published-mail.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const mailerPath = path.resolve(__dirname, '../../utils/WellcomeMailer.js');
+
+function loadMailerWithMocks(sendMailCalls) {
+  const nodemailerMock = {
+    createTransport: () => ({
+      sendMail: async (message) => {
+        sendMailCalls.push(message);
+        return { messageId: 'message-1' };
+      },
+    }),
+  };
+
+  const frontendUrlMock = {
+    buildFrontendUrl: (route = '/') =>
+      `https://mosaicbizhub.com${route.startsWith('/') ? route : `/${route}`}`,
+    getFrontendLogoUrl: () => 'https://mosaicbizhub.com/logo.png',
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'nodemailer') {
+      return nodemailerMock;
+    }
+    if (request === './frontendUrl') {
+      return frontendUrlMock;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[mailerPath];
+  const mailer = require(mailerPath);
+  Module._load = originalLoad;
+  return mailer;
+}
+
+test('sendVendorStorefrontPublishedEmail uses congratulations copy and dashboard link', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+
+  const sendMailCalls = [];
+  const mailer = loadMailerWithMocks(sendMailCalls);
+
+  await mailer.sendVendorStorefrontPublishedEmail({
+    to: 'vendor@example.com',
+    vendorName: 'Abhay',
+    businessName: 'Abhay Salon',
+    listingType: 'service',
+    businessSlug: 'abhay-9',
+  });
+
+  assert.equal(sendMailCalls.length, 1);
+  const message = sendMailCalls[0];
+  assert.equal(message.to, 'vendor@example.com');
+  assert.match(message.subject, /Congratulations/i);
+  assert.match(message.subject, /Storefront Is Live/i);
+  assert.match(message.html, /Congratulations, Abhay!/);
+  assert.match(message.html, /Abhay Salon/);
+  assert.match(message.html, /service storefront and listings are now live/i);
+  assert.match(message.html, /https:\/\/mosaicbizhub\.com\/partners\/abhay-9/);
+  assert.match(message.html, /Go to Dashboard/);
+});
+
+test('sendVendorStorefrontPublishedEmail escapes html in vendor-visible fields', async () => {
+  process.env.MAIL_USER = 'mail@example.com';
+
+  const sendMailCalls = [];
+  const mailer = loadMailerWithMocks(sendMailCalls);
+
+  await mailer.sendVendorStorefrontPublishedEmail({
+    to: 'vendor@example.com',
+    vendorName: 'Vendor <script>',
+    businessName: 'Biz & Co',
+    listingType: 'product',
+    businessSlug: 'biz-co',
+  });
+
+  const message = sendMailCalls[0];
+  assert.doesNotMatch(message.html, /<script>/);
+  assert.match(message.html, /Vendor &lt;script&gt;/);
+  assert.match(message.html, /Biz &amp; Co/);
+  assert.match(message.html, /product storefront and listings are now live/i);
+});

--- a/tests/vendor/vendor-onboarding-business-sync.test.js
+++ b/tests/vendor/vendor-onboarding-business-sync.test.js
@@ -44,6 +44,17 @@ function buildOnboarding(overrides = {}) {
     featureBanner: { url: 'https://example.com/banner.png' },
     businessEmail: 'shop@example.com',
     businessPhone: '5551234567',
+    address: {
+      street: '100 Main St',
+      city: 'Norfolk',
+      state: 'Virginia',
+      country: 'United States',
+      zipCode: '23510',
+    },
+    website: 'https://example.com',
+    facebook: 'https://facebook.com/example',
+    language: 'English',
+    minorityCategories: ['Woman', 'Asian'],
     save: async () => {},
     ...overrides,
   };
@@ -99,6 +110,11 @@ test('syncBusinessFromOnboarding creates Business when none exists', async () =>
   assert.equal(created.owner, userId);
   assert.equal(created.subscriptionId, subscriptionId);
   assert.equal(created.isApproved, true);
+  assert.equal(created.address.city, 'Norfolk');
+  assert.equal(created.address.zipCode, '23510');
+  assert.equal(created.socialLinks.website, 'https://example.com');
+  assert.equal(created.language, 'English');
+  assert.deepEqual(created.minorityCategories, ['Woman', 'Asian']);
   assert.equal(onboarding.businessId, business._id);
 });
 
@@ -147,7 +163,81 @@ test('syncBusinessFromOnboarding updates existing Business', async () => {
 
   assert.equal(existingBusiness.businessName, 'Synced Business');
   assert.equal(existingBusiness.description, 'Bio text');
+  assert.equal(existingBusiness.address.state, 'Virginia');
+  assert.equal(existingBusiness.socialLinks.facebook, 'https://facebook.com/example');
+  assert.equal(existingBusiness.language, 'English');
+  assert.deepEqual(existingBusiness.minorityCategories, ['Woman', 'Asian']);
   assert.equal(onboarding.businessId, existingBusiness._id);
+});
+
+test('needsProfileBackfillFromOnboarding detects missing address on Business', () => {
+  const {
+    needsProfileBackfillFromOnboarding,
+  } = require(syncUtilPath);
+
+  const onboarding = buildOnboarding();
+  const businessWithAddress = {
+    address: { city: 'Norfolk' },
+    logo: 'https://example.com/logo.png',
+    coverImage: 'https://example.com/banner.png',
+    language: 'English',
+    minorityCategories: ['Woman'],
+  };
+  const businessWithoutAddress = {
+    address: {},
+    logo: '',
+    coverImage: '',
+    language: '',
+    minorityCategories: [],
+  };
+
+  assert.equal(
+    needsProfileBackfillFromOnboarding(businessWithAddress, onboarding),
+    false
+  );
+  assert.equal(
+    needsProfileBackfillFromOnboarding(businessWithoutAddress, onboarding),
+    true
+  );
+});
+
+test('needsProfileBackfillFromOnboarding detects missing language and minority categories', () => {
+  const { needsProfileBackfillFromOnboarding } = require(syncUtilPath);
+  const onboarding = buildOnboarding({
+    address: {},
+    businessProfileImage: { url: '' },
+    featureBanner: { url: '' },
+    language: 'Spanish',
+    minorityCategories: ['LatinX'],
+  });
+
+  assert.equal(
+    needsProfileBackfillFromOnboarding(
+      {
+        address: {},
+        logo: '',
+        coverImage: '',
+        language: '',
+        minorityCategories: [],
+      },
+      onboarding
+    ),
+    true
+  );
+
+  assert.equal(
+    needsProfileBackfillFromOnboarding(
+      {
+        address: {},
+        logo: '',
+        coverImage: '',
+        language: 'Spanish',
+        minorityCategories: ['LatinX'],
+      },
+      onboarding
+    ),
+    false
+  );
 });
 
 test('syncBusinessFromOnboarding propagates Business save failures', async () => {

--- a/utils/WellcomeMailer.js
+++ b/utils/WellcomeMailer.js
@@ -327,6 +327,79 @@ exports.sendVendorApprovedEmail = async ({
   return transporter.sendMail(mailOptions);
 };
 
+const storefrontListingCopy = Object.freeze({
+  product: {
+    label: 'product',
+    summary:
+      'Your product storefront and listings are now live on Mosaic Biz Hub.',
+  },
+  service: {
+    label: 'service',
+    summary:
+      'Your service storefront and listings are now live on Mosaic Biz Hub.',
+  },
+  food: {
+    label: 'food',
+    summary:
+      'Your food storefront and listings are now live on Mosaic Biz Hub.',
+  },
+});
+
+exports.sendVendorStorefrontPublishedEmail = async ({
+  to,
+  vendorName,
+  businessName,
+  listingType = 'product',
+  businessSlug,
+}) => {
+  const normalizedType = String(listingType || 'product').trim().toLowerCase();
+  const copy =
+    storefrontListingCopy[normalizedType] || storefrontListingCopy.product;
+  const displayName = vendorName || businessName || 'there';
+  const displayBusinessName = businessName || 'your business';
+  const dashboardPath = businessSlug ? `/partners/${businessSlug}` : '/partners';
+  const dashboardUrl = buildFrontendUrl(dashboardPath);
+
+  const mailOptions = {
+    from: formatMosaicFromHeader(),
+    to,
+    subject: 'Congratulations — Your Mosaic Biz Hub Storefront Is Live 🎉',
+    html: `
+      <div style="font-family:Arial,sans-serif;background:#f8fafc;padding:28px;">
+        <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:8px;padding:28px;border:1px solid #e2e8f0;">
+          <h2 style="margin:0 0 12px;color:#28a745;">Congratulations, ${escapeHtml(displayName)}!</h2>
+          <p style="color:#475569;line-height:1.6;margin:0 0 16px;">
+            <strong>${escapeHtml(displayBusinessName)}</strong> has completed onboarding and your storefront is live.
+          </p>
+          <p style="color:#475569;line-height:1.6;margin:0 0 16px;">
+            ${escapeHtml(copy.summary)} Customers can now discover your ${escapeHtml(copy.label)} business on the marketplace.
+          </p>
+          <p style="color:#475569;line-height:1.6;margin:0 0 8px;">
+            <strong>What you can do next:</strong>
+          </p>
+          <ul style="margin:8px 0 0 18px;padding:0;color:#475569;line-height:1.6;">
+            <li>Open your vendor dashboard to manage bookings, orders, and inventory</li>
+            <li>Review your public storefront and keep listings up to date</li>
+            <li>Share your business profile with customers</li>
+          </ul>
+          <div style="margin:24px 0;text-align:center;">
+            <a href="${dashboardUrl}" style="background:#c9a227;color:#111827;padding:12px 20px;text-decoration:none;border-radius:6px;font-size:14px;font-weight:bold;">
+              Go to Dashboard
+            </a>
+          </div>
+          <p style="font-size:13px;color:#64748b;line-height:1.5;margin:24px 0 0;">
+            Welcome to the Mosaic Biz Hub community — we're excited to see your business grow.
+          </p>
+          <p style="font-size:13px;color:#64748b;margin:18px 0 0;">
+            Mosaic Biz Hub Team
+          </p>
+        </div>
+      </div>
+    `,
+  };
+
+  return transporter.sendMail(mailOptions);
+};
 
 
 exports.sendVendorRejectionEmail = async ({

--- a/utils/businessListingVisibility.js
+++ b/utils/businessListingVisibility.js
@@ -313,12 +313,9 @@ function buildPublicationBlockers({ business, onboarding, snapshot }) {
     });
   }
 
-  if (business?.isActive !== true) {
-    blockers.push({
-      code: 'BUSINESS_ACTIVE_REQUIRED',
-      message: 'Business must be active before publishing.',
-    });
-  }
+  // isActive is no longer a prerequisite blocker — it is SET by publishBusinessListings
+  // upon successful completion of Stage 6. Checking it here would create a chicken-and-egg
+  // deadlock where a vendor can never launch because they aren't active yet.
 
   if (requiresPayoutSetupForBusiness(business) && !isPayoutCompleteForBusiness(business)) {
     blockers.push({
@@ -397,6 +394,14 @@ async function publishBusinessListings({ business, userId }) {
         blockers,
       },
     };
+  }
+
+  // Stage 6 is the single launch moment. Flip the business live now that all
+  // blockers have passed. This is the ONLY place isActive is set to true for
+  // a vendor going through the normal onboarding funnel.
+  if (!business.isActive) {
+    business.isActive = true;
+    await business.save();
   }
 
   const eligible = eligibleBeforePublication;

--- a/utils/syncBusinessFromOnboarding.js
+++ b/utils/syncBusinessFromOnboarding.js
@@ -1,3 +1,82 @@
+function hasAnyAddressValue(address) {
+  if (!address) return false;
+  return ['street', 'city', 'state', 'country', 'zipCode'].some(
+    (key) => String(address[key] || '').trim()
+  );
+}
+
+function normalizeMinorityCategories(categories) {
+  if (!Array.isArray(categories)) return [];
+  return categories
+    .map((item) => String(item || '').trim())
+    .filter(Boolean);
+}
+
+function buildAddressFromOnboarding(onboarding) {
+  const src = onboarding?.address || {};
+  return {
+    street: String(src.street || '').trim(),
+    city: String(src.city || '').trim(),
+    state: String(src.state || '').trim(),
+    country: String(src.country || '').trim(),
+    zipCode: String(src.zipCode || '').trim(),
+  };
+}
+
+function buildSocialLinksFromOnboarding(onboarding) {
+  return {
+    website: onboarding?.website || '',
+    facebook: onboarding?.facebook || '',
+    instagram: onboarding?.instagram || '',
+    twitter: onboarding?.twitter || '',
+    linkedin: onboarding?.linkedin || '',
+    tiktok: onboarding?.tiktok || '',
+  };
+}
+
+/**
+ * Returns true when onboarding has profile data that never made it onto Business
+ * (e.g. vendors who completed onboarding before profile sync included all fields).
+ */
+function needsProfileBackfillFromOnboarding(business, onboarding) {
+  if (!business || !onboarding) return false;
+
+  const needsAddress =
+    hasAnyAddressValue(onboarding.address) &&
+    !hasAnyAddressValue(business.address);
+
+  const onboardingLogo = onboarding.businessProfileImage?.url;
+  const needsLogo =
+    Boolean(String(onboardingLogo || '').trim()) &&
+    !String(business.logo || '').trim();
+
+  const onboardingCover = onboarding.featureBanner?.url;
+  const needsCover =
+    Boolean(String(onboardingCover || '').trim()) &&
+    !String(business.coverImage || '').trim();
+
+  const needsLanguage =
+    Boolean(String(onboarding.language || '').trim()) &&
+    !String(business.language || '').trim();
+
+  const onboardingMinority = normalizeMinorityCategories(
+    onboarding.minorityCategories
+  );
+  const businessMinority = normalizeMinorityCategories(
+    business.minorityCategories
+  );
+  const needsMinority =
+    onboardingMinority.length > 0 && businessMinority.length === 0;
+
+  return (
+    needsAddress ||
+    needsLogo ||
+    needsCover ||
+    needsLanguage ||
+    needsMinority
+  );
+}
+
 async function syncBusinessFromOnboarding({
   userId,
   onboarding,
@@ -18,6 +97,10 @@ async function syncBusinessFromOnboarding({
     coverImage: onboarding.featureBanner?.url,
     email: onboarding.businessEmail || onboarding.secondaryBusinessEmail,
     phone: onboarding.businessPhone || onboarding.primaryPhone,
+    address: buildAddressFromOnboarding(onboarding),
+    socialLinks: buildSocialLinksFromOnboarding(onboarding),
+    language: String(onboarding.language || '').trim(),
+    minorityCategories: normalizeMinorityCategories(onboarding.minorityCategories),
     listingType: onboarding.businessType || 'product',
     points: onboarding.totalVerificationPoints || 0,
     badge: onboarding.badge || null,
@@ -33,7 +116,9 @@ async function syncBusinessFromOnboarding({
       // Public marketplace approval mirrors the Stage-1 application decision;
       // never grant visibility before admin verification.
       isApproved: onboarding.status === 'verified',
-      isActive: true,
+      // isActive stays false until Stage 6 (publish-storefront) completes.
+      // That is the single point where a business goes live on the marketplace.
+      isActive: false,
       usage: {
         totalProducts: 0,
         totalServices: 0,
@@ -51,6 +136,13 @@ async function syncBusinessFromOnboarding({
     business.coverImage = businessData.coverImage;
     business.email = businessData.email;
     business.phone = businessData.phone;
+    business.address = businessData.address;
+    business.socialLinks = {
+      ...(business.socialLinks || {}),
+      ...businessData.socialLinks,
+    };
+    business.language = businessData.language;
+    business.minorityCategories = businessData.minorityCategories;
     business.listingType = businessData.listingType;
     business.points = businessData.points;
     business.badge = businessData.badge;
@@ -78,4 +170,8 @@ async function syncBusinessFromOnboarding({
 
 module.exports = {
   syncBusinessFromOnboarding,
+  needsProfileBackfillFromOnboarding,
+  buildAddressFromOnboarding,
+  buildSocialLinksFromOnboarding,
+  normalizeMinorityCategories,
 };


### PR DESCRIPTION
## Summary
- Aligns business activation with publish-storefront so vendors go live only after final review, fixing legacy `isActive` defaults and visibility blockers.
- Expands onboarding-to-Business sync (address, social links, language, minority categories) and adds profile backfill on business fetch.
- Adds go-live congratulations email on publish-storefront and richer private food inventory metadata (`isPublished`, `unpublishedCount`) for partner dashboard.

## Test plan
- [ ] Publish storefront for an onboarded vendor and confirm `isActive=true`, listing visibility, and go-live email delivery
- [ ] Verify `GET /api/business/:slug` backfills missing profile fields from onboarding stage 1
- [ ] Verify `GET /api/private/food/list?businessId=...` returns `isPublished` and `unpublishedCount`
- [ ] Run vendor onboarding business sync tests and storefront published mail test
- [ ] Regression: service edit persistence and draft/publication flows still pass


Made with [Cursor](https://cursor.com)