### PR TITLE
fix: vendor alerts API and legacy shipping fallback for checkout

### DIFF
--- a/app.js
+++ b/app.js
@@ -218,6 +218,8 @@ app.use('/api/cart', cartRoutes);
 app.use('/api/payments', paymentRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api/bookings', bookingRoutes)
+const vendorAlertsRoutes = require('./routes/vendorAlertsRoutes');
+app.use('/api/vendor/alerts', vendorAlertsRoutes);
 app.use('/api/connect', connectRoutes);
 
 

--- a/controllers/bookingController.js
+++ b/controllers/bookingController.js
@@ -5,10 +5,14 @@ const Business = require('../models/Business');
 const User = require('../models/User');
 const {
   sendVendorNewServiceBookingEmail,
+  sendVendorNewFoodBookingEmail,
   sendCustomerNewServiceBookingConfirmationEmail,
   sendCustomerServicePaymentRequestEmail,
   sendCustomerServiceBookingDecisionEmail,
 } = require('../utils/bookingMailer');
+const {
+  resolveVendorNotificationRecipients,
+} = require('../utils/notificationPreferenceGate');
 
 const ALLOWED_SEAT_OPTIONS = ['upto 2', 'upto 4', 'upto 8', 'more than 10'];
 
@@ -46,8 +50,12 @@ const formatBookingDate = (value) => {
   });
 };
 
-const getVendorRecipients = (business, owner) => {
-  return [...new Set([business?.email, owner?.email].filter(Boolean))];
+const getVendorRecipients = async (business, owner) => {
+  return resolveVendorNotificationRecipients({
+    business,
+    owner,
+    preference: 'newBookingOrOrder',
+  });
 };
 
 const loadBookingForVendorAction = async (bookingId, vendorId) => {
@@ -96,7 +104,7 @@ exports.createServiceBooking = async (req, res) => {
     }
 
     const [business, owner] = await Promise.all([
-      Business.findById(service.businessId).select('businessName email'),
+      Business.findById(service.businessId).select('businessName email slug'),
       User.findById(service.ownerId).select('name email'),
     ]);
 
@@ -118,8 +126,9 @@ exports.createServiceBooking = async (req, res) => {
     });
 
     try {
+      const vendorRecipients = await getVendorRecipients(business, owner);
       await sendVendorNewServiceBookingEmail({
-        to: getVendorRecipients(business, owner),
+        to: vendorRecipients,
         vendorName: owner?.name || business?.businessName || 'Vendor',
         serviceTitle: service.title,
         customerName: name,
@@ -129,6 +138,7 @@ exports.createServiceBooking = async (req, res) => {
         date: formatBookingDate(date),
         slot,
         bookingId: newBooking._id.toString(),
+        businessSlug: business?.slug,
       });
     } catch (mailError) {
       console.error('Failed to send new service booking email to vendor:', mailError);
@@ -193,6 +203,11 @@ exports.createFoodBooking = async (req, res) => {
       return res.status(404).json({ success: false, message: 'Food listing not found' });
     }
 
+    const [business, owner] = await Promise.all([
+      Business.findById(food.businessId).select('businessName email slug'),
+      User.findById(food.ownerId).select('name email'),
+    ]);
+
     const newBooking = await Booking.create({
       bookingType: 'food',
       foodId: food._id,
@@ -209,6 +224,25 @@ exports.createFoodBooking = async (req, res) => {
       customerId: getAuthenticatedUserId(req),
       customerInfo: { name, email, phone },
     });
+
+    try {
+      const vendorRecipients = await getVendorRecipients(business, owner);
+      await sendVendorNewFoodBookingEmail({
+        to: vendorRecipients,
+        vendorName: owner?.name || business?.businessName || 'Vendor',
+        foodTitle: food.title,
+        customerName: name,
+        customerEmail: email,
+        customerPhone: phone,
+        date: formatBookingDate(date),
+        slot,
+        seats: normalizedSeats,
+        bookingId: newBooking._id.toString(),
+        businessSlug: business?.slug,
+      });
+    } catch (mailError) {
+      console.error('Failed to send new food booking email to vendor:', mailError);
+    }
 
     res.status(201).json({ success: true, booking: newBooking });
   } catch (error) {

--- a/controllers/customer/cartController.js
+++ b/controllers/customer/cartController.js
@@ -4,7 +4,7 @@ const Product = require('../../models/Product');
 const ProductVariant = require('../../models/ProductVariant');
 const Business = require('../../models/Business');
 const {
-    calculateShippingForVendor,
+    resolveShippingForCheckout,
     normalizeDeliverySpeed,
 } = require('../../utils/vendorShipping');
 const {
@@ -145,14 +145,15 @@ const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc, co
     let shipping = null;
     let shippingError = null;
 
-    if (business?.shippingSettings?.method && totalQuantity > 0) {
+    if (totalQuantity > 0) {
         try {
-            const shippingResult = calculateShippingForVendor(
-                business.shippingSettings,
+            const shippingResult = resolveShippingForCheckout(
+                business?.shippingSettings,
                 {
                     deliverySpeed,
                     subtotal: discountedSubtotal,
                     totalQuantity,
+                    legacyItems: items,
                 }
             );
 
@@ -167,8 +168,6 @@ const buildCartPricing = async ({ cartDoc, items, deliverySpeed, businessDoc, co
         } catch (error) {
             shippingError = error.message;
         }
-    } else if (totalQuantity > 0) {
-        shippingError = 'Vendor shipping settings are not configured';
     }
 
     const shippingAmount = Number(shipping?.amount || 0);

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -105,7 +105,7 @@ const {
 } = require("../utils/orderPhase");
 const { sendCustomerOrderLifecycleEmail } = require("../utils/orderLifecycleEmailDelivery");
 const {
-  calculateShippingForVendor,
+  resolveShippingForCheckout,
   normalizeDeliverySpeed,
 } = require("../utils/vendorShipping");
 const {
@@ -685,6 +685,11 @@ exports.initiateOrder = async (req, res) => {
           variant.color ||
           getVariantAttribute(variant, "color") ||
           "default",
+        shippingMethod: deliverySpeed,
+        shipping:
+          variant.shipping ||
+          variant.productId?.shipping ||
+          null,
       });
     }
 
@@ -838,12 +843,13 @@ exports.initiateOrder = async (req, res) => {
 
     let shippingCalculation;
     try {
-      shippingCalculation = calculateShippingForVendor(
+      shippingCalculation = resolveShippingForCheckout(
         business.shippingSettings,
         {
           deliverySpeed,
           subtotal: discountedSubtotal,
           totalQuantity,
+          legacyItems: rawVendorItems,
         }
       );
     } catch (shippingError) {

--- a/controllers/stripePaymentController.js
+++ b/controllers/stripePaymentController.js
@@ -159,7 +159,7 @@ exports.retrieveIntent = async (req, res) => {
       .select('userId groupOrderId status paymentStatus totalAmount currency items')
       .populate({
         path: "items.productId",
-        select: "title",
+        select: "title coverImage",
       });
 
     if (!orders || orders.length === 0) {

--- a/controllers/vendorAlertsController.js
+++ b/controllers/vendorAlertsController.js
@@ -1,0 +1,78 @@
+const mongoose = require('mongoose');
+const Order = require('../models/Order');
+const Booking = require('../models/Booking');
+const BusinessEnquiry = require('../models/BusinessEnquiry');
+
+const getAuthenticatedUserId = (req) => req.user?.id || req.user?._id;
+
+exports.getVendorAlertsSummary = async (req, res) => {
+  try {
+    const { businessId } = req.query;
+    const ownerId = getAuthenticatedUserId(req);
+
+    if (!businessId) {
+      return res.status(400).json({
+        success: false,
+        message: 'businessId is required',
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(businessId)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid businessId',
+      });
+    }
+
+    const businessObjectId = new mongoose.Types.ObjectId(businessId);
+
+    const [
+      pendingOrders,
+      pendingServiceBookings,
+      pendingFoodBookings,
+      totalInquiries,
+    ] = await Promise.all([
+      Order.countDocuments({
+        vendorId: ownerId,
+        businessId: businessObjectId,
+        paymentStatus: 'paid',
+        status: 'ordered',
+      }),
+      Booking.countDocuments({
+        ownerId,
+        businessId: businessObjectId,
+        bookingType: 'service',
+        status: 'pending_vendor_action',
+      }),
+      Booking.countDocuments({
+        ownerId,
+        businessId: businessObjectId,
+        bookingType: 'food',
+        status: 'Booked',
+      }),
+      BusinessEnquiry.countDocuments({
+        vendorId: ownerId,
+        businessId: businessObjectId,
+      }),
+    ]);
+
+    const pendingBookings = pendingServiceBookings + pendingFoodBookings;
+    const totalPending = pendingOrders + pendingBookings;
+
+    return res.status(200).json({
+      success: true,
+      pendingOrders,
+      pendingServiceBookings,
+      pendingFoodBookings,
+      pendingBookings,
+      totalInquiries,
+      totalPending,
+    });
+  } catch (error) {
+    console.error('Failed to fetch vendor alerts summary:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to fetch vendor alerts summary',
+    });
+  }
+};

--- a/models/Order.js
+++ b/models/Order.js
@@ -152,7 +152,7 @@ const orderSchema = new Schema(
       },
       method: {
         type: String,
-        enum: ["flat_rate", "quantity_based", "free_shipping"],
+        enum: ["flat_rate", "quantity_based", "free_shipping", "legacy_product_shipping"],
       },
       amount: {
         type: Number,

--- a/routes/vendorAlertsRoutes.js
+++ b/routes/vendorAlertsRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const authenticate = require('../middlewares/authenticate');
+const isBusinessOwner = require('../middlewares/isBusinessOwner');
+const { getVendorAlertsSummary } = require('../controllers/vendorAlertsController');
+
+router.get('/summary', authenticate, isBusinessOwner, getVendorAlertsSummary);
+
+module.exports = router;

--- a/tests/email/order-paid-mailer-smtp.test.js
+++ b/tests/email/order-paid-mailer-smtp.test.js
@@ -68,6 +68,12 @@ function loadOrderMailerWithMocks({ createdConfigs, sentMessages }) {
     if (request === '../services/invoiceService') {
       return invoiceServiceMock;
     }
+    if (request === './notificationPreferenceGate') {
+      return {
+        filterOrderPaidVendorEmails: async (_order, vendorEmails = []) =>
+          [...new Set((vendorEmails || []).map((e) => String(e || '').trim()).filter(Boolean))],
+      };
+    }
     return originalLoad.call(this, request, parent, isMain);
   };
 
@@ -100,7 +106,7 @@ test('sendOrderPaidEmails uses provider-neutral SMTP config and MAIL_FROM', asyn
     _id: '507f1f77bcf86cd799439020',
     groupOrderId: 'MBH-ORDER-001',
     userId: { name: 'Customer User', email: 'customer@example.com' },
-    vendorId: { name: 'Vendor User', email: 'vendor@example.com' },
+    vendorId: '507f1f77bcf86cd799439021',
     businessId: {
       businessName: 'Vendor Shop',
       slug: 'vendor-shop',

--- a/tests/stripe/order-initiate-connect.test.js
+++ b/tests/stripe/order-initiate-connect.test.js
@@ -188,6 +188,7 @@ function loadInitiateOrder({
     }
     if (request.endsWith('utils/vendorShipping')) {
       return {
+        resolveShippingForCheckout: () => shippingResult,
         calculateShippingForVendor: () => shippingResult,
         normalizeDeliverySpeed: (value) => value || 'standard',
       };

--- a/tests/stripe/order-initiate-coupon.test.js
+++ b/tests/stripe/order-initiate-coupon.test.js
@@ -189,6 +189,7 @@ function loadInitiateOrder({
     }
     if (request.endsWith('utils/vendorShipping')) {
       return {
+        resolveShippingForCheckout: () => shippingResult,
         calculateShippingForVendor: () => shippingResult,
         normalizeDeliverySpeed: (value) => value || 'standard',
       };

--- a/tests/vendor/notification-preference-gate.test.js
+++ b/tests/vendor/notification-preference-gate.test.js
@@ -1,0 +1,91 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  shouldSendVendorNotification,
+  resolveVendorNotificationRecipients,
+  filterOrderPaidVendorEmails,
+} = require('../../utils/notificationPreferenceGate');
+
+test('resolveVendorNotificationRecipients includes business email and owner when prefs allow', async () => {
+  const User = require('../../models/User');
+  const originalFindById = User.findById;
+
+  User.findById = () => ({
+    select: () => ({
+      lean: async () => ({
+        notificationPreferences: { newBookingOrOrder: true },
+      }),
+    }),
+  });
+
+  try {
+    const recipients = await resolveVendorNotificationRecipients({
+      business: { email: 'shop@example.com' },
+      owner: { _id: 'owner-1', email: 'owner@example.com' },
+    });
+
+    assert.deepEqual(recipients, ['shop@example.com', 'owner@example.com']);
+  } finally {
+    User.findById = originalFindById;
+  }
+});
+
+test('resolveVendorNotificationRecipients omits owner email when prefs block', async () => {
+  const User = require('../../models/User');
+  const originalFindById = User.findById;
+
+  User.findById = () => ({
+    select: () => ({
+      lean: async () => ({
+        notificationPreferences: { newBookingOrOrder: false },
+      }),
+    }),
+  });
+
+  try {
+    const recipients = await resolveVendorNotificationRecipients({
+      business: { email: 'shop@example.com' },
+      owner: { _id: 'owner-1', email: 'owner@example.com' },
+    });
+
+    assert.deepEqual(recipients, ['shop@example.com']);
+  } finally {
+    User.findById = originalFindById;
+  }
+});
+
+test('filterOrderPaidVendorEmails removes owner email when payment prefs block', async () => {
+  const User = require('../../models/User');
+  const originalFindById = User.findById;
+
+  User.findById = () => ({
+    select: () => ({
+      lean: async () => ({
+        notificationPreferences: {
+          newBookingOrOrder: true,
+          paymentReceived: false,
+        },
+      }),
+    }),
+  });
+
+  try {
+    const filtered = await filterOrderPaidVendorEmails(
+      {
+        vendorId: { _id: 'owner-1', email: 'owner@example.com' },
+        businessId: { email: 'shop@example.com' },
+      },
+      ['owner@example.com', 'shop@example.com']
+    );
+
+    assert.deepEqual(filtered, ['shop@example.com']);
+  } finally {
+    User.findById = originalFindById;
+  }
+});
+
+test('shouldSendVendorNotification defaults to true without owner id', async () => {
+  const allowed = await shouldSendVendorNotification(null, 'newBookingOrOrder');
+  assert.equal(allowed, true);
+});

--- a/utils/OrderMail.js
+++ b/utils/OrderMail.js
@@ -7,6 +7,7 @@ const {
   buildSmtpTransportConfig,
   formatMosaicFromHeader,
 } = require("./smtpTransport");
+const { filterOrderPaidVendorEmails } = require("./notificationPreferenceGate");
 
 const SUPPORT_EMAIL = process.env.SUPPORT_EMAIL || process.env.MAIL_USER;
 const LOGO_URL = getFrontendLogoUrl();
@@ -323,12 +324,14 @@ function vendorIntro({ order, businessName }) {
  * Expects order populated with: userId{name,email}, vendorId{name,email}, businessId{businessName,slug,email,owner{email}}, items.productId{name|title}
  */
 exports.sendOrderPaidEmails = async ({ order, currency, customerEmails = [], vendorEmails = [] }) => {
+  const filteredVendorEmails = await filterOrderPaidVendorEmails(order, vendorEmails);
+
   console.log("Preparing order-paid emails", {
     orderId: order?._id?.toString?.() || null,
     groupOrderId: order?.groupOrderId || null,
     currency,
     customerRecipientCount: customerEmails.length,
-    vendorRecipientCount: vendorEmails.length,
+    vendorRecipientCount: filteredVendorEmails.length,
   });
 
   const businessName = order.businessId?.businessName || "Vendor";
@@ -380,7 +383,7 @@ exports.sendOrderPaidEmails = async ({ order, currency, customerEmails = [], ven
   }
 
   // VENDOR EMAIL
-  if (vendorEmails.length) {
+  if (filteredVendorEmails.length) {
     const vendorHtml = baseLayout({
       heading: "💸 You’ve received a paid order",
       introHtml: vendorIntro({ order, businessName }),
@@ -401,7 +404,7 @@ exports.sendOrderPaidEmails = async ({ order, currency, customerEmails = [], ven
 
     await transporter.sendMail({
       from: formatMosaicFromHeader(),
-      to: vendorEmails,
+      to: filteredVendorEmails,
       subject: `🛍️ New paid order #${orderNo}`,
       text: vendorText,
       html: vendorHtml,

--- a/utils/bookingMailer.js
+++ b/utils/bookingMailer.js
@@ -12,6 +12,13 @@ const safe = (value, fallback = 'N/A') => {
   return normalized || fallback;
 };
 
+const buildPartnerBookingsUrl = (businessSlug) => {
+  if (businessSlug) {
+    return buildFrontendUrl(`/partners/${encodeURIComponent(businessSlug)}/bookings`);
+  }
+  return buildFrontendUrl('/partners/dashboard');
+};
+
 exports.sendVendorNewServiceBookingEmail = async ({
   to,
   vendorName,
@@ -23,10 +30,11 @@ exports.sendVendorNewServiceBookingEmail = async ({
   date,
   slot,
   bookingId,
+  businessSlug,
 }) => {
   if (!to || to.length === 0) return;
 
-  const dashboardLink = buildFrontendUrl('/partners/dashboard');
+  const dashboardLink = buildPartnerBookingsUrl(businessSlug);
 
   const selectedServices = Array.isArray(services) && services.length > 0
     ? services.map((item) => `<li>${safe(item)}</li>`).join('')
@@ -49,7 +57,49 @@ exports.sendVendorNewServiceBookingEmail = async ({
         <p>Please review the request and either request payment, approve it, or reject it from your dashboard.</p>
         <p>
           <a href="${dashboardLink}" style="display:inline-block;padding:10px 18px;background:#0d6efd;color:#fff;text-decoration:none;border-radius:4px;">
-            Open Vendor Dashboard
+            Review booking requests
+          </a>
+        </p>
+      </div>
+    `,
+  });
+};
+
+exports.sendVendorNewFoodBookingEmail = async ({
+  to,
+  vendorName,
+  foodTitle,
+  customerName,
+  customerEmail,
+  customerPhone,
+  date,
+  slot,
+  seats,
+  bookingId,
+  businessSlug,
+}) => {
+  if (!to || to.length === 0) return;
+
+  const dashboardLink = buildPartnerBookingsUrl(businessSlug);
+
+  await transporter.sendMail({
+    from: formatMosaicFromHeader(),
+    to,
+    subject: 'New food reservation request received',
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+        <h2>Hi ${safe(vendorName, 'Vendor')},</h2>
+        <p>You have received a new food reservation request.</p>
+        <p><strong>Booking ID:</strong> ${safe(bookingId)}</p>
+        <p><strong>Food item:</strong> ${safe(foodTitle)}</p>
+        <p><strong>Date:</strong> ${safe(date)}</p>
+        <p><strong>Slot:</strong> ${safe(slot)}</p>
+        <p><strong>Party size:</strong> ${safe(seats)}</p>
+        <p><strong>Customer:</strong> ${safe(customerName)} (${safe(customerEmail)}, ${safe(customerPhone)})</p>
+        <p>Please review the reservation from your dashboard.</p>
+        <p>
+          <a href="${dashboardLink}" style="display:inline-block;padding:10px 18px;background:#0d6efd;color:#fff;text-decoration:none;border-radius:4px;">
+            Review reservations
           </a>
         </p>
       </div>

--- a/utils/notificationPreferenceGate.js
+++ b/utils/notificationPreferenceGate.js
@@ -1,0 +1,77 @@
+const User = require('../models/User');
+
+/**
+ * Returns whether the vendor owner account opted in for a notification class.
+ * Defaults to true when prefs are missing.
+ */
+async function shouldSendVendorNotification(ownerUserId, preference = 'newBookingOrOrder') {
+  if (!ownerUserId) return true;
+
+  const user = await User.findById(ownerUserId).select('notificationPreferences email').lean();
+  if (!user) return true;
+
+  const prefs = user.notificationPreferences || {};
+
+  if (preference === 'paymentReceived') {
+    return prefs.paymentReceived !== false && prefs.newBookingOrOrder !== false;
+  }
+
+  return prefs[preference] !== false;
+}
+
+/**
+ * Build vendor recipient list: always include business profile email when present;
+ * include owner user email only when notification prefs allow it.
+ */
+async function resolveVendorNotificationRecipients({
+  business,
+  owner,
+  preference = 'newBookingOrOrder',
+}) {
+  const recipients = [];
+  const businessEmail = String(business?.email || '').trim();
+  const ownerEmail = String(owner?.email || '').trim();
+  const ownerId = owner?._id || owner?.id;
+
+  if (businessEmail) {
+    recipients.push(businessEmail);
+  }
+
+  const ownerAllowed = await shouldSendVendorNotification(ownerId, preference);
+  if (ownerEmail && ownerAllowed && !recipients.includes(ownerEmail)) {
+    recipients.push(ownerEmail);
+  }
+
+  return [...new Set(recipients)];
+}
+
+/**
+ * Filter a pre-built vendor email list from order-paid webhook payloads.
+ * Removes the vendor user email when prefs block it; keeps distinct business email.
+ */
+async function filterOrderPaidVendorEmails(order, vendorEmails = []) {
+  const normalized = [...new Set((vendorEmails || []).map((e) => String(e || '').trim()).filter(Boolean))];
+  if (!normalized.length) return [];
+
+  const ownerId = order?.vendorId?._id || order?.vendorId;
+  const ownerEmail = String(order?.vendorId?.email || '').trim();
+  const businessEmail = String(order?.businessId?.email || '').trim();
+
+  const ownerAllowed = await shouldSendVendorNotification(ownerId, 'paymentReceived');
+
+  if (ownerAllowed) {
+    return normalized;
+  }
+
+  return normalized.filter((email) => {
+    if (ownerEmail && email === ownerEmail) return false;
+    if (businessEmail && email === businessEmail) return true;
+    return !ownerEmail || email !== ownerEmail;
+  });
+}
+
+module.exports = {
+  shouldSendVendorNotification,
+  resolveVendorNotificationRecipients,
+  filterOrderPaidVendorEmails,
+};

--- a/utils/paymentIntentResponse.js
+++ b/utils/paymentIntentResponse.js
@@ -44,12 +44,17 @@ function sanitizeOrderForPaymentPoll(order) {
     items: Array.isArray(plain.items)
       ? plain.items.map((item) => ({
           productId: item.productId?._id?.toString?.() || item.productId,
+          variantId: item.variantId?._id?.toString?.() || item.variantId,
           title: item.productId?.title || item.title || null,
+          coverImage: item.productId?.coverImage || null,
           quantity: item.quantity,
           price: item.price,
           size: item.size,
+          color: item.color || null,
         }))
       : [],
+    couponCode: plain.couponCode || null,
+    discountAmount: plain.discountAmount ?? 0,
   };
 }
 

--- a/utils/vendorShipping.js
+++ b/utils/vendorShipping.js
@@ -226,10 +226,71 @@ const calculateShippingForVendor = (settings, options = {}) => {
   };
 };
 
+const readLegacyShippingAmount = (shippingObj, deliverySpeed) => {
+  if (!shippingObj || typeof shippingObj !== "object" || Array.isArray(shippingObj)) {
+    return 0;
+  }
+
+  const speed = normalizeDeliverySpeed(deliverySpeed);
+  if (speed === "express") {
+    const expressAmount = toNumber(shippingObj.express ?? shippingObj.overnight);
+    return Number.isFinite(expressAmount) && expressAmount >= 0 ? expressAmount : 0;
+  }
+
+  const amount = toNumber(shippingObj[speed]);
+  return Number.isFinite(amount) && amount >= 0 ? amount : 0;
+};
+
+const calculateLegacyShippingTotal = (items = [], deliverySpeed = "standard") => {
+  if (!Array.isArray(items) || items.length === 0) return 0;
+
+  const requestedSpeed = normalizeDeliverySpeed(deliverySpeed);
+
+  return items.reduce((sum, item) => {
+    const quantity = Number(item?.quantity || 1);
+    const itemSpeed = normalizeDeliverySpeed(item?.shippingMethod || item?.shippingType || "standard");
+    const storedCharge = toNumber(item?.shippingCharge ?? item?.shippingCost);
+
+    if (Number.isFinite(storedCharge) && storedCharge >= 0 && itemSpeed === requestedSpeed) {
+      return sum + storedCharge * quantity;
+    }
+
+    const legacyAmount = readLegacyShippingAmount(item?.shipping, deliverySpeed);
+    return sum + legacyAmount * quantity;
+  }, 0);
+};
+
+const resolveShippingForCheckout = (settings, options = {}) => {
+  if (settings?.method) {
+    return calculateShippingForVendor(settings, options);
+  }
+
+  const deliverySpeed = normalizeDeliverySpeed(options.deliverySpeed);
+  if (!DELIVERY_SPEEDS.includes(deliverySpeed)) {
+    throw new Error("Invalid delivery speed selected");
+  }
+
+  const legacyShippingAmount = Number.isFinite(toNumber(options.legacyShippingAmount))
+    ? Math.max(0, toNumber(options.legacyShippingAmount))
+    : calculateLegacyShippingTotal(options.legacyItems || [], deliverySpeed);
+
+  return {
+    deliverySpeed,
+    amount: legacyShippingAmount,
+    method: "legacy_product_shipping",
+    freeShippingApplied: false,
+    freeShippingThreshold: null,
+    matchedTier: null,
+  };
+};
+
 module.exports = {
   SHIPPING_METHODS,
   DELIVERY_SPEEDS,
   normalizeDeliverySpeed,
   normalizeShippingSettingsInput,
   calculateShippingForVendor,
+  readLegacyShippingAmount,
+  calculateLegacyShippingTotal,
+  resolveShippingForCheckout,
 };


### PR DESCRIPTION
## Summary
- Adds `GET /api/vendor/alerts/summary` for dashboard notification bell (pending paid orders, bookings, inquiries) with notification preference gating.
- Falls back to legacy product/variant shipping when business `shippingSettings` are unset so checkout is not blocked for test/onboarding vendors.
- Extends `Order.shipping.method` enum with `legacy_product_shipping` and enriches payment-success poll payload (title, coverImage, coupon fields).

## Test plan
- [ ] Place paid product order as customer — vendor bell shows 1 pending order
- [ ] Vendor without shipping settings configured — order initiation succeeds with $0/product shipping
- [ ] `GET /api/vendor/alerts/summary?businessId=...` returns counts for authenticated vendor owner
- [ ] `GET /api/orders/retrieve-intent/:id` returns order `id`, item `title`, and `coverImage`
- [ ] Run `node tests/vendor/notification-preference-gate.test.js` (if wired in CI)


Made with [Cursor](https://cursor.com)