### PR TITLE
release: explicit listing pricing gate (staging → main)

### DIFF
--- a/controllers/foodController.js
+++ b/controllers/foodController.js
@@ -22,6 +22,9 @@ const {
   logUploadFailure,
 } = require('../utils/uploadDiagnostics');
 const { publicMarketplaceBusinessFilter } = require('../lib/marketplace/businessEligibility');
+const {
+  validateFoodPublishState,
+} = require('../lib/marketplace/listingPricePolicy');
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -108,10 +111,23 @@ exports.createFood = async (req, res) => {
       });
     }
 
+    const nextPublished = Boolean(isPublished);
+    const numericPrice = Number.isFinite(Number(price)) ? Number(price) : null;
+    const publishCheck = validateFoodPublishState({
+      food: { price: numericPrice },
+      isPublished: nextPublished,
+    });
+    if (!publishCheck.ok) {
+      return res.status(400).json({
+        error: publishCheck.message,
+        code: publishCheck.code,
+      });
+    }
+
     const food = new Food({
       title: title || 'Food',
       description: description || '',
-      price: Number.isFinite(Number(price)) ? Number(price) : 0,
+      price: numericPrice ?? 0,
       categoryId,
       subcategoryId,
       businessId,
@@ -131,7 +147,7 @@ exports.createFood = async (req, res) => {
       address: location.address || '',
     }
   : undefined,
-      isPublished: Boolean(isPublished),
+      isPublished: nextPublished,
       foodType: foodType || '',
       brand: brand || '',
     });
@@ -337,6 +353,17 @@ exports.updateFood = async (req, res) => {
 
     if (Array.isArray(food.images)) {
       food.images = food.images.filter(Boolean);
+    }
+
+    const publishCheck = validateFoodPublishState({
+      food: food.toObject(),
+      isPublished: food.isPublished,
+    });
+    if (!publishCheck.ok) {
+      return res.status(400).json({
+        message: publishCheck.message,
+        code: publishCheck.code,
+      });
     }
 
     await food.save();

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -30,6 +30,7 @@ const {
   logUploadConfigFailure,
   logUploadFailure,
 } = require('../utils/uploadDiagnostics');
+const { validateProductPublishState } = require('../lib/marketplace/listingPricePolicy');
 const { Decimal128 } = mongoose.Types;
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
@@ -352,6 +353,8 @@ exports.createProductWithVariants = async (req, res) => {
       });
     }
 
+    const willPublish = Boolean(isPublished);
+
     // Create Product
     const product = new Product({
       title,
@@ -367,7 +370,7 @@ exports.createProductWithVariants = async (req, res) => {
       galleryImages: galleryImages || [],
       metaFields: metaFields || [],
       discount: discount || null,
-      isPublished: isPublished || false,
+      isPublished: false,
     });
 
     await product.save();
@@ -420,9 +423,24 @@ for (const variant of variants) {
     stock: normalizedVariant.stock,
     shipping: normalizeVariantShipping(variant.shipping),
     images: variant.images || [],
-    isPublished: isPublished || false,
+    isPublished: willPublish,
   });
 }
+
+    if (willPublish) {
+      const publishCheck = validateProductPublishState({
+        product: {},
+        variants: variantDocs,
+        isPublished: true,
+      });
+      if (!publishCheck.ok) {
+        await Product.findByIdAndDelete(product._id);
+        return res.status(400).json({
+          error: publishCheck.message,
+          code: publishCheck.code,
+        });
+      }
+    }
 
 // const variantDocs = [];
 // const usedSkus = new Set();
@@ -493,6 +511,7 @@ const maxPrice = Math.max(...prices);
       await Product.findByIdAndUpdate(product._id, {
         price: Decimal128.fromString(minPrice.toString()),
         maxPrice: Decimal128.fromString(maxPrice.toString()),
+        isPublished: willPublish,
       });
 
     } catch (variantErr) {
@@ -862,7 +881,7 @@ exports.updateProduct = async (req, res) => {
     }
     product.metaFields = metaFields || product.metaFields;
     product.discount = discount || product.discount;
-    product.isPublished =
+    const nextPublished =
       isPublished !== undefined ? isPublished : product.isPublished;
 
     await product.save();
@@ -969,6 +988,22 @@ exports.updateProduct = async (req, res) => {
     // Recalculate product price based on min salePrice
     // -----------------------------
     const allVariants = await ProductVariant.find({ productId });
+
+    if (nextPublished) {
+      const publishCheck = validateProductPublishState({
+        product,
+        variants: allVariants,
+        isPublished: true,
+      });
+      if (!publishCheck.ok) {
+        return res.status(400).json({
+          error: publishCheck.message,
+          code: publishCheck.code,
+        });
+      }
+    }
+
+    product.isPublished = nextPublished;
 
     if (allVariants.length > 0) {
       const prices = allVariants.map(v => {
@@ -1353,12 +1388,54 @@ exports.updateVariant = async (req, res) => {
       variant.shipping = normalizeVariantShipping(shipping, variant.shipping);
     }
     if (images) variant.images = images;
+
+    const nextVariantPublished =
+      isPublished !== undefined ? isPublished : variant.isPublished;
+
+    if (nextVariantPublished) {
+      const candidateVariant = {
+        ...variant.toObject(),
+        price: normalizedVariant.hasPrice
+          ? toDecimal128(normalizedVariant.price)
+          : variant.price,
+        salePrice: normalizedVariant.hasSalePrice
+          ? (normalizedVariant.hasSalePrice ? toDecimal128(normalizedVariant.salePrice) : null)
+          : variant.salePrice,
+        isPublished: true,
+      };
+      const publishCheck = validateProductPublishState({
+        product,
+        variants: [candidateVariant],
+        isPublished: true,
+      });
+      if (!publishCheck.ok) {
+        return res.status(400).json({
+          error: publishCheck.message,
+          code: publishCheck.code,
+        });
+      }
+    }
+
     if (isPublished !== undefined) variant.isPublished = isPublished;
 
     await variant.save();
 
     // Auto-publish/unpublish product based on variants
     if (isPublished === true && !product.isPublished) {
+      const allVariants = await ProductVariant.find({ productId, isDeleted: false });
+      const publishCheck = validateProductPublishState({
+        product,
+        variants: allVariants,
+        isPublished: true,
+      });
+      if (!publishCheck.ok) {
+        variant.isPublished = false;
+        await variant.save();
+        return res.status(400).json({
+          error: publishCheck.message,
+          code: publishCheck.code,
+        });
+      }
       product.isPublished = true;
       await product.save();
     } else if (isPublished === false) {

--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -53,7 +53,7 @@ function normalizePrice(value) {
 }
 
 function normalizePriceLabel(price) {
-  if (price == null) return 'Contact for price';
+  if (price == null || !Number.isFinite(price) || price <= 0) return null;
   return `$${price.toFixed(2)}`;
 }
 

--- a/lib/marketplace/listingPricePolicy.js
+++ b/lib/marketplace/listingPricePolicy.js
@@ -1,0 +1,167 @@
+const LISTING_PRICE_REQUIRED_MESSAGE =
+  'A price greater than $0 is required before publishing this listing.';
+
+const LISTING_PRICE_REQUIRED_CODE = 'LISTING_PRICE_REQUIRED';
+
+function parseListingPrice(value) {
+  if (value == null || value === '') return null;
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'object' && value.$numberDecimal != null) {
+    const parsed = Number(value.$numberDecimal);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  if (typeof value === 'object' && value != null && typeof value.toString === 'function') {
+    const parsed = Number(value.toString());
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  const parsed = Number(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasPositiveListingPrice(value) {
+  const price = parseListingPrice(value);
+  return price !== null && price > 0;
+}
+
+function getVariantEffectivePrice(variant = {}) {
+  const salePrice = parseListingPrice(variant.salePrice);
+  if (salePrice !== null && salePrice > 0) return salePrice;
+
+  const price = parseListingPrice(variant.price);
+  if (price !== null && price > 0) return price;
+
+  return null;
+}
+
+function getServiceEffectivePrice(service = {}) {
+  const children = Array.isArray(service.services) ? service.services : [];
+  const childPrices = children
+    .map((child) => parseListingPrice(child?.price))
+    .filter((price) => price !== null && price > 0);
+
+  if (childPrices.length) {
+    return Math.min(...childPrices);
+  }
+
+  const parentPrice = parseListingPrice(service.price);
+  return parentPrice !== null && parentPrice > 0 ? parentPrice : null;
+}
+
+function productHasPublishablePrice(product = {}) {
+  const variants = Array.isArray(product.variants) ? product.variants : [];
+  const publishedVariants = variants.filter(
+    (variant) => variant?.isDeleted !== true && variant?.isPublished !== false
+  );
+
+  if (publishedVariants.length) {
+    return publishedVariants.some((variant) => getVariantEffectivePrice(variant) !== null);
+  }
+
+  return hasPositiveListingPrice(product.price);
+}
+
+function serviceHasPublishablePrice(service = {}) {
+  return getServiceEffectivePrice(service) !== null;
+}
+
+function foodHasPublishablePrice(food = {}) {
+  return hasPositiveListingPrice(food.price);
+}
+
+function validateProductPublishState({ product, variants, isPublished }) {
+  if (!isPublished) {
+    return { ok: true };
+  }
+
+  const candidate = {
+    ...product,
+    variants: Array.isArray(variants) ? variants : [],
+  };
+
+  if (!productHasPublishablePrice(candidate)) {
+    return {
+      ok: false,
+      code: LISTING_PRICE_REQUIRED_CODE,
+      message: LISTING_PRICE_REQUIRED_MESSAGE,
+    };
+  }
+
+  return { ok: true };
+}
+
+function validateServicePublishState({ service, isPublished }) {
+  if (!isPublished) {
+    return { ok: true };
+  }
+
+  if (!serviceHasPublishablePrice(service)) {
+    return {
+      ok: false,
+      code: LISTING_PRICE_REQUIRED_CODE,
+      message: LISTING_PRICE_REQUIRED_MESSAGE,
+    };
+  }
+
+  return { ok: true };
+}
+
+function validateFoodPublishState({ food, isPublished }) {
+  if (!isPublished) {
+    return { ok: true };
+  }
+
+  if (!foodHasPublishablePrice(food)) {
+    return {
+      ok: false,
+      code: LISTING_PRICE_REQUIRED_CODE,
+      message: LISTING_PRICE_REQUIRED_MESSAGE,
+    };
+  }
+
+  return { ok: true };
+}
+
+function filterPublishableListings(listingType, listings = []) {
+  const type = String(listingType || '').trim().toLowerCase();
+
+  if (type === 'product') {
+    return listings.filter((product) => productHasPublishablePrice(product));
+  }
+
+  if (type === 'service') {
+    return listings.filter(
+      (service) =>
+        Array.isArray(service.services) &&
+        service.services.length > 0 &&
+        serviceHasPublishablePrice(service)
+    );
+  }
+
+  if (type === 'food') {
+    return listings.filter((food) => foodHasPublishablePrice(food));
+  }
+
+  return [];
+}
+
+module.exports = {
+  LISTING_PRICE_REQUIRED_MESSAGE,
+  LISTING_PRICE_REQUIRED_CODE,
+  parseListingPrice,
+  hasPositiveListingPrice,
+  getVariantEffectivePrice,
+  getServiceEffectivePrice,
+  productHasPublishablePrice,
+  serviceHasPublishablePrice,
+  foodHasPublishablePrice,
+  validateProductPublishState,
+  validateServicePublishState,
+  validateFoodPublishState,
+  filterPublishableListings,
+};

--- a/lib/service/serviceContract.js
+++ b/lib/service/serviceContract.js
@@ -261,7 +261,11 @@ const validateChildServices = (children = []) => {
     }
 
     if (item.price === null || item.price === undefined) {
-      fieldErrors[`services[${index}].price`] = 'Child service price is required and must be a number >= 0.';
+      fieldErrors[`services[${index}].price`] =
+        'Child service price is required and must be a number greater than 0.';
+    } else if (!Number.isFinite(Number(item.price)) || Number(item.price) <= 0) {
+      fieldErrors[`services[${index}].price`] =
+        'Child service price is required and must be a number greater than 0.';
     }
 
     if (!item.durationMinutes) {

--- a/scripts/smoke-test-listing-price-live.js
+++ b/scripts/smoke-test-listing-price-live.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Live smoke test against running backend (default http://localhost:3001).
+ * Uses session-only env credentials — never logs secrets.
+ */
+
+require('dotenv').config();
+
+const BASE_URL = process.env.SMOKE_TEST_API_BASE_URL || 'http://localhost:3001';
+const EMAIL =
+  process.env.MBH_TEST_VENDOR_EMAIL ||
+  process.env.SMOKE_TEST_VENDOR_EMAIL;
+const PASSWORD =
+  process.env.MBH_TEST_VENDOR_PASSWORD ||
+  process.env.SMOKE_TEST_VENDOR_PASSWORD;
+
+function assertCondition(label, ok, details = '') {
+  const status = ok ? 'PASS' : 'FAIL';
+  console.log(`[${status}] ${label}${details ? ` — ${details}` : ''}`);
+  if (!ok) process.exitCode = 1;
+}
+
+async function parseJson(res) {
+  const text = await res.text();
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return { raw: text };
+  }
+}
+
+function getCookieHeader(setCookie) {
+  if (!setCookie) return '';
+  const headers = Array.isArray(setCookie) ? setCookie : [setCookie];
+  return headers.map((entry) => entry.split(';')[0]).join('; ');
+}
+
+async function login() {
+  const res = await fetch(`${BASE_URL}/api/users/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD }),
+  });
+  const body = await parseJson(res);
+  return {
+    ok: res.status === 200,
+    status: res.status,
+    body,
+    cookie: getCookieHeader(res.headers.getSetCookie?.() || res.headers.raw?.()['set-cookie']),
+  };
+}
+
+async function authedFetch(path, { method = 'GET', cookie, body } = {}) {
+  const headers = { cookie };
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  return { status: res.status, body: await parseJson(res) };
+}
+
+async function main() {
+  if (!EMAIL || !PASSWORD) {
+    console.error('Missing MBH_TEST_VENDOR_EMAIL/PASSWORD or SMOKE_TEST_VENDOR_* env vars.');
+    process.exit(1);
+  }
+
+  console.log(`Live listing-price smoke against ${BASE_URL}`);
+
+  const session = await login();
+  assertCondition('Vendor login', session.ok, `status=${session.status}`);
+  if (!session.ok) return;
+
+  const myBusinesses = await authedFetch('/api/business/my', { cookie: session.cookie });
+  assertCondition('Load vendor businesses', myBusinesses.status === 200);
+  const foodBusiness = (myBusinesses.body?.businesses || []).find(
+    (item) => item.listingType === 'food'
+  );
+
+  if (!foodBusiness) {
+    console.log('[SKIP] No food vendor business on this account — food-specific live checks skipped.');
+  } else {
+    const foodsRes = await authedFetch('/api/food/my-foods', { cookie: session.cookie });
+    assertCondition('Load vendor foods', foodsRes.status === 200);
+
+    const categoryId = foodBusiness.categoryId || foodBusiness.categories?.[0]?.categoryId;
+    const subcategoryId = foodBusiness.subcategoryId || foodBusiness.categories?.[0]?.subcategoryIds?.[0];
+
+    const zeroPublishAttempt = await authedFetch('/api/food/add-food', {
+      method: 'POST',
+      cookie: session.cookie,
+      body: {
+        title: `Smoke Zero Price ${Date.now()}`,
+        description: 'Should be rejected at publish',
+        price: 0,
+        businessId: foodBusiness._id,
+        categoryId,
+        subcategoryId,
+        isPublished: true,
+      },
+    });
+    assertCondition(
+      'Block publish on zero-price food create',
+      zeroPublishAttempt.status === 400 &&
+        zeroPublishAttempt.body?.code === 'LISTING_PRICE_REQUIRED',
+      `status=${zeroPublishAttempt.status} code=${zeroPublishAttempt.body?.code || 'n/a'}`
+    );
+
+    const draftSave = await authedFetch('/api/food/add-food', {
+      method: 'POST',
+      cookie: session.cookie,
+      body: {
+        title: `Smoke Draft Zero ${Date.now()}`,
+        description: 'Draft save should work',
+        price: 0,
+        businessId: foodBusiness._id,
+        categoryId,
+        subcategoryId,
+        isPublished: false,
+      },
+    });
+    assertCondition(
+      'Allow draft save with zero price',
+      draftSave.status === 201 && draftSave.body?.food?.isPublished === false,
+      `status=${draftSave.status}`
+    );
+
+    if (draftSave.body?.food?._id) {
+      const blockedPublishUpdate = await authedFetch(
+        `/api/food/update-food/${draftSave.body.food._id}`,
+        {
+          method: 'PUT',
+          cookie: session.cookie,
+          body: { isPublished: true, price: 0 },
+        }
+      );
+      assertCondition(
+        'Block publish on zero-price food update',
+        blockedPublishUpdate.status === 400 &&
+          blockedPublishUpdate.body?.code === 'LISTING_PRICE_REQUIRED',
+        `status=${blockedPublishUpdate.status} code=${blockedPublishUpdate.body?.code || 'n/a'}`
+      );
+
+      const allowedPublishUpdate = await authedFetch(
+        `/api/food/update-food/${draftSave.body.food._id}`,
+        {
+          method: 'PUT',
+          cookie: session.cookie,
+          body: { isPublished: true, price: 12.99 },
+        }
+      );
+      assertCondition(
+        'Allow publish when price is positive',
+        allowedPublishUpdate.status === 200 &&
+          allowedPublishUpdate.body?.food?.isPublished === true &&
+          Number(allowedPublishUpdate.body?.food?.price) > 0,
+        `status=${allowedPublishUpdate.status}`
+      );
+    }
+
+    const zeroOnlyListing = (foodsRes.body?.foods || []).find(
+      (food) => Number(food.price) <= 0 && food.isPublished === true
+    );
+    if (zeroOnlyListing) {
+      const publicFood = await fetch(`${BASE_URL}/api/public/foods/${zeroOnlyListing._id}`);
+      const publicBody = await parseJson(publicFood);
+      assertCondition(
+        'Public food DTO avoids Contact-for-price label on zero/missing price',
+        publicFood.status === 200 &&
+          publicBody?.data?.priceLabel == null &&
+          publicBody?.data?.displayPrice == null,
+        `status=${publicFood.status} priceLabel=${publicBody?.data?.priceLabel}`
+      );
+    } else {
+      console.log('[INFO] No currently published zero-price food found on this account.');
+    }
+  }
+
+  if (process.exitCode) {
+    console.log('\nLive smoke finished with failures.');
+  } else {
+    console.log('\nLive smoke finished successfully.');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/unpublish-unpriced-listings.js
+++ b/scripts/unpublish-unpriced-listings.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * One-time cleanup: unpublish live listings with missing or zero effective price.
+ *
+ * Usage:
+ *   node scripts/unpublish-unpriced-listings.js --dry-run
+ *   node scripts/unpublish-unpriced-listings.js --apply
+ */
+
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const Product = require('../models/Product');
+const ProductVariant = require('../models/ProductVariant');
+const Service = require('../models/Service');
+const Food = require('../models/Food');
+const {
+  productHasPublishablePrice,
+  serviceHasPublishablePrice,
+  foodHasPublishablePrice,
+} = require('../lib/marketplace/listingPricePolicy');
+
+const mode = process.argv.includes('--apply') ? 'apply' : 'dry-run';
+
+async function main() {
+  await mongoose.connect(process.env.MONGODB_URI);
+
+  const [products, services, foods, variants] = await Promise.all([
+    Product.find({ isPublished: true, isDeleted: { $ne: true } }).lean(),
+    Service.find({ isPublished: true }).lean(),
+    Food.find({ isPublished: true }).lean(),
+    ProductVariant.find({ isDeleted: { $ne: true } }).select('productId price salePrice isPublished isDeleted').lean(),
+  ]);
+
+  const variantsByProduct = new Map();
+  for (const variant of variants) {
+    const productId = String(variant.productId);
+    if (!variantsByProduct.has(productId)) variantsByProduct.set(productId, []);
+    variantsByProduct.get(productId).push(variant);
+  }
+
+  const badProducts = products.filter((product) =>
+    !productHasPublishablePrice({
+      ...product,
+      variants: variantsByProduct.get(String(product._id)) || [],
+    })
+  );
+  const badServices = services.filter((service) => !serviceHasPublishablePrice(service));
+  const badFoods = foods.filter((food) => !foodHasPublishablePrice(food));
+
+  const summary = {
+    mode,
+    badProducts: badProducts.map((item) => ({ id: String(item._id), title: item.title })),
+    badServices: badServices.map((item) => ({ id: String(item._id), title: item.title })),
+    badFoods: badFoods.map((item) => ({ id: String(item._id), title: item.title })),
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (mode !== 'apply') {
+    console.log('Dry run only. Re-run with --apply to unpublish these listings.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  const [productResult, serviceResult, foodResult] = await Promise.all([
+    badProducts.length
+      ? Product.updateMany(
+          { _id: { $in: badProducts.map((item) => item._id) } },
+          { $set: { isPublished: false } }
+        )
+      : { modifiedCount: 0 },
+    badServices.length
+      ? Service.updateMany(
+          { _id: { $in: badServices.map((item) => item._id) } },
+          { $set: { isPublished: false } }
+        )
+      : { modifiedCount: 0 },
+    badFoods.length
+      ? Food.updateMany(
+          { _id: { $in: badFoods.map((item) => item._id) } },
+          { $set: { isPublished: false } }
+        )
+      : { modifiedCount: 0 },
+  ]);
+
+  console.log(
+    JSON.stringify(
+      {
+        applied: true,
+        modifiedProducts: productResult.modifiedCount || 0,
+        modifiedServices: serviceResult.modifiedCount || 0,
+        modifiedFoods: foodResult.modifiedCount || 0,
+      },
+      null,
+      2
+    )
+  );
+
+  await mongoose.disconnect();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/integration/listing-price-publish.integration.test.js
+++ b/tests/integration/listing-price-publish.integration.test.js
@@ -1,0 +1,249 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const mongoose = require('mongoose');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedApprovedBusiness,
+  seedServiceBusiness,
+  seedServiceCategories,
+  seedVendorOnboarding,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const Food = require('../../models/Food');
+const FoodCategory = require('../../models/FoodCategory');
+const FoodSubcategory = require('../../models/FoodSubcategory');
+const Product = require('../../models/Product');
+const ProductVariant = require('../../models/ProductVariant');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+async function setupFoodVendor(agent) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, { listingType: 'food' });
+  const category = await FoodCategory.create({
+    name: `Price Gate Food Category ${Date.now()}`,
+  });
+  const subcategory = await FoodSubcategory.create({
+    name: `Price Gate Food Subcategory ${Date.now()}`,
+    category: category._id,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  return { vendor, user, business, category, subcategory };
+}
+
+async function setupServiceVendor(agent) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user);
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  return { vendor, user, business, category, subcategory };
+}
+
+test('POST /api/food/add-food blocks publish when price is zero', async () => {
+  const agent = createAgent(getApp());
+  const { business, category, subcategory } = await setupFoodVendor(agent);
+
+  const res = await agent.post('/api/food/add-food').send({
+    title: 'Zero Price Supper',
+    description: 'Should stay draft-only',
+    price: 0,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: true,
+  });
+
+  assert.equal(res.status, 400, JSON.stringify(res.body));
+  assert.equal(res.body.code, 'LISTING_PRICE_REQUIRED');
+});
+
+test('POST /api/food/add-food allows draft save with zero price', async () => {
+  const agent = createAgent(getApp());
+  const { business, category, subcategory } = await setupFoodVendor(agent);
+
+  const res = await agent.post('/api/food/add-food').send({
+    title: 'Draft Zero Price Supper',
+    description: 'Draft is allowed without price',
+    price: 0,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: false,
+  });
+
+  assert.equal(res.status, 201, JSON.stringify(res.body));
+  assert.equal(res.body.food.isPublished, false);
+});
+
+test('POST /api/food/add-food allows publish when price is positive', async () => {
+  const agent = createAgent(getApp());
+  const { business, category, subcategory } = await setupFoodVendor(agent);
+
+  const res = await agent.post('/api/food/add-food').send({
+    title: 'Priced Supper',
+    description: 'Should publish',
+    price: 24.5,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: true,
+  });
+
+  assert.equal(res.status, 201, JSON.stringify(res.body));
+  assert.equal(res.body.food.isPublished, true);
+  assert.equal(res.body.food.price, 24.5);
+});
+
+test('PUT /api/food/update-food/:id blocks publish when price is zero', async () => {
+  const agent = createAgent(getApp());
+  const { user, business, category, subcategory } = await setupFoodVendor(agent);
+
+  const food = await Food.create({
+    title: 'Draft Food',
+    description: 'Will try to publish at zero price',
+    price: 0,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    businessId: business._id,
+    ownerId: user._id,
+    isPublished: false,
+  });
+
+  const res = await agent.put(`/api/food/update-food/${food._id}`).send({
+    isPublished: true,
+    price: 0,
+  });
+
+  assert.equal(res.status, 400, JSON.stringify(res.body));
+  assert.equal(res.body.code, 'LISTING_PRICE_REQUIRED');
+});
+
+test('POST /api/service blocks publish when child service price is zero', async () => {
+  const agent = createAgent(getApp());
+  const { business, category, subcategory } = await setupServiceVendor(agent);
+
+  const res = await agent.post('/api/service/').send({
+    title: 'Zero Price Salon',
+    description: 'Should not publish',
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: true,
+    services: [{ name: 'Basic Cut', price: 0, durationMinutes: 60 }],
+  });
+
+  assert.equal(res.status, 400, JSON.stringify(res.body));
+  assert.ok(res.body.fieldErrors?.['services[0].price'] || res.body.fieldErrors?.isPublished);
+});
+
+test('POST /api/business/:id/publish-storefront blocks food vendor with only zero-price listing', async () => {
+  const agent = createAgent(getApp());
+  const { user, business, category, subcategory } = await setupFoodVendor(agent);
+
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+
+  await Food.create({
+    title: 'Unpriced Food Listing',
+    description: 'Exists but cannot satisfy publish readiness',
+    price: 0,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    businessId: business._id,
+    ownerId: user._id,
+    isPublished: false,
+  });
+
+  const readinessRes = await agent.get('/api/business/my');
+  assert.equal(readinessRes.status, 200, JSON.stringify(readinessRes.body));
+  const returnedBusiness = readinessRes.body.businesses.find(
+    (item) => String(item._id) === String(business._id)
+  );
+  assert.ok(returnedBusiness);
+  assert.ok(
+    returnedBusiness.onboardingReadiness.blockers.some(
+      (blocker) => blocker.code === 'LISTING_PRICE_REQUIRED'
+    )
+  );
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 409, JSON.stringify(publishRes.body));
+  assert.ok(
+    (publishRes.body.blockers || []).some((blocker) => blocker.code === 'LISTING_PRICE_REQUIRED')
+  );
+});
+
+test('POST /api/business/:id/publish-storefront succeeds for product vendor with priced variant', async () => {
+  const agent = createAgent(getApp());
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedApprovedBusiness(user, {
+    listingType: 'product',
+    chargesEnabled: true,
+    payoutsEnabled: true,
+  });
+  await seedVendorOnboarding(user, {
+    businessId: business._id,
+    status: 'verified',
+  });
+
+  const product = await Product.create({
+    title: 'Priced Product',
+    description: 'Ready for storefront publish',
+    categoryId: new mongoose.Types.ObjectId(),
+    subcategoryId: new mongoose.Types.ObjectId(),
+    ownerId: user._id,
+    businessId: business._id,
+    coverImage: 'https://example.test/priced-product.png',
+    isPublished: false,
+    isDeleted: false,
+    price: 30,
+  });
+
+  await ProductVariant.create({
+    productId: product._id,
+    businessId: business._id,
+    ownerId: user._id,
+    attributes: { size: 'standard' },
+    sku: `PRICE-GATE-${Date.now()}`,
+    price: 30,
+    stock: 3,
+    images: ['https://example.test/priced-product.png'],
+    isPublished: false,
+    isDeleted: false,
+  });
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const publishRes = await agent.post(`/api/business/${business._id}/publish-storefront`);
+  assert.equal(publishRes.status, 200, JSON.stringify(publishRes.body));
+});

--- a/tests/marketplace/featured-products-response.test.js
+++ b/tests/marketplace/featured-products-response.test.js
@@ -146,7 +146,7 @@ test('getFeaturedProducts preserves products and pagination wrapper', async () =
   assert.equal(res.body.pagination.totalProducts, 5);
   assert.equal(res.body.pagination.totalPages, 3);
   assert.equal(res.body.products[0].price, null);
-  assert.equal(res.body.products[0].priceLabel, 'Contact for price');
+  assert.equal(res.body.products[0].priceLabel, null);
 });
 
 test('getFeaturedProducts scopes query to approved active businesses', async () => {

--- a/tests/marketplace/listing-price-policy.test.js
+++ b/tests/marketplace/listing-price-policy.test.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  parseListingPrice,
+  hasPositiveListingPrice,
+  productHasPublishablePrice,
+  serviceHasPublishablePrice,
+  foodHasPublishablePrice,
+  validateProductPublishState,
+  validateServicePublishState,
+  validateFoodPublishState,
+  filterPublishableListings,
+  LISTING_PRICE_REQUIRED_CODE,
+} = require('../../lib/marketplace/listingPricePolicy');
+
+test('parseListingPrice handles Decimal128-like objects', () => {
+  assert.equal(parseListingPrice({ toString: () => '24.50' }), 24.5);
+});
+
+test('hasPositiveListingPrice rejects zero and missing values', () => {
+  assert.equal(hasPositiveListingPrice(null), false);
+  assert.equal(hasPositiveListingPrice(0), false);
+  assert.equal(hasPositiveListingPrice(12.5), true);
+});
+
+test('productHasPublishablePrice requires a positive variant price when publishing', () => {
+  assert.equal(
+    productHasPublishablePrice({
+      variants: [{ price: 0, isPublished: true }],
+    }),
+    false
+  );
+  assert.equal(
+    productHasPublishablePrice({
+      variants: [{ price: 19.99, isPublished: true }],
+    }),
+    true
+  );
+});
+
+test('serviceHasPublishablePrice uses minimum positive child price', () => {
+  assert.equal(
+    serviceHasPublishablePrice({
+      services: [{ name: 'Cut', price: 0, durationMinutes: 30 }],
+    }),
+    false
+  );
+  assert.equal(
+    serviceHasPublishablePrice({
+      services: [{ name: 'Cut', price: 25, durationMinutes: 30 }],
+    }),
+    true
+  );
+});
+
+test('foodHasPublishablePrice requires price greater than zero', () => {
+  assert.equal(foodHasPublishablePrice({ price: 0 }), false);
+  assert.equal(foodHasPublishablePrice({ price: 8 }), true);
+});
+
+test('validate publish helpers return LISTING_PRICE_REQUIRED when price is missing', () => {
+  const productResult = validateProductPublishState({
+    product: {},
+    variants: [{ price: 0, isPublished: true }],
+    isPublished: true,
+  });
+  assert.equal(productResult.ok, false);
+  assert.equal(productResult.code, LISTING_PRICE_REQUIRED_CODE);
+
+  const serviceResult = validateServicePublishState({
+    service: { services: [{ name: 'Cut', price: 0, durationMinutes: 30 }] },
+    isPublished: true,
+  });
+  assert.equal(serviceResult.ok, false);
+  assert.equal(serviceResult.code, LISTING_PRICE_REQUIRED_CODE);
+
+  const foodResult = validateFoodPublishState({
+    food: { price: 0 },
+    isPublished: true,
+  });
+  assert.equal(foodResult.ok, false);
+  assert.equal(foodResult.code, LISTING_PRICE_REQUIRED_CODE);
+});
+
+test('filterPublishableListings keeps only priced listings per type', () => {
+  const products = filterPublishableListings('product', [
+    { price: 0, variants: [] },
+    { variants: [{ price: 12, isPublished: true }] },
+  ]);
+  assert.equal(products.length, 1);
+
+  const services = filterPublishableListings('service', [
+    { services: [{ name: 'A', price: 0, durationMinutes: 30 }] },
+    { services: [{ name: 'B', price: 40, durationMinutes: 60 }] },
+  ]);
+  assert.equal(services.length, 1);
+
+  const foods = filterPublishableListings('food', [
+    { price: 0 },
+    { price: 15 },
+  ]);
+  assert.equal(foods.length, 1);
+});

--- a/tests/marketplace/public-listing-dto.test.js
+++ b/tests/marketplace/public-listing-dto.test.js
@@ -59,7 +59,7 @@ test('toPublicListingCard handles missing price with safe priceLabel', () => {
     { listingType: 'product' }
   );
   assert.equal(card.price, null);
-  assert.equal(card.priceLabel, 'Contact for price');
+  assert.equal(card.priceLabel, null);
   assert.equal(card.listingType, 'product');
   assert.equal(card.id, '507f1f77bcf86cd799439011');
   assert.deepEqual(card.tags, []);
@@ -300,7 +300,7 @@ test('displayPrice mirrors priceLabel on listing cards', () => {
     { _id: '507f1f77bcf86cd799439011', title: 'Free quote' },
     { listingType: 'service' }
   );
-  assert.equal(noPrice.displayPrice, 'Contact for price');
+  assert.equal(noPrice.displayPrice, null);
 });
 
 test('vendorLogo comes from populated businessId without inventing values', () => {

--- a/tests/marketplace/stripe-connect-payout-policy.test.js
+++ b/tests/marketplace/stripe-connect-payout-policy.test.js
@@ -25,7 +25,11 @@ function activeApprovedBusiness(overrides = {}) {
 function listingSnapshotForType(listingType) {
   if (listingType === 'product') {
     return {
-      products: [{ _id: 'prod-1', isPublished: false, variants: [] }],
+      products: [{
+        _id: 'prod-1',
+        isPublished: false,
+        variants: [{ price: 25, isPublished: false }],
+      }],
       services: [],
       foods: [],
     };
@@ -44,7 +48,7 @@ function listingSnapshotForType(listingType) {
   return {
     products: [],
     services: [],
-    foods: [{ _id: 'food-1', isPublished: false }],
+    foods: [{ _id: 'food-1', isPublished: false, price: 12 }],
   };
 }
 
@@ -93,4 +97,18 @@ test('food vendor can publish without Connect or payout flags', () => {
   });
 
   assert.equal(blockers.length, 0);
+});
+
+test('buildPublicationBlockers surfaces LISTING_PRICE_REQUIRED when listings exist without price', () => {
+  const blockers = buildPublicationBlockers({
+    business: activeApprovedBusiness({ listingType: 'food' }),
+    onboarding: verifiedOnboarding(),
+    snapshot: {
+      products: [],
+      services: [],
+      foods: [{ _id: 'food-1', isPublished: false, price: 0 }],
+    },
+  });
+
+  assert.ok(blockers.some((blocker) => blocker.code === 'LISTING_PRICE_REQUIRED'));
 });

--- a/tests/service/service-payload-contract.test.js
+++ b/tests/service/service-payload-contract.test.js
@@ -16,6 +16,15 @@ const {
   formatOwnerServiceResponse,
 } = require('../../lib/service/serviceContract');
 
+test('validateChildServices rejects zero child price with field key', () => {
+  const result = validateChildServices([
+    { name: 'Basic Cut', price: 0, durationMinutes: 60 },
+  ]);
+
+  assert.equal(result.ok, false);
+  assert.ok(result.fieldErrors['services[0].price']);
+});
+
 test('validateChildServices rejects missing child price with field key', () => {
   const result = validateChildServices([
     { name: 'Basic Cut', durationMinutes: 60 },

--- a/utils/businessListingVisibility.js
+++ b/utils/businessListingVisibility.js
@@ -6,6 +6,11 @@ const VendorOnboardingStage1 = require('../models/VendorOnboardingStage1');
 const {
   isPublicMarketplaceBusiness,
 } = require('../lib/marketplace/businessEligibility');
+const {
+  filterPublishableListings,
+  LISTING_PRICE_REQUIRED_CODE,
+  LISTING_PRICE_REQUIRED_MESSAGE,
+} = require('../lib/marketplace/listingPricePolicy');
 
 const LISTING_TYPES = new Set(['product', 'service', 'food']);
 // Approved 2026-07-07 (#218): Connect/payout setup required only for product vendors
@@ -127,12 +132,15 @@ function summarizeCounts(snapshot) {
 
 function getEligibleListingsForBusiness(business, snapshot) {
   const listingType = String(business?.listingType || '').trim().toLowerCase();
+  let candidateListings = [];
 
   if (listingType === 'product') {
+    candidateListings = snapshot.products || [];
     return {
       type: listingType,
-      listings: snapshot.products || [],
-      variantIds: (snapshot.products || [])
+      listings: filterPublishableListings(listingType, candidateListings),
+      allListings: candidateListings,
+      variantIds: candidateListings
         .flatMap((product) => product.variants || [])
         .map((variant) => variant._id)
         .filter(Boolean),
@@ -140,22 +148,26 @@ function getEligibleListingsForBusiness(business, snapshot) {
   }
 
   if (listingType === 'service') {
+    candidateListings = (snapshot.services || []).filter((service) => (
+      Array.isArray(service.services) && service.services.length > 0
+    ));
     return {
       type: listingType,
-      listings: (snapshot.services || []).filter((service) => (
-        Array.isArray(service.services) && service.services.length > 0
-      )),
+      listings: filterPublishableListings(listingType, candidateListings),
+      allListings: candidateListings,
     };
   }
 
   if (listingType === 'food') {
+    candidateListings = snapshot.foods || [];
     return {
       type: listingType,
-      listings: snapshot.foods || [],
+      listings: filterPublishableListings(listingType, candidateListings),
+      allListings: candidateListings,
     };
   }
 
-  return { type: listingType, listings: [] };
+  return { type: listingType, listings: [], allListings: [] };
 }
 
 function countRequiredListings(eligible) {
@@ -206,16 +218,16 @@ async function loadListingSnapshotsByBusinessIds(businessIds = []) {
 
   const [products, services, foods, variants] = await Promise.all([
     Product.find({ businessId: { $in: ids }, isDeleted: false })
-      .select('_id title slug businessId ownerId coverImage isPublished isDeleted createdAt updatedAt')
+      .select('_id title slug businessId ownerId coverImage price isPublished isDeleted createdAt updatedAt')
       .lean(),
     Service.find({ businessId: { $in: ids } })
-      .select('_id title slug businessId ownerId coverImage isPublished services createdAt updatedAt')
+      .select('_id title slug businessId ownerId coverImage price isPublished services createdAt updatedAt')
       .lean(),
     Food.find({ businessId: { $in: ids } })
-      .select('_id title slug businessId ownerId coverImage isPublished createdAt updatedAt')
+      .select('_id title slug businessId ownerId coverImage price isPublished createdAt updatedAt')
       .lean(),
     ProductVariant.find({ businessId: { $in: ids }, isDeleted: false })
-      .select('_id productId businessId ownerId sku stock isPublished isDeleted createdAt updatedAt')
+      .select('_id productId businessId ownerId sku stock price salePrice isPublished isDeleted createdAt updatedAt')
       .lean(),
   ]);
 
@@ -328,6 +340,11 @@ function buildPublicationBlockers({ business, onboarding, snapshot }) {
     blockers.push({
       code: 'LISTING_TYPE_REQUIRED',
       message: 'Choose a valid business listing type before publishing.',
+    });
+  } else if (eligible.allListings?.length > 0 && eligible.listings.length === 0) {
+    blockers.push({
+      code: LISTING_PRICE_REQUIRED_CODE,
+      message: LISTING_PRICE_REQUIRED_MESSAGE,
     });
   } else if (eligible.listings.length === 0) {
     blockers.push({


### PR DESCRIPTION
## Summary
- Promotes staging to production with **Option A explicit pricing**: listings cannot publish or go live without an effective price greater than $0.
- Adds publish gates for products, services, food, and business storefront readiness (`LISTING_PRICE_REQUIRED`).
- Includes one-time migration script to unpublish existing zero-price live listings.
- Removes `"Contact for price"` from public listing DTOs (missing/zero prices return `null` labels).

## Included merges
- #235 — `fix: require positive listing price before marketplace publish`

## Post-deploy (production DB)
Run after Elastic Beanstalk deploy completes:
```bash
node scripts/unpublish-unpriced-listings.js --dry-run
node scripts/unpublish-unpriced-listings.js --apply
```

## Test plan
- [ ] Merge → confirm GitHub Actions `Deploy to Elastic Beanstalk` succeeds on `main`
- [ ] `GET https://api.mosaicbizhub.com/api/products/list?limit=10` — no unpriced published cards in response
- [ ] Partner dashboard: publish with price `0` blocked; publish with price `> 0` succeeds
- [ ] Run production migration `--dry-run` then `--apply`
- [ ] `https://mosaicbizhub.com/products` — no "Price on request" cards for live listings

## Rollback
Revert this merge on `main` or redeploy prior known-good `main` SHA if regressions appear. Migration unpublish is non-destructive (sets `isPublished: false` only).


Made with [Cursor](https://cursor.com)