### PR TITLE
fix: harden public marketplace vendor visibility gates

### DIFF
--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -186,6 +186,10 @@ const syncBusinessPoints = async (application, badge, options = {}) => {
     update.isApproved = options.isApproved;
   }
 
+  if (options.isActive !== undefined) {
+    update.isActive = options.isActive;
+  }
+
   await Business.findOneAndUpdate(
     { owner: ownerId },
     { $set: update }
@@ -1077,6 +1081,7 @@ exports.finalizeVerification = async (req, res) => {
     // ✅ Sync business
     await syncBusinessPoints(application, badge, {
       isApproved: application.status === 'verified',
+      ...(application.status === 'verified' ? {} : { isActive: false }),
     });
 
     const vendorEmail = application.userId?.email;

--- a/controllers/foodController.js
+++ b/controllers/foodController.js
@@ -21,6 +21,7 @@ const {
   logUploadConfigFailure,
   logUploadFailure,
 } = require('../utils/uploadDiagnostics');
+const { publicMarketplaceBusinessFilter } = require('../lib/marketplace/businessEligibility');
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -203,10 +204,9 @@ exports.getBusinessFoodById = async (req, res) => {
       return res.status(404).json({ message: 'Business food not found.' });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: food.businessId?._id,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: food.businessId?._id })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({ message: 'Business food not found.' });

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -20,6 +20,7 @@ const {
   formatValidationErrorResponse,
 } = require('../lib/service/serviceContract');
 const { normalizeImages } = require('../lib/listing/publicListingDto');
+const { publicMarketplaceBusinessFilter } = require('../lib/marketplace/businessEligibility');
 const { hasActiveServiceBookings } = require('../utils/bookingDeleteGuards');
 const { S3Client } = require('@aws-sdk/client-s3');
 const { PutObjectCommand } = require("@aws-sdk/client-s3");
@@ -1000,10 +1001,9 @@ exports.getBusinessServiceById = async (req, res) => {
       });
     }
 
-    const visibleBusiness = await Business.findOne({
-      _id: service.businessId?._id,
-      isActive: true,
-    }).select('_id').lean();
+    const visibleBusiness = await Business.findOne(
+      publicMarketplaceBusinessFilter({ _id: service.businessId?._id })
+    ).select('_id').lean();
 
     if (!visibleBusiness) {
       return res.status(404).json({

--- a/tests/admin/vendor-onboarding-finalize.test.js
+++ b/tests/admin/vendor-onboarding-finalize.test.js
@@ -178,6 +178,7 @@ test('finalizeVerification rejects when required docs missing', async () => {
   assert.deepEqual(application.verificationNotificationLog[0].messageIds, ['vendor-rejection-message']);
   assert.deepEqual(application.verificationNotificationLog[0].documentsNeeded, ['EIN document']);
   assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
+  assert.equal(businessUpdates.at(-1).update.$set.isActive, false);
 });
 
 test('finalizeVerification explicit approve persists reviewer identity and timestamps', async () => {
@@ -272,6 +273,7 @@ test('finalizeVerification explicit reject stores reason, notes, next action, an
   assert.equal(res.body.data.requiredNextAction, 'Upload a current business license and resubmit.');
   assert.equal(mailerCalls.rejection.rejectionReason, 'Business license appears expired');
   assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
+  assert.equal(businessUpdates.at(-1).update.$set.isActive, false);
 });
 
 test('finalizeVerification auto reject persists default review metadata', async () => {

--- a/tests/integration/marketplace.integration.test.js
+++ b/tests/integration/marketplace.integration.test.js
@@ -13,12 +13,18 @@ const {
   createAdminDirect,
   seedApprovedBusiness,
   seedPublishedProduct,
+  seedServiceBusiness,
+  seedServiceCategories,
 } = require('./helpers/factories');
 const User = require('../../models/User');
 const Business = require('../../models/Business');
 const ProductVariant = require('../../models/ProductVariant');
 const Cart = require('../../models/Cart');
 const CartItem = require('../../models/CartItem');
+const Service = require('../../models/Service');
+const Food = require('../../models/Food');
+const FoodCategory = require('../../models/FoodCategory');
+const FoodSubcategory = require('../../models/FoodSubcategory');
 
 test.before(async () => {
   await startHarness();
@@ -219,4 +225,78 @@ test('admin activation does not approve, while admin approve sets public eligibi
   reloaded = await Business.findById(business._id).lean();
   assert.equal(reloaded.isApproved, true);
   assert.equal(reloaded.isActive, true);
+});
+
+test('legacy business-service endpoint hides rejected-live vendor', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user, {
+    isApproved: false,
+    isActive: true,
+    businessName: 'Rejected Live Service Vendor',
+  });
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const createRes = await agent.post('/api/service/').send({
+    title: 'Rejected Live Service',
+    description: 'Should stay hidden from legacy public lookup',
+    price: 45,
+    duration: '60',
+    services: [{ name: 'Basic Cut' }],
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: true,
+  });
+  assert.equal(createRes.status, 201);
+
+  const serviceId = String(createRes.body?.data?.service?._id);
+  assert.ok(serviceId);
+
+  const legacyDetail = await agent.get(`/api/service/business-service/${serviceId}`);
+  assert.equal(legacyDetail.status, 404);
+
+  const publicDetail = await agent.get(`/api/public/services/${serviceId}`);
+  assert.equal(publicDetail.status, 404);
+});
+
+test('legacy business-food endpoint hides rejected-live vendor', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    listingType: 'food',
+    isApproved: false,
+    isActive: true,
+    businessName: 'Rejected Live Food Vendor',
+  });
+
+  const category = await FoodCategory.create({
+    name: `Rejected Food Category ${Date.now()}`,
+  });
+  const subcategory = await FoodSubcategory.create({
+    name: `Rejected Food Subcategory ${Date.now()}`,
+    category: category._id,
+  });
+
+  const food = await Food.create({
+    title: 'Rejected Live Supper Club',
+    description: 'Should stay hidden from legacy public lookup',
+    price: 35,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    businessId: business._id,
+    ownerId: user._id,
+    isPublished: true,
+  });
+
+  const legacyDetail = await agent.get(`/api/food/business-food/${food._id}`);
+  assert.equal(legacyDetail.status, 404);
+
+  const publicDetail = await agent.get(`/api/public/foods/${food._id}`);
+  assert.equal(publicDetail.status, 404);
 });

--- a/tests/service/service-draft-lookup-contract.test.js
+++ b/tests/service/service-draft-lookup-contract.test.js
@@ -110,8 +110,14 @@ function loadController(options = {}) {
           if (query._id === businessId && query.owner === ownerId && authorized) {
             return makeQuery(business);
           }
-          if (query._id === businessId && query.isActive === true) {
-            return makeQuery(business);
+          if (
+            query._id === businessId &&
+            query.isActive === true &&
+            query.isApproved === true
+          ) {
+            return makeQuery(
+              business.isApproved === true && business.isActive === true ? business : null
+            );
           }
           return makeQuery(null);
         },
@@ -181,6 +187,19 @@ test('private business service lookup rejects unauthorized owner', async () => {
 test('public business-service lookup still hides unpublished parent service', async () => {
   const controller = loadController({
     service: buildService({ isPublished: false }),
+  });
+  const res = mockResponse();
+
+  await controller.getBusinessServiceById({ params: { id: businessId } }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.body.message, 'Business service not found.');
+});
+
+test('public business-service lookup hides published service for ineligible business', async () => {
+  const controller = loadController({
+    service: buildService({ isPublished: true }),
+    business: buildBusiness({ isApproved: false, isActive: true }),
   });
   const res = mockResponse();
 


### PR DESCRIPTION
## Summary
- Closes audit gaps in public marketplace vendor visibility by requiring both `isApproved` and `isActive` on legacy public service/food lookup endpoints.
- Ensures admin rejection also sets `isActive: false`, preventing previously-live rejected vendors from retaining stale active state.

## Changes
- `serviceController.getBusinessServiceById` — uses `publicMarketplaceBusinessFilter({ _id })`
- `foodController.getBusinessFoodById` — same dual-flag filter
- `vendorOnboardVerifyStage1.finalizeVerification` — rejection syncs `isActive: false`

## Impact
- No change for approved + active live vendors
- Rejected/pending/inactive vendors remain hidden from directory, search, and storefronts
- Rejected-live stale vendors are now blocked on legacy public endpoints too

## Test plan
- [x] `node --test tests/service/service-draft-lookup-contract.test.js`
- [x] `node --test tests/admin/vendor-onboarding-finalize.test.js`
- [x] `node --test tests/integration/marketplace.integration.test.js`
- [ ] CI passes on PR
- [ ] After merge to staging: verify rejected admin vendors (e.g. BKHarris, Locke Enterprise) do not appear in public marketplace


Made with [Cursor](https://cursor.com)