### PR TITLE
release: service taxonomy payload (staging → main)

### DIFF
--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -235,7 +235,11 @@ exports.getAllServices = async (req, res) => {
     const { page: pageN, limit: limitN, skip } = clipListPagination(page, limit);
 
     let services = await Service.find(filters)
-      .select('title services averageRating totalReviews slug description contact.address coverImage location price businessId')
+      .select(
+        'title services averageRating totalReviews slug description contact.address coverImage location price businessId categoryId subcategoryId features amenities'
+      )
+      .populate('categoryId', 'name slug')
+      .populate('subcategoryId', 'name slug')
       .sort(sortOption)
       .skip(skip)
       .limit(limitN)
@@ -250,7 +254,7 @@ exports.getAllServices = async (req, res) => {
     const serviceBusinesses = await Business.find(
       publicMarketplaceBusinessFilter({ _id: { $in: serviceBusinessIds } })
     )
-      .select('_id businessName description logo email phone address socialLinks badge')
+      .select('_id businessName description logo email phone address socialLinks badge tags')
       .lean();
 
     const vendorDetails = await VendorOnboardingStage1.find({ businessId: { $in: serviceBusinessIds } })
@@ -273,6 +277,7 @@ exports.getAllServices = async (req, res) => {
       return toPublicListingCard(
         {
           ...service,
+          tags: Array.isArray(businessInfo?.tags) ? businessInfo.tags : [],
           businessDetails: {
             businessName: businessInfo?.businessName || null,
             description: businessInfo?.description || null,
@@ -293,6 +298,7 @@ exports.getAllServices = async (req, res) => {
               designation: vendorInfo?.primaryContactDesignation || null,
             },
             badge: businessInfo?.badge || null,
+            tags: Array.isArray(businessInfo?.tags) ? businessInfo.tags : [],
           },
         },
         { listingType: 'service' }
@@ -365,8 +371,8 @@ exports.getServiceById = async (req, res) => {
     const { id } = req.params;
 
     const service = await Service.findById(id)
-      .populate('categoryId', 'name')
-      .populate('subcategoryId', 'name')
+      .populate('categoryId', 'name slug')
+      .populate('subcategoryId', 'name slug')
       .populate({
         path: 'businessId',
         select: `
@@ -381,6 +387,7 @@ exports.getServiceById = async (req, res) => {
           address
           socialLinks
           badge
+          tags
         `,
       });
 
@@ -436,6 +443,9 @@ exports.getServiceById = async (req, res) => {
     }
 
     const serviceData = service.toObject();
+    if (Array.isArray(business?.tags) && business.tags.length) {
+      serviceData.tags = business.tags;
+    }
     delete serviceData.businessId;
 
     res.status(200).json({

--- a/tests/marketplace/service-list-taxonomy.test.js
+++ b/tests/marketplace/service-list-taxonomy.test.js
@@ -1,0 +1,230 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(__dirname, '../../controllers/publicListing.js');
+const filtersPath = path.resolve(__dirname, '../../lib/listing/publicSearchFilters.js');
+
+const businessId = '507f1f77bcf86cd799439011';
+
+function mockResponse() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function buildServiceFindChain(rows) {
+  const chain = {
+    select() { return chain; },
+    populate() { return chain; },
+    sort() { return chain; },
+    skip() { return chain; },
+    limit() { return chain; },
+    lean() { return Promise.resolve(rows); },
+  };
+  return chain;
+}
+
+function loadController(serviceRows, businessRows) {
+  const captured = { serviceSelectCalls: 0, populateCalls: 0 };
+
+  const Service = {
+    find: () => {
+      const chain = buildServiceFindChain(serviceRows);
+      const originalSelect = chain.select;
+      chain.select = function select(...args) {
+        captured.serviceSelectCalls += 1;
+        captured.serviceSelect = args[0];
+        return originalSelect.apply(this, args);
+      };
+      const originalPopulate = chain.populate;
+      chain.populate = function populate(...args) {
+        captured.populateCalls += 1;
+        captured.populateArgs = captured.populateArgs || [];
+        captured.populateArgs.push(args);
+        return originalPopulate.apply(this, args);
+      };
+      return chain;
+    },
+    countDocuments: async () => serviceRows.length,
+    findOne: async () => null,
+    findById: () => ({
+      populate() {
+        return {
+          populate() {
+            return {
+              populate: async () => null,
+            };
+          },
+        };
+      },
+    }),
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).endsWith('models/Service')) return Service;
+    if (String(request).endsWith('models/Food')) {
+      return {
+        find: () => buildServiceFindChain([]),
+        countDocuments: async () => 0,
+      };
+    }
+    if (String(request).endsWith('models/Business')) {
+      return {
+        find: () => ({
+          select() {
+            return { lean: async () => businessRows };
+          },
+        }),
+        findOne: () => ({ select: () => ({ lean: async () => businessRows[0] || null }) }),
+      };
+    }
+    if (String(request).endsWith('models/VendorOnboardingStage1')) {
+      return { find: () => ({ select: () => ({ lean: async () => [] }) }) };
+    }
+    if (String(request).endsWith('models/Review')) return { find: () => ({ populate: async () => [] }) };
+    if (String(request).endsWith('models/ServiceCategory')) return { findOne: async () => null };
+    if (String(request).endsWith('models/ServiceSubcategory')) return { findOne: async () => null };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  delete require.cache[filtersPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+
+  return { controller, captured };
+}
+
+test('getAllServices returns populated category, subcategory, and business tags', async () => {
+  const serviceRows = [
+    {
+      _id: '507f1f77bcf86cd799439020',
+      title: 'Taxonomy Service',
+      description: 'Service with taxonomy',
+      businessId,
+      isPublished: true,
+      price: 45,
+      services: [{ name: 'Consultation', price: 45, durationMinutes: 60 }],
+      categoryId: {
+        _id: '507f1f77bcf86cd799439021',
+        name: 'Professional Services',
+        slug: 'professional-services',
+      },
+      subcategoryId: {
+        _id: '507f1f77bcf86cd799439022',
+        name: 'Business Consulting',
+        slug: 'business-consulting',
+      },
+      features: ['Online Booking'],
+    },
+  ];
+
+  const businessRows = [
+    {
+      _id: businessId,
+      businessName: 'Taxonomy Vendor',
+      badge: 'Silver',
+      isApproved: true,
+      isActive: true,
+      tags: ['Minority-Owned', 'Atlanta'],
+    },
+  ];
+
+  const { controller } = loadController(serviceRows, businessRows);
+  const res = mockResponse();
+
+  await controller.getAllServices({ query: { page: 1, limit: 10 } }, res);
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.length, 1);
+
+  const card = res.body.data[0];
+  assert.equal(card.category?.name, 'Professional Services');
+  assert.equal(card.subcategory?.name, 'Business Consulting');
+  assert.deepEqual(card.tags, ['Minority-Owned', 'Atlanta']);
+});
+
+test('getServiceById merges business tags into service detail payload', async () => {
+  const serviceDoc = {
+    _id: '507f1f77bcf86cd799439020',
+    title: 'Taxonomy Service',
+    description: 'Detail taxonomy',
+    isPublished: true,
+    price: 45,
+    services: [{ name: 'Consultation', price: 45, durationMinutes: 60 }],
+    categoryId: {
+      _id: '507f1f77bcf86cd799439021',
+      name: 'Professional Services',
+      slug: 'professional-services',
+    },
+    subcategoryId: {
+      _id: '507f1f77bcf86cd799439022',
+      name: 'Business Consulting',
+      slug: 'business-consulting',
+    },
+    businessId: {
+      _id: businessId,
+      businessName: 'Taxonomy Vendor',
+      badge: 'Silver',
+      tags: ['Minority-Owned', 'Atlanta'],
+      toObject() {
+        return { ...this };
+      },
+    },
+    toObject() {
+      return { ...this, businessId: this.businessId };
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).endsWith('models/Service')) {
+      return {
+        findById: () => ({
+          populate() {
+            return {
+              populate() {
+                return {
+                  populate: async () => serviceDoc,
+                };
+              },
+            };
+          },
+        }),
+      };
+    }
+    if (String(request).endsWith('models/Business')) {
+      return {
+        findOne: () => ({ select: () => ({ lean: async () => ({ _id: businessId }) }) }),
+      };
+    }
+    if (String(request).endsWith('models/VendorOnboardingStage1')) {
+      return { findOne: () => ({ select: () => ({ lean: async () => null }) }) };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+
+  const res = mockResponse();
+  await controller.getServiceById({ params: { id: '507f1f77bcf86cd799439020' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.service.category.name, 'Professional Services');
+  assert.equal(res.body.data.service.subcategory.name, 'Business Consulting');
+  assert.deepEqual(res.body.data.service.tags, ['Minority-Owned', 'Atlanta']);
+});


### PR DESCRIPTION
## Summary
- Promotes staging to production with service taxonomy API fixes (PR #237).
- `GET /api/services/list` now returns populated `category`, `subcategory`, and business `tags`.
- `GET /api/public/services/:id` merges business tags into detail payloads.

## Included merges
- #237 — `fix: return service taxonomy fields on public list and detail APIs`

## Test plan
- [ ] Merge → confirm `Deploy to Elastic Beanstalk` succeeds on `main`
- [ ] `GET https://api.mosaicbizhub.com/api/services/list?limit=5` — cards include `category.name` / `subcategory.name`
- [ ] `GET https://api.mosaicbizhub.com/api/public/services/:id` — taxonomy + tags present
- [ ] Pair with frontend release PR for full UI verification


Made with [Cursor](https://cursor.com)