### PR TITLE
fix: vendor directory all listing types

### DIFF
--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -1,4 +1,6 @@
 const Business = require("../models/Business");
+const Service = require("../models/Service");
+const Food = require("../models/Food");
 const Subscription = require("../models/Subscription");
 const { uploadFile } = require("../utils/uploadFile");
 const cleanupUploads = require("../utils/cleanupUploads");
@@ -17,6 +19,12 @@ const { toPublicBusinessCard } = require("../lib/listing/publicListingDto");
 const {
   publicMarketplaceBusinessFilter,
 } = require("../lib/marketplace/businessEligibility");
+const {
+  resolveListingTypeFilter,
+  applyListingTypeCategoryFilter,
+  buildStorefrontPath,
+  mapFirstListingIdByBusiness,
+} = require("../lib/marketplace/vendorDirectoryQuery");
 const {
   attachListingSnapshotToBusiness,
   enrichBusinessesWithListingSnapshots,
@@ -863,7 +871,7 @@ exports.getProductBusinesses = async (req, res) => {
       city,
       state,
       country,
-      productCategory,
+      listingType,
       tag,
       tags,
       zip,
@@ -871,18 +879,21 @@ exports.getProductBusinesses = async (req, res) => {
       limit = 10,
     } = req.query;
 
+    const listingTypeFilter = resolveListingTypeFilter(listingType);
     const filters = publicMarketplaceBusinessFilter({
-      listingType: "product",
+      listingType: listingTypeFilter,
     });
 
     if (search) filters.businessName = { $regex: search, $options: "i" };
     if (city) filters["address.city"] = city;
     if (state) filters["address.state"] = state;
     if (country) filters["address.country"] = country;
-    if (productCategory) {
-      const categoryIds = productCategory.split(",");
-      filters.productCategories = { $in: categoryIds };
-    }
+
+    applyListingTypeCategoryFilter(
+      filters,
+      typeof listingTypeFilter === "string" ? listingTypeFilter : null,
+      req.query
+    );
 
     const tagList = String(tags || tag || "")
       .split(",")
@@ -910,24 +921,73 @@ exports.getProductBusinesses = async (req, res) => {
       );
     }
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limitNum = Math.max(1, Math.min(50, parseInt(limit, 10) || 10));
+    const skip = (pageNum - 1) * limitNum;
 
     const businesses = await Business.find(filters)
-      .select("businessName slug logo") // ✅ Only these fields
+      .select("businessName slug logo listingType")
       .skip(skip)
-      .limit(parseInt(limit))
-      .sort({ createdAt: -1 });
+      .limit(limitNum)
+      .sort({ createdAt: -1 })
+      .lean();
 
     const total = await Business.countDocuments(filters);
+
+    const serviceBusinessIds = businesses
+      .filter((business) => business.listingType === "service")
+      .map((business) => business._id);
+    const foodBusinessIds = businesses
+      .filter((business) => business.listingType === "food")
+      .map((business) => business._id);
+
+    const [serviceRows, foodRows] = await Promise.all([
+      serviceBusinessIds.length
+        ? Service.find({
+            businessId: { $in: serviceBusinessIds },
+            isPublished: true,
+          })
+            .select("_id businessId")
+            .sort({ createdAt: -1 })
+            .lean()
+        : [],
+      foodBusinessIds.length
+        ? Food.find({
+            businessId: { $in: foodBusinessIds },
+            isPublished: true,
+          })
+            .select("_id businessId")
+            .sort({ createdAt: -1 })
+            .lean()
+        : [],
+    ]);
+
+    const serviceListingByBusiness = mapFirstListingIdByBusiness(serviceRows);
+    const foodListingByBusiness = mapFirstListingIdByBusiness(foodRows);
 
     res.json({
       success: true,
       total,
-      page: parseInt(page),
-      totalPages: Math.ceil(total / limit),
-      data: businesses.map((business) =>
-        toPublicBusinessCard(business.toObject ? business.toObject() : business)
-      ),
+      page: pageNum,
+      totalPages: Math.ceil(total / limitNum) || 0,
+      data: businesses.map((business) => {
+        const businessId = String(business._id);
+        const listingId =
+          business.listingType === "service"
+            ? serviceListingByBusiness.get(businessId)
+            : business.listingType === "food"
+              ? foodListingByBusiness.get(businessId)
+              : businessId;
+        const card = toPublicBusinessCard(business);
+        const storefrontPath = buildStorefrontPath(
+          business.listingType,
+          businessId,
+          listingId
+        );
+        return storefrontPath
+          ? { ...card, storefrontPath }
+          : card;
+      }),
     });
   } catch (err) {
     console.error("Error fetching businesses:", err);

--- a/lib/marketplace/vendorDirectoryQuery.js
+++ b/lib/marketplace/vendorDirectoryQuery.js
@@ -1,0 +1,81 @@
+const mongoose = require('mongoose');
+
+const VALID_MARKETPLACE_LISTING_TYPES = Object.freeze(['product', 'service', 'food']);
+
+function parseObjectIdCsv(value = '') {
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => mongoose.Types.ObjectId.isValid(item))
+    .map((item) => new mongoose.Types.ObjectId(item));
+}
+
+function resolveListingTypeFilter(listingType) {
+  const normalized = String(listingType || '').trim().toLowerCase();
+  if (VALID_MARKETPLACE_LISTING_TYPES.includes(normalized)) {
+    return normalized;
+  }
+  return { $in: [...VALID_MARKETPLACE_LISTING_TYPES] };
+}
+
+function applyListingTypeCategoryFilter(filters, listingType, query = {}) {
+  const {
+    productCategory,
+    serviceCategory,
+    foodCategory,
+  } = query;
+
+  const activeListingType =
+    typeof listingType === 'string' ? listingType : null;
+
+  if (activeListingType === 'product' || !activeListingType) {
+    const productCategoryIds = parseObjectIdCsv(productCategory);
+    if (productCategoryIds.length) {
+      filters.productCategories = { $in: productCategoryIds };
+    }
+  }
+
+  if (activeListingType === 'service' || !activeListingType) {
+    const serviceCategoryIds = parseObjectIdCsv(serviceCategory);
+    if (serviceCategoryIds.length) {
+      filters.serviceCategories = { $in: serviceCategoryIds };
+    }
+  }
+
+  if (activeListingType === 'food' || !activeListingType) {
+    const foodCategoryIds = parseObjectIdCsv(foodCategory);
+    if (foodCategoryIds.length) {
+      filters.foodCategories = { $in: foodCategoryIds };
+    }
+  }
+}
+
+function buildStorefrontPath(listingType, businessId, listingId) {
+  const businessKey = String(businessId);
+  if (listingType === 'service') {
+    return listingId ? `/vendor-profile/service-vendor/${listingId}` : null;
+  }
+  if (listingType === 'food') {
+    return listingId ? `/vendor-profile/food-vendor/${listingId}` : null;
+  }
+  return `/vendor-profile/product-vendor/${businessKey}`;
+}
+
+function mapFirstListingIdByBusiness(rows = []) {
+  const map = new Map();
+  for (const row of rows) {
+    const businessId = String(row.businessId?._id || row.businessId || '');
+    if (!businessId || map.has(businessId)) continue;
+    map.set(businessId, String(row._id));
+  }
+  return map;
+}
+
+module.exports = {
+  VALID_MARKETPLACE_LISTING_TYPES,
+  parseObjectIdCsv,
+  resolveListingTypeFilter,
+  applyListingTypeCategoryFilter,
+  buildStorefrontPath,
+  mapFirstListingIdByBusiness,
+};

--- a/tests/integration/marketplace.integration.test.js
+++ b/tests/integration/marketplace.integration.test.js
@@ -300,3 +300,43 @@ test('legacy business-food endpoint hides rejected-live vendor', async () => {
   const publicDetail = await agent.get(`/api/public/foods/${food._id}`);
   assert.equal(publicDetail.status, 404);
 });
+
+test('GET /api/business returns all approved marketplace listing types', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/business').query({ limit: 50 });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.success, true);
+  assert.ok(res.body.total >= 0);
+
+  const listingTypes = new Set(
+    (res.body.data || []).map((row) => row.listingType).filter(Boolean)
+  );
+  if (res.body.total > 0) {
+    assert.ok([...listingTypes].every((type) => ['product', 'service', 'food'].includes(type)));
+  }
+});
+
+test('GET /api/business listingType filter scopes results', async () => {
+  const agent = createAgent(getApp());
+  const allRes = await agent.get('/api/business').query({ limit: 50 });
+  const serviceRes = await agent.get('/api/business').query({ listingType: 'service', limit: 50 });
+
+  assert.equal(allRes.status, 200);
+  assert.equal(serviceRes.status, 200);
+  assert.ok(serviceRes.body.total <= allRes.body.total);
+  assert.ok(
+    (serviceRes.body.data || []).every((row) => row.listingType === 'service')
+  );
+});
+
+test('GET /api/business ignores invalid productCategory labels without 500', async () => {
+  const agent = createAgent(getApp());
+  const res = await agent.get('/api/business').query({
+    productCategory: 'Fashion',
+    limit: 10,
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.success, true);
+  assert.ok(Array.isArray(res.body.data));
+});

--- a/tests/marketplace/vendor-directory-query.test.js
+++ b/tests/marketplace/vendor-directory-query.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  parseObjectIdCsv,
+  resolveListingTypeFilter,
+  applyListingTypeCategoryFilter,
+  buildStorefrontPath,
+  mapFirstListingIdByBusiness,
+} = require('../../lib/marketplace/vendorDirectoryQuery');
+
+test('resolveListingTypeFilter returns all marketplace types by default', () => {
+  assert.deepEqual(resolveListingTypeFilter(), { $in: ['product', 'service', 'food'] });
+  assert.deepEqual(resolveListingTypeFilter('invalid'), { $in: ['product', 'service', 'food'] });
+});
+
+test('resolveListingTypeFilter accepts valid listing type', () => {
+  assert.equal(resolveListingTypeFilter('service'), 'service');
+  assert.equal(resolveListingTypeFilter('FOOD'), 'food');
+});
+
+test('parseObjectIdCsv ignores invalid category labels', () => {
+  const validId = new mongoose.Types.ObjectId().toString();
+  const parsed = parseObjectIdCsv(`Fashion,${validId},Electronics`);
+  assert.equal(parsed.length, 1);
+  assert.equal(String(parsed[0]), validId);
+});
+
+test('applyListingTypeCategoryFilter only applies valid object ids', () => {
+  const filters = {};
+  const validId = new mongoose.Types.ObjectId().toString();
+
+  applyListingTypeCategoryFilter(filters, 'product', {
+    productCategory: `Fashion,${validId}`,
+  });
+
+  assert.deepEqual(filters.productCategories.$in.map(String), [validId]);
+});
+
+test('buildStorefrontPath routes by listing type', () => {
+  assert.equal(
+    buildStorefrontPath('product', 'biz1', 'biz1'),
+    '/vendor-profile/product-vendor/biz1'
+  );
+  assert.equal(
+    buildStorefrontPath('service', 'biz1', 'svc1'),
+    '/vendor-profile/service-vendor/svc1'
+  );
+  assert.equal(buildStorefrontPath('service', 'biz1', null), null);
+  assert.equal(
+    buildStorefrontPath('food', 'biz1', 'food1'),
+    '/vendor-profile/food-vendor/food1'
+  );
+  assert.equal(buildStorefrontPath('food', 'biz1', null), null);
+});
+
+test('mapFirstListingIdByBusiness keeps first listing per business', () => {
+  const map = mapFirstListingIdByBusiness([
+    { _id: 'svc-a', businessId: 'biz-1' },
+    { _id: 'svc-b', businessId: 'biz-1' },
+    { _id: 'svc-c', businessId: 'biz-2' },
+  ]);
+
+  assert.equal(map.get('biz-1'), 'svc-a');
+  assert.equal(map.get('biz-2'), 'svc-c');
+});


### PR DESCRIPTION
## Summary
- Broadens `GET /api/business` to return approved live **product**, **service**, and **food** vendors instead of product-only results.
- Safely ignores invalid `productCategory` labels (e.g. `Fashion`) to prevent Mongoose cast errors and HTTP 500s.
- Adds `storefrontPath` on directory cards so service/food vendors link to the correct public storefront route.

## Security
- Keeps `publicMarketplaceBusinessFilter` (`isApproved: true` + `isActive: true`) unchanged — rejected/pending vendors remain hidden.

## Test plan
- [x] `node --test tests/marketplace/vendor-directory-query.test.js`
- [x] `node --test tests/integration/marketplace.integration.test.js`
- [ ] `GET /api/business` returns product + service + food vendors
- [ ] `GET /api/business?productCategory=Fashion` returns 200 (not 500)
- [ ] `GET /api/business?listingType=service` scopes to service vendors only
- [ ] CI passes

## Frontend pairing
Requires frontend PR on `fix/vendor-directory-listing-types` for listing-type dropdown + `storefrontPath` card links.


Made with [Cursor](https://cursor.com)