### PR TITLE
feat: service RFQ API, admin catalog/reviews, and onboarding reminder jobs

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,8 +39,10 @@ const foodCategoryRoutes = require('./routes/admin/foodCategoryRoutes')
 const foodSubcategoryRoutes = require('./routes/admin/foodSubcategoryRoutes');
 const adminBusinessRoutes = require('./routes/admin/businessRoutes')
 const adminProductRoutes = require('./routes/admin/adminProductRoutes')
+const adminCatalogRoutes = require('./routes/admin/adminCatalogRoutes')
 const adminOrderRoutes = require('./routes/admin/adminOrderRoutes')
 const adminAuditRoutes = require('./routes/admin/adminAuditRoutes')
+const adminReviewRoutes = require('./routes/admin/adminReviewRoutes')
 const vendorOnboardVerifyStage1Routes= require("./routes/vendorOnboarding.routes")
 
 
@@ -187,8 +189,10 @@ app.use('/admin/api/blogs', blogRoutes);
 app.use('/admin/api/business', adminBusinessRoutes);
 app.use('/api/admin/business', adminBusinessRoutes);
 app.use('/admin/api/products', adminProductRoutes);
+app.use('/api/admin/catalog', adminCatalogRoutes);
 app.use('/admin/api/orders', adminOrderRoutes);
 app.use('/admin/api/audit-events', adminAuditRoutes);
+app.use('/api/admin/reviews', adminReviewRoutes);
 app.use('/api/business-profile', businessProfileRoutes);
 app.use('/api/admin/category/product', productCategoryRoutes);
 app.use('/api/admin/category/product-subcategory', productSubcategoryRoutes);

--- a/controllers/admin/adminCatalog.controller.js
+++ b/controllers/admin/adminCatalog.controller.js
@@ -1,0 +1,538 @@
+const Product = require('../../models/Product');
+const ProductVariant = require('../../models/ProductVariant');
+const Service = require('../../models/Service');
+const Food = require('../../models/Food');
+const {
+  ADMIN_AUDIT_ACTIONS,
+  ADMIN_AUDIT_TARGET_TYPES,
+} = require('../../utils/audit/actionRegistry');
+const {
+  recordAdminAuditSuccess,
+  buildFieldChangeSummary,
+} = require('../../services/adminAuditService');
+const {
+  CATALOG_AUDIT_FLAGS,
+  matchesRequestedFlags,
+  buildAuditItem,
+} = require('../../lib/admin/catalogAudit');
+const { parseListingPrice } = require('../../lib/marketplace/listingPricePolicy');
+const {
+  hasActiveFoodBookings,
+  hasActiveServiceBookings,
+} = require('../../utils/bookingDeleteGuards');
+
+const CATALOG_TYPES = Object.freeze(['product', 'service', 'food']);
+
+const MODEL_BY_TYPE = Object.freeze({
+  product: Product,
+  service: Service,
+  food: Food,
+});
+
+const ALLOWED_UPDATE_FIELDS = Object.freeze({
+  product: ['title', 'description', 'price', 'coverImage', 'isActive', 'isPublished', 'adminRemark'],
+  service: ['title', 'description', 'price', 'coverImage', 'isActive', 'isPublished', 'adminRemark'],
+  food: ['title', 'description', 'price', 'coverImage', 'isActive', 'isPublished', 'adminRemark'],
+});
+
+function normalizeCatalogType(value) {
+  const type = String(value || '').trim().toLowerCase();
+  return CATALOG_TYPES.includes(type) ? type : null;
+}
+
+function parseBoolean(value) {
+  if (value === true || value === 'true' || value === 1 || value === '1') return true;
+  if (value === false || value === 'false' || value === 0 || value === '0') return false;
+  return null;
+}
+
+function parsePageLimit(query = {}) {
+  const page = Math.max(parseInt(query.page, 10) || 1, 1);
+  const limit = Math.min(Math.max(parseInt(query.limit, 10) || 20, 1), 100);
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+function parseRequestedFlags(rawFlags) {
+  if (!rawFlags) return [];
+  const values = Array.isArray(rawFlags) ? rawFlags : String(rawFlags).split(',');
+  return values
+    .map((flag) => String(flag || '').trim().toLowerCase())
+    .filter((flag) => CATALOG_AUDIT_FLAGS.includes(flag));
+}
+
+function getModel(type) {
+  return MODEL_BY_TYPE[type] || null;
+}
+
+function baseListFilter(type) {
+  if (type === 'product') {
+    return { isDeleted: false };
+  }
+  return {};
+}
+
+function applyActivePublishedFilters(filter, query = {}) {
+  const isActive = parseBoolean(query.isActive);
+  const isPublished = parseBoolean(query.isPublished);
+
+  if (isActive === true) {
+    filter.isActive = { $ne: false };
+  } else if (isActive === false) {
+    filter.isActive = false;
+  }
+
+  if (isPublished === true) {
+    filter.isPublished = true;
+  } else if (isPublished === false) {
+    filter.isPublished = false;
+  }
+
+  return filter;
+}
+
+async function loadVariantsByProductId(productIds = []) {
+  const map = new Map();
+  if (!productIds.length) return map;
+
+  const variants = await ProductVariant.find({
+    productId: { $in: productIds },
+    isDeleted: { $ne: true },
+  })
+    .select('productId price salePrice isPublished isDeleted')
+    .lean();
+
+  for (const variant of variants) {
+    const key = String(variant.productId);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(variant);
+  }
+
+  return map;
+}
+
+function serializePrice(value) {
+  const parsed = parseListingPrice(value);
+  return parsed !== null ? parsed : null;
+}
+
+function serializeListing(listing, type) {
+  const business = listing.businessId;
+  return {
+    listingType: type,
+    _id: listing._id,
+    title: listing.title,
+    description: listing.description,
+    price: serializePrice(listing.price),
+    coverImage: listing.coverImage,
+    isPublished: Boolean(listing.isPublished),
+    isActive: listing.isActive !== false,
+    isFeatured: type === 'product' ? Boolean(listing.isFeatured) : false,
+    adminRemark: listing.adminRemark || '',
+    businessId: business?._id || listing.businessId || null,
+    businessName: business?.businessName || null,
+    categoryId: listing.categoryId || null,
+    subcategoryId: listing.subcategoryId || null,
+    createdAt: listing.createdAt,
+    updatedAt: listing.updatedAt,
+  };
+}
+
+function pickAllowedUpdates(type, body = {}) {
+  const allowed = ALLOWED_UPDATE_FIELDS[type] || [];
+  const updates = {};
+
+  for (const field of allowed) {
+    if (body[field] === undefined) continue;
+
+    if (field === 'isActive' || field === 'isPublished') {
+      const parsed = parseBoolean(body[field]);
+      if (parsed !== null) updates[field] = parsed;
+      continue;
+    }
+
+    if (field === 'price') {
+      const parsed = Number(body[field]);
+      if (Number.isFinite(parsed) && parsed >= 0) updates[field] = parsed;
+      continue;
+    }
+
+    if (typeof body[field] === 'string') {
+      updates[field] = body[field].trim();
+    }
+  }
+
+  return updates;
+}
+
+exports.listCatalog = async (req, res) => {
+  try {
+    const type = normalizeCatalogType(req.query.type);
+    const types = type ? [type] : CATALOG_TYPES;
+    const { page, limit, skip } = parsePageLimit(req.query);
+
+    const rows = [];
+
+    for (const listingType of types) {
+      const Model = getModel(listingType);
+      const filter = applyActivePublishedFilters(baseListFilter(listingType), req.query);
+
+      const items = await Model.find(filter)
+        .populate('businessId', 'businessName')
+        .populate('categoryId', 'name')
+        .populate('subcategoryId', 'name')
+        .sort({ updatedAt: -1 })
+        .lean();
+
+      for (const item of items) {
+        rows.push(serializeListing(item, listingType));
+      }
+    }
+
+    rows.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+
+    const total = rows.length;
+    const totalPages = Math.max(Math.ceil(total / limit), 1);
+    const safePage = Math.min(page, totalPages);
+    const safeSkip = (safePage - 1) * limit;
+    const paged = rows.slice(safeSkip, safeSkip + limit);
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        items: paged,
+        pagination: {
+          currentPage: safePage,
+          totalPages,
+          total,
+          limit,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('listCatalog error:', error);
+    return res.status(500).json({ success: false, message: 'Failed to load catalog listings.' });
+  }
+};
+
+exports.getCatalogItem = async (req, res) => {
+  try {
+    const type = normalizeCatalogType(req.params.type);
+    if (!type) {
+      return res.status(400).json({ success: false, message: 'Invalid listing type.' });
+    }
+
+    const Model = getModel(type);
+    const listing = await Model.findOne({
+      _id: req.params.id,
+      ...(type === 'product' ? { isDeleted: false } : {}),
+    })
+      .populate('businessId', 'businessName')
+      .lean();
+
+    if (!listing) {
+      return res.status(404).json({ success: false, message: 'Listing not found.' });
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: serializeListing(listing, type),
+    });
+  } catch (error) {
+    console.error('getCatalogItem error:', error);
+    return res.status(500).json({ success: false, message: 'Failed to load listing.' });
+  }
+};
+
+exports.updateCatalogItem = async (req, res) => {
+  try {
+    const type = normalizeCatalogType(req.params.type);
+    if (!type) {
+      return res.status(400).json({ success: false, message: 'Invalid listing type.' });
+    }
+
+    const Model = getModel(type);
+    const listing = await Model.findOne({
+      _id: req.params.id,
+      ...(type === 'product' ? { isDeleted: false } : {}),
+    });
+
+    if (!listing) {
+      return res.status(404).json({ success: false, message: 'Listing not found.' });
+    }
+
+    const before = {
+      title: listing.title,
+      description: listing.description,
+      price: listing.price,
+      coverImage: listing.coverImage,
+      isActive: listing.isActive !== false,
+      isPublished: Boolean(listing.isPublished),
+      adminRemark: listing.adminRemark || '',
+    };
+
+    const updates = pickAllowedUpdates(type, req.body || {});
+    if (!Object.keys(updates).length) {
+      return res.status(400).json({ success: false, message: 'No valid fields to update.' });
+    }
+
+    if (updates.isActive === false) {
+      updates.isPublished = false;
+    }
+
+    Object.assign(listing, updates);
+    listing.adminModeratedAt = new Date();
+    listing.adminModeratedBy = req.user?._id || req.user?.id;
+
+    await listing.save();
+
+    const after = {
+      title: listing.title,
+      description: listing.description,
+      price: listing.price,
+      coverImage: listing.coverImage,
+      isActive: listing.isActive !== false,
+      isPublished: Boolean(listing.isPublished),
+      adminRemark: listing.adminRemark || '',
+    };
+
+    const actionCode = updates.isActive === false
+      ? ADMIN_AUDIT_ACTIONS.CATALOG_DEACTIVATE
+      : updates.isActive === true
+        ? ADMIN_AUDIT_ACTIONS.CATALOG_ACTIVATE
+        : ADMIN_AUDIT_ACTIONS.CATALOG_UPDATE;
+
+    await recordAdminAuditSuccess(req, {
+      actionCode,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATALOG_LISTING,
+      targetId: listing._id,
+      changeSummary: buildFieldChangeSummary(before, after, Object.keys(updates)),
+      note: updates.adminRemark || null,
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: 'Listing updated successfully.',
+      data: serializeListing(listing.toObject(), type),
+    });
+  } catch (error) {
+    console.error('updateCatalogItem error:', error);
+    return res.status(500).json({ success: false, message: 'Failed to update listing.' });
+  }
+};
+
+exports.patchCatalogActive = async (req, res) => {
+  req.body = {
+    isActive: req.body?.isActive,
+    adminRemark: req.body?.adminRemark || req.body?.remark || req.body?.reason,
+  };
+  return exports.updateCatalogItem(req, res);
+};
+
+exports.deleteCatalogItem = async (req, res) => {
+  try {
+    const type = normalizeCatalogType(req.params.type);
+    if (!type) {
+      return res.status(400).json({ success: false, message: 'Invalid listing type.' });
+    }
+
+    const adminRemark = String(
+      req.body?.adminRemark || req.body?.remark || req.body?.reason || ''
+    ).trim();
+
+    if (!adminRemark) {
+      return res.status(400).json({
+        success: false,
+        message: 'adminRemark is required to delete a listing.',
+      });
+    }
+
+    const Model = getModel(type);
+    const listing = await Model.findOne({
+      _id: req.params.id,
+      ...(type === 'product' ? { isDeleted: false } : {}),
+    });
+
+    if (!listing) {
+      return res.status(404).json({ success: false, message: 'Listing not found.' });
+    }
+
+    const before = {
+      title: listing.title,
+      isActive: listing.isActive !== false,
+      isPublished: Boolean(listing.isPublished),
+      isDeleted: Boolean(listing.isDeleted),
+    };
+
+    let archivedDueToBookings = false;
+    let removed = false;
+    let archived = false;
+
+    if (type === 'service') {
+      const hasActiveBookings = await hasActiveServiceBookings({
+        serviceId: listing._id,
+        ownerId: listing.ownerId,
+      });
+      if (hasActiveBookings) {
+        listing.isActive = false;
+        listing.isPublished = false;
+        listing.adminRemark = adminRemark;
+        listing.adminModeratedAt = new Date();
+        listing.adminModeratedBy = req.user?._id || req.user?.id;
+        await listing.save();
+        archivedDueToBookings = true;
+        archived = true;
+      }
+    }
+
+    if (!archivedDueToBookings && type === 'food') {
+      const hasActiveBookings = await hasActiveFoodBookings({
+        foodId: listing._id,
+        ownerId: listing.ownerId,
+      });
+      if (hasActiveBookings) {
+        listing.isActive = false;
+        listing.isPublished = false;
+        listing.adminRemark = adminRemark;
+        listing.adminModeratedAt = new Date();
+        listing.adminModeratedBy = req.user?._id || req.user?.id;
+        await listing.save();
+        archivedDueToBookings = true;
+        archived = true;
+      }
+    }
+
+    if (!archivedDueToBookings) {
+      if (type === 'product') {
+        listing.isDeleted = true;
+        listing.isActive = false;
+        listing.isPublished = false;
+        listing.adminRemark = adminRemark;
+        listing.adminModeratedAt = new Date();
+        listing.adminModeratedBy = req.user?._id || req.user?.id;
+        await listing.save();
+
+        await ProductVariant.updateMany(
+          { productId: listing._id },
+          { $set: { isDeleted: true } }
+        );
+        archived = true;
+      } else {
+        await listing.deleteOne();
+        removed = true;
+      }
+    }
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: archivedDueToBookings
+        ? ADMIN_AUDIT_ACTIONS.CATALOG_DEACTIVATE
+        : ADMIN_AUDIT_ACTIONS.CATALOG_DELETE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.CATALOG_LISTING,
+      targetId: listing._id,
+      changeSummary: buildFieldChangeSummary(before, {
+        title: before.title,
+        isActive: false,
+        isPublished: false,
+        isDeleted: archived && type === 'product',
+      }, ['isActive', 'isPublished', 'isDeleted']),
+      note: archivedDueToBookings
+        ? `${adminRemark} (archived instead of deleted due to active bookings)`
+        : adminRemark,
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: archivedDueToBookings
+        ? 'Listing has active bookings and was archived (hidden) instead of permanently removed.'
+        : 'Listing deleted successfully.',
+      data: {
+        listingType: type,
+        id: String(listing._id),
+        archived: archived || type === 'product',
+        removed,
+        archivedDueToBookings,
+      },
+    });
+  } catch (error) {
+    console.error('deleteCatalogItem error:', error);
+    return res.status(500).json({ success: false, message: 'Failed to delete listing.' });
+  }
+};
+
+exports.auditCatalog = async (req, res) => {
+  try {
+    const type = normalizeCatalogType(req.query.type);
+    const types = type ? [type] : CATALOG_TYPES;
+    const requestedFlags = parseRequestedFlags(req.query.flags);
+    const { page, limit, skip } = parsePageLimit(req.query);
+
+    const auditRows = [];
+
+    for (const listingType of types) {
+      const Model = getModel(listingType);
+      const filter = applyActivePublishedFilters(baseListFilter(listingType), req.query);
+
+      const listings = await Model.find(filter)
+        .populate('businessId', 'businessName')
+        .sort({ updatedAt: -1 })
+        .lean();
+
+      let variantsByProductId = new Map();
+      if (listingType === 'product' && listings.length) {
+        variantsByProductId = await loadVariantsByProductId(listings.map((item) => item._id));
+      }
+
+      for (const listing of listings) {
+        const options = listingType === 'product'
+          ? { variants: variantsByProductId.get(String(listing._id)) || [] }
+          : {};
+        const item = buildAuditItem(listing, listingType, options);
+        if (!matchesRequestedFlags(item.flags, requestedFlags)) continue;
+        auditRows.push(item);
+      }
+    }
+
+    auditRows.sort((a, b) => {
+      const severityRank = { high: 3, medium: 2, low: 1, none: 0 };
+      const diff = (severityRank[b.severity] || 0) - (severityRank[a.severity] || 0);
+      if (diff !== 0) return diff;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+
+    const summary = {
+      total: auditRows.length,
+      byType: auditRows.reduce((acc, row) => {
+        acc[row.listingType] = (acc[row.listingType] || 0) + 1;
+        return acc;
+      }, {}),
+      byFlag: CATALOG_AUDIT_FLAGS.reduce((acc, flag) => {
+        acc[flag] = auditRows.filter((row) => row.flags.includes(flag)).length;
+        return acc;
+      }, {}),
+    };
+
+    const total = auditRows.length;
+    const totalPages = Math.max(Math.ceil(total / limit), 1);
+    const safePage = Math.min(page, totalPages);
+    const safeSkip = (safePage - 1) * limit;
+    const paged = auditRows.slice(safeSkip, safeSkip + limit);
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        summary,
+        items: paged,
+        pagination: {
+          currentPage: safePage,
+          totalPages,
+          total,
+          limit,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('auditCatalog error:', error);
+    return res.status(500).json({ success: false, message: 'Failed to audit catalog listings.' });
+  }
+};
+
+module.exports.CATALOG_TYPES = CATALOG_TYPES;

--- a/controllers/admin/adminProduct.controller.js
+++ b/controllers/admin/adminProduct.controller.js
@@ -79,7 +79,7 @@ exports.getAllProducts = async (req, res) => {
       .populate('categoryId', 'name')
       .populate('subcategoryId', 'name')
       .populate('businessId', 'businessName')
-      .select('title coverImage isFeatured isPublished createdAt')
+      .select('title coverImage isFeatured isPublished isActive description price createdAt')
       .sort({ createdAt: -1 })
       .skip(skip)
       .limit(parseInt(limit));

--- a/controllers/admin/adminReviewController.js
+++ b/controllers/admin/adminReviewController.js
@@ -1,0 +1,343 @@
+const mongoose = require('mongoose');
+const Review = require('../../models/Review');
+const User = require('../../models/User');
+const Business = require('../../models/Business');
+const { LISTING_MODELS, refreshListingReviewStats } = require('../../services/reviewService');
+
+const MAX_LIMIT = 100;
+const LISTING_SELECT = '_id title slug businessId coverImage isDeleted';
+const BUSINESS_SELECT = '_id businessName slug logo';
+const USER_SELECT = '_id name email profileImage';
+
+const normalizeId = (value) => {
+  if (!value) return value;
+  return typeof value.toString === 'function' ? value.toString() : value;
+};
+
+const normalizeDate = (value) => {
+  if (!value) return value;
+  return value instanceof Date ? value.toISOString() : value;
+};
+
+const parsePagination = (query) => {
+  const page = Math.max(1, parseInt(query.page, 10) || 1);
+  const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(query.limit, 10) || 25));
+  return { page, limit };
+};
+
+const buildReviewFilter = async (query) => {
+  const filter = {};
+
+  if (query.listingType && ['product', 'service', 'food'].includes(query.listingType)) {
+    filter.listingType = query.listingType;
+  }
+
+  if (query.isHidden === 'true') {
+    filter.isHidden = true;
+  } else if (query.isHidden === 'false') {
+    filter.isHidden = { $ne: true };
+  }
+
+  if (query.businessId && mongoose.Types.ObjectId.isValid(query.businessId)) {
+    const businessObjectId = new mongoose.Types.ObjectId(query.businessId);
+    const listingIds = [];
+
+    await Promise.all(
+      Object.entries(LISTING_MODELS).map(async ([listingType, Model]) => {
+        const listings = await Model.find({ businessId: businessObjectId })
+          .select('_id')
+          .lean();
+        listings.forEach((listing) => {
+          listingIds.push({ id: listing._id, listingType });
+        });
+      })
+    );
+
+    if (listingIds.length === 0) {
+      return { filter: null, empty: true };
+    }
+
+    filter.$or = listingIds.map(({ id, listingType }) => ({
+      listingId: id,
+      listingType,
+    }));
+  }
+
+  return { filter, empty: false };
+};
+
+const toAdminListing = (listing, listingType) => {
+  if (!listing) return null;
+
+  return {
+    _id: normalizeId(listing._id),
+    listingType,
+    title: listing.title || '',
+    slug: listing.slug || '',
+    businessId: normalizeId(listing.businessId),
+    coverImage: listing.coverImage || '',
+    isDeleted: Boolean(listing.isDeleted),
+  };
+};
+
+const toAdminBusiness = (business) => {
+  if (!business) return null;
+
+  return {
+    _id: normalizeId(business._id),
+    businessName: business.businessName || '',
+    slug: business.slug || '',
+    logo: business.logo || '',
+  };
+};
+
+const toAdminUser = (user) => {
+  if (!user) return null;
+
+  return {
+    _id: normalizeId(user._id),
+    name: user.name || '',
+    email: user.email || '',
+    profileImage: user.profileImage || '',
+  };
+};
+
+const toAdminReviewRecord = (review, context) => {
+  const listingKey = `${review.listingType}:${normalizeId(review.listingId)}`;
+  const listing = context.listings.get(listingKey) || null;
+  const business = listing?.businessId
+    ? context.businesses.get(normalizeId(listing.businessId)) || null
+    : null;
+
+  return {
+    _id: normalizeId(review._id),
+    rating: review.rating,
+    comment: review.comment,
+    image: review.image || '',
+    listingType: review.listingType,
+    listingId: normalizeId(review.listingId),
+    isHidden: Boolean(review.isHidden),
+    moderatedAt: normalizeDate(review.moderatedAt),
+    createdAt: normalizeDate(review.createdAt),
+    updatedAt: normalizeDate(review.updatedAt),
+    user: toAdminUser(context.users.get(normalizeId(review.userId))),
+    listing: toAdminListing(listing, review.listingType),
+    business: toAdminBusiness(business),
+  };
+};
+
+const loadReviewContexts = async (reviews) => {
+  const userIds = new Set();
+  const listingIdsByType = {
+    product: new Set(),
+    service: new Set(),
+    food: new Set(),
+  };
+
+  reviews.forEach((review) => {
+    userIds.add(normalizeId(review.userId));
+    if (listingIdsByType[review.listingType]) {
+      listingIdsByType[review.listingType].add(normalizeId(review.listingId));
+    }
+  });
+
+  const [users, productListings, serviceListings, foodListings] = await Promise.all([
+    User.find({ _id: { $in: [...userIds] } })
+      .select(USER_SELECT)
+      .lean(),
+    listingIdsByType.product.size
+      ? LISTING_MODELS.product
+          .find({ _id: { $in: [...listingIdsByType.product] } })
+          .select(LISTING_SELECT)
+          .lean()
+      : [],
+    listingIdsByType.service.size
+      ? LISTING_MODELS.service
+          .find({ _id: { $in: [...listingIdsByType.service] } })
+          .select(LISTING_SELECT)
+          .lean()
+      : [],
+    listingIdsByType.food.size
+      ? LISTING_MODELS.food
+          .find({ _id: { $in: [...listingIdsByType.food] } })
+          .select(LISTING_SELECT)
+          .lean()
+      : [],
+  ]);
+
+  const listings = new Map();
+  productListings.forEach((listing) => {
+    listings.set(`product:${normalizeId(listing._id)}`, listing);
+  });
+  serviceListings.forEach((listing) => {
+    listings.set(`service:${normalizeId(listing._id)}`, listing);
+  });
+  foodListings.forEach((listing) => {
+    listings.set(`food:${normalizeId(listing._id)}`, listing);
+  });
+
+  const businessIds = new Set();
+  [...productListings, ...serviceListings, ...foodListings].forEach((listing) => {
+    if (listing?.businessId) {
+      businessIds.add(normalizeId(listing.businessId));
+    }
+  });
+
+  const businesses = await Business.find({ _id: { $in: [...businessIds] } })
+    .select(BUSINESS_SELECT)
+    .lean();
+
+  return {
+    users: new Map(users.map((user) => [normalizeId(user._id), user])),
+    listings,
+    businesses: new Map(businesses.map((business) => [normalizeId(business._id), business])),
+  };
+};
+
+exports.listAllPlatformReviews = async (req, res) => {
+  try {
+    const { page, limit } = parsePagination(req.query);
+    const skip = (page - 1) * limit;
+    const { filter, empty } = await buildReviewFilter(req.query);
+
+    if (empty) {
+      return res.status(200).json({
+        success: true,
+        data: {
+          reviews: [],
+          pagination: {
+            total: 0,
+            page,
+            limit,
+            totalPages: 0,
+          },
+        },
+      });
+    }
+
+    const [reviews, total] = await Promise.all([
+      Review.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Review.countDocuments(filter),
+    ]);
+
+    const context = await loadReviewContexts(reviews);
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        reviews: reviews.map((review) => toAdminReviewRecord(review, context)),
+        pagination: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit) || 0,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('listAllPlatformReviews error:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to fetch platform reviews',
+    });
+  }
+};
+
+exports.toggleReviewVisibility = async (req, res) => {
+  try {
+    const { reviewId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(reviewId)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid review ID',
+      });
+    }
+
+    const review = await Review.findById(reviewId);
+
+    if (!review) {
+      return res.status(404).json({
+        success: false,
+        message: 'Review not found',
+      });
+    }
+
+    review.isHidden = !review.isHidden;
+    review.moderatedAt = new Date();
+    await review.save();
+
+    const summary = await refreshListingReviewStats(review.listingId, review.listingType);
+
+    return res.status(200).json({
+      success: true,
+      message: review.isHidden ? 'Review hidden successfully' : 'Review restored successfully',
+      data: {
+        review: {
+          _id: normalizeId(review._id),
+          listingId: normalizeId(review.listingId),
+          listingType: review.listingType,
+          isHidden: review.isHidden,
+          moderatedAt: normalizeDate(review.moderatedAt),
+        },
+        summary,
+      },
+    });
+  } catch (error) {
+    console.error('toggleReviewVisibility error:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to update review visibility',
+    });
+  }
+};
+
+exports.removePlatformReview = async (req, res) => {
+  try {
+    const { reviewId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(reviewId)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid review ID',
+      });
+    }
+
+    const review = await Review.findById(reviewId);
+
+    if (!review) {
+      return res.status(404).json({
+        success: false,
+        message: 'Review not found',
+      });
+    }
+
+    const listingId = review.listingId;
+    const listingType = review.listingType;
+
+    await review.deleteOne();
+
+    const summary = await refreshListingReviewStats(listingId, listingType);
+
+    return res.status(200).json({
+      success: true,
+      message: 'Review removed successfully',
+      data: {
+        reviewId: normalizeId(reviewId),
+        listingId: normalizeId(listingId),
+        listingType,
+        summary,
+      },
+    });
+  } catch (error) {
+    console.error('removePlatformReview error:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to remove review',
+    });
+  }
+};

--- a/controllers/admin/business.Controller.js
+++ b/controllers/admin/business.Controller.js
@@ -13,6 +13,7 @@ const {
 const {
   isPublicMarketplaceBusiness,
 } = require("../../lib/marketplace/businessEligibility");
+const { normalizeBusinessTags } = require("../../lib/admin/businessTags");
 
 const parseBoolean = (value) => {
   if (value === true || value === "true" || value === 1 || value === "1") return true;
@@ -183,6 +184,222 @@ exports.toggleBusinessStatus = async (req, res) => {
       message: `Business has been ${statusText} successfully.`,
       data: business,
       publicMarketplaceEligible: isPublicMarketplaceBusiness(business),
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: "Server error. Please try again later.",
+    });
+  }
+};
+
+exports.updateBusinessProfile = async (req, res) => {
+  try {
+    const body = req.body || {};
+    const hasBusinessName = Object.prototype.hasOwnProperty.call(body, "businessName");
+    const hasDescription = Object.prototype.hasOwnProperty.call(body, "description");
+    const hasTags = Object.prototype.hasOwnProperty.call(body, "tags");
+
+    if (!hasBusinessName && !hasDescription && !hasTags) {
+      return res.status(400).json({
+        success: false,
+        message: "Provide at least one of businessName, description, or tags.",
+      });
+    }
+
+    if (hasTags && !Array.isArray(body.tags)) {
+      return res.status(400).json({
+        success: false,
+        message: "tags must be an array of strings.",
+      });
+    }
+
+    const business = await Business.findById(req.params.id).select(
+      "businessName description tags"
+    );
+
+    if (!business) {
+      return res.status(404).json({
+        success: false,
+        message: "Business not found.",
+      });
+    }
+
+    const before = {
+      businessName: business.businessName,
+      description: business.description || "",
+      tags: Array.isArray(business.tags) ? [...business.tags] : [],
+    };
+
+    if (hasBusinessName) {
+      const nextName = String(body.businessName || "").trim();
+      if (!nextName) {
+        return res.status(400).json({
+          success: false,
+          message: "businessName cannot be empty.",
+        });
+      }
+      business.businessName = nextName;
+    }
+
+    if (hasDescription) {
+      business.description = String(body.description || "").trim();
+    }
+
+    if (hasTags) {
+      business.tags = normalizeBusinessTags(body.tags);
+    }
+
+    await business.save();
+
+    const after = {
+      businessName: business.businessName,
+      description: business.description || "",
+      tags: Array.isArray(business.tags) ? [...business.tags] : [],
+    };
+
+    const changedFields = ["businessName", "description", "tags"].filter((field) => {
+      if (field === "tags") {
+        return JSON.stringify(before.tags) !== JSON.stringify(after.tags);
+      }
+      return before[field] !== after[field];
+    });
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.BUSINESS_PROFILE_UPDATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+      targetId: business._id,
+      changeSummary: buildFieldChangeSummary(before, after, changedFields),
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "Business profile updated successfully.",
+      data: {
+        _id: business._id,
+        businessName: business.businessName,
+        description: business.description || "",
+        tags: business.tags || [],
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: "Server error. Please try again later.",
+    });
+  }
+};
+
+exports.updateBusinessTags = async (req, res) => {
+  try {
+    if (!req.body || !Object.prototype.hasOwnProperty.call(req.body, "tags")) {
+      return res.status(400).json({
+        success: false,
+        message: "tags is required and must be an array of strings.",
+      });
+    }
+
+    if (!Array.isArray(req.body.tags)) {
+      return res.status(400).json({
+        success: false,
+        message: "tags must be an array of strings.",
+      });
+    }
+
+    const business = await Business.findById(req.params.id).select(
+      "businessName tags"
+    );
+
+    if (!business) {
+      return res.status(404).json({
+        success: false,
+        message: "Business not found.",
+      });
+    }
+
+    const previousTags = Array.isArray(business.tags) ? [...business.tags] : [];
+    const nextTags = normalizeBusinessTags(req.body.tags);
+
+    business.tags = nextTags;
+    await business.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: ADMIN_AUDIT_ACTIONS.BUSINESS_TAGS_UPDATE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+      targetId: business._id,
+      changeSummary: buildFieldChangeSummary(
+        { tags: previousTags },
+        { tags: nextTags },
+        ["tags"]
+      ),
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "Business tags updated successfully.",
+      data: {
+        _id: business._id,
+        businessName: business.businessName,
+        tags: nextTags,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: "Server error. Please try again later.",
+    });
+  }
+};
+
+exports.updateBusinessFeatured = async (req, res) => {
+  try {
+    const nextFeatured = parseBoolean(req.body?.isFeatured);
+    if (nextFeatured === null) {
+      return res.status(400).json({
+        success: false,
+        message: "isFeatured is required and must be true or false.",
+      });
+    }
+
+    const business = await Business.findById(req.params.id).select(
+      "businessName isFeatured"
+    );
+
+    if (!business) {
+      return res.status(404).json({
+        success: false,
+        message: "Business not found.",
+      });
+    }
+
+    const previousFeatured = Boolean(business.isFeatured);
+    business.isFeatured = nextFeatured;
+    await business.save();
+
+    await recordAdminAuditSuccess(req, {
+      actionCode: nextFeatured
+        ? ADMIN_AUDIT_ACTIONS.BUSINESS_FEATURE
+        : ADMIN_AUDIT_ACTIONS.BUSINESS_UNFEATURE,
+      targetType: ADMIN_AUDIT_TARGET_TYPES.BUSINESS,
+      targetId: business._id,
+      changeSummary: buildFieldChangeSummary(
+        { isFeatured: previousFeatured },
+        { isFeatured: business.isFeatured },
+        ["isFeatured"]
+      ),
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: `Business ${nextFeatured ? "featured" : "unfeatured"} successfully.`,
+      data: {
+        _id: business._id,
+        businessName: business.businessName,
+        isFeatured: business.isFeatured,
+      },
     });
   } catch (error) {
     console.error(error);

--- a/controllers/admin/vendorOnboardVerifyStage1.js
+++ b/controllers/admin/vendorOnboardVerifyStage1.js
@@ -40,6 +40,10 @@ exports.PENDING_REVIEW_STATUSES = PENDING_REVIEW_STATUSES;
 exports.APPLICATION_STATUS_FILTERS = APPLICATION_STATUS_FILTERS;
 
 const VERIFICATION_GUIDANCE_OUTCOMES = Object.freeze({
+  changes_requested: {
+    label: 'vendor_changes_requested',
+    defaultReason: 'Application updates are required before approval can continue.',
+  },
   missing_documents: {
     label: 'vendor_missing_documents',
     defaultReason: 'Required documents are missing or not verified.',
@@ -1146,36 +1150,58 @@ exports.finalizeVerification = async (req, res) => {
     // ❌ REJECTED
     if (application.status === 'rejected') {
       const rejectionReason = application.rejectionReason;
+      const requiredNextAction = application.requiredNextAction;
+      const rejectionOutcome = explicitDecision === 'reject' && hasRequiredDocsVerified
+        ? 'changes_requested'
+        : 'missing_documents';
 
-      const emailDelivery = await deliverVendorOnboardingEmails([
-        {
-          label: 'vendor_rejection',
-          send: () => sendVendorRejectionEmail({
-            to: vendorEmail,
-            vendorName,
-            businessName: application.businessName,
-            applicationId: application.applicationId,
-            currentStatus: application.status,
-            rejectionReason,
-            documentsNeeded: missingRequiredDocuments,
-          }),
-        },
-      ]);
+      let emailDelivery;
+      if (!vendorEmail) {
+        console.warn(
+          `Vendor rejection email skipped (vendor_rejection): missing vendor email for application ${application.applicationId}`
+        );
+        emailDelivery = {
+          results: [{
+            label: 'vendor_rejection',
+            sent: false,
+            skipped: false,
+            error: 'vendor_email_missing',
+          }],
+          emailSent: false,
+          emailSkipped: false,
+          emailFailed: true,
+        };
+      } else {
+        emailDelivery = await deliverVendorOnboardingEmails([
+          {
+            label: 'vendor_rejection',
+            send: () => sendVendorRejectionEmail({
+              to: vendorEmail,
+              vendorName,
+              businessName: application.businessName,
+              applicationId: application.applicationId,
+              rejectionReason,
+              requiredNextAction,
+              documentsNeeded: missingRequiredDocuments,
+            }),
+          },
+        ]);
+      }
 
       const rejectionFingerprint = buildGuidanceFingerprint({
-        outcome: 'missing_documents',
+        outcome: rejectionOutcome,
         applicationStatus: application.status,
         reasons: [rejectionReason],
         documentsNeeded: missingRequiredDocuments,
-        fieldsNeeded: [],
+        fieldsNeeded: [requiredNextAction],
       });
 
       const notificationLog = await appendVerificationNotificationLog(application, {
-        outcome: 'missing_documents',
+        outcome: rejectionOutcome,
         fingerprint: rejectionFingerprint,
         reasons: [rejectionReason],
         documentsNeeded: missingRequiredDocuments,
-        fieldsNeeded: [],
+        fieldsNeeded: [requiredNextAction],
         emailDelivery,
         triggeredBy: reviewerId,
       });
@@ -1189,7 +1215,7 @@ exports.finalizeVerification = async (req, res) => {
           { status: application.status, badge },
           ['status', 'badge']
         ),
-        note: `${rejectionReason} ${explicitDecision ? '(explicit admin decision)' : '(auto decision)'} ${buildGuidanceAuditNote('missing_documents', emailDelivery, notificationLog)}`,
+        note: `${rejectionReason} ${explicitDecision ? '(explicit admin decision)' : '(auto decision)'} ${buildGuidanceAuditNote(rejectionOutcome, emailDelivery, notificationLog)}`,
       });
 
       return res.status(200).json({

--- a/controllers/businessController.js
+++ b/controllers/businessController.js
@@ -875,6 +875,7 @@ exports.getProductBusinesses = async (req, res) => {
       tag,
       tags,
       zip,
+      featured,
       page = 1,
       limit = 10,
     } = req.query;
@@ -883,6 +884,10 @@ exports.getProductBusinesses = async (req, res) => {
     const filters = publicMarketplaceBusinessFilter({
       listingType: listingTypeFilter,
     });
+
+    if (String(featured || "").trim().toLowerCase() === "true") {
+      filters.isFeatured = true;
+    }
 
     if (search) filters.businessName = { $regex: search, $options: "i" };
     if (city) filters["address.city"] = city;
@@ -926,10 +931,10 @@ exports.getProductBusinesses = async (req, res) => {
     const skip = (pageNum - 1) * limitNum;
 
     const businesses = await Business.find(filters)
-      .select("businessName slug logo listingType")
+      .select("businessName slug logo listingType description tags isFeatured")
       .skip(skip)
       .limit(limitNum)
-      .sort({ createdAt: -1 })
+      .sort({ isFeatured: -1, updatedAt: -1, createdAt: -1 })
       .lean();
 
     const total = await Business.countDocuments(filters);

--- a/controllers/customer/enquiry.js
+++ b/controllers/customer/enquiry.js
@@ -2,6 +2,34 @@ const mongoose = require('mongoose');
 
 const Business = require('../../models/Business');
 const BusinessEnquiry = require('../../models/BusinessEnquiry');
+const Service = require('../../models/Service');
+const ServiceRfq = require('../../models/ServiceRfq');
+const User = require('../../models/User');
+const {
+  resolvePublicExternalLink,
+} = require('../../utils/serviceLeadConfig');
+const {
+  sendVendorNewServiceRfqEmail,
+  sendCustomerServiceRfqConfirmationEmail,
+} = require('../../utils/rfqMailer');
+const {
+  resolveVendorNotificationRecipients,
+} = require('../../utils/notificationPreferenceGate');
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const normalizeStringArray = (value) => {
+  if (!value) return [];
+  const items = Array.isArray(value) ? value : [value];
+  return items.map((item) => String(item ?? '').trim()).filter(Boolean);
+};
+
+const getVendorRecipients = async (business, owner) =>
+  resolveVendorNotificationRecipients({
+    business,
+    owner,
+    preference: 'newBookingOrOrder',
+  });
 
 exports.createRevealEnquiry = async (req, res) => {
   try {
@@ -90,6 +118,255 @@ exports.createRevealEnquiry = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: 'Failed to save enquiry',
+    });
+  }
+};
+
+exports.createServiceRfq = async (req, res) => {
+  try {
+    const {
+      serviceId,
+      name,
+      email,
+      phone,
+      message,
+      services,
+      budget,
+    } = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(serviceId)) {
+      return res.status(400).json({
+        success: false,
+        message: 'Valid serviceId is required',
+      });
+    }
+
+    const trimmedName = String(name || '').trim();
+    const trimmedEmail = String(email || '').trim().toLowerCase();
+    const trimmedPhone = String(phone || '').trim();
+    const trimmedMessage = String(message || '').trim();
+    const trimmedBudget = String(budget || '').trim();
+
+    if (!trimmedName || !trimmedEmail || !trimmedPhone || !trimmedMessage) {
+      return res.status(400).json({
+        success: false,
+        message: 'name, email, phone, and message are required',
+      });
+    }
+
+    if (!EMAIL_PATTERN.test(trimmedEmail)) {
+      return res.status(400).json({
+        success: false,
+        message: 'A valid email address is required',
+      });
+    }
+
+    if (trimmedMessage.length < 10) {
+      return res.status(400).json({
+        success: false,
+        message: 'message must be at least 10 characters',
+      });
+    }
+
+    const service = await Service.findById(serviceId)
+      .select('_id title businessId ownerId isPublished isActive rfqEnabled externalLink bookingToolLink')
+      .lean();
+
+    if (!service || service.isPublished !== true || service.isActive === false) {
+      return res.status(404).json({
+        success: false,
+        message: 'Service not found',
+      });
+    }
+
+    if (service.rfqEnabled !== true) {
+      return res.status(400).json({
+        success: false,
+        message: 'This service listing does not accept quote requests',
+      });
+    }
+
+    if (resolvePublicExternalLink(service)) {
+      return res.status(400).json({
+        success: false,
+        message: 'This service uses an external booking link. Quote requests are unavailable.',
+      });
+    }
+
+    const business = await Business.findById(service.businessId)
+      .select('_id owner businessName email slug isActive isApproved')
+      .lean();
+
+    if (!business || business.isActive !== true) {
+      return res.status(404).json({
+        success: false,
+        message: 'Business not found',
+      });
+    }
+
+    if (business.owner?.toString() === req.user._id.toString()) {
+      return res.status(400).json({
+        success: false,
+        message: 'You cannot submit a quote request for your own business',
+      });
+    }
+
+    const owner = await User.findById(service.ownerId).select('name email').lean();
+    const requestedServices = normalizeStringArray(services);
+
+    const rfq = await ServiceRfq.create({
+      serviceId: service._id,
+      businessId: business._id,
+      vendorId: business.owner,
+      customerId: req.user._id,
+      customerName: trimmedName,
+      customerEmail: trimmedEmail,
+      customerPhone: trimmedPhone,
+      message: trimmedMessage,
+      requestedServices,
+      budget: trimmedBudget,
+      status: 'pending',
+      source: 'service_rfq',
+    });
+
+    try {
+      const vendorRecipients = await getVendorRecipients(business, owner);
+      await sendVendorNewServiceRfqEmail({
+        to: vendorRecipients,
+        vendorName: owner?.name || business.businessName || 'Vendor',
+        serviceTitle: service.title || 'Service',
+        customerName: trimmedName,
+        customerEmail: trimmedEmail,
+        customerPhone: trimmedPhone,
+        message: trimmedMessage,
+        requestedServices,
+        budget: trimmedBudget,
+        rfqId: rfq._id.toString(),
+        businessSlug: business.slug,
+      });
+    } catch (mailError) {
+      console.error('Failed to send service RFQ email to vendor:', mailError);
+    }
+
+    try {
+      await sendCustomerServiceRfqConfirmationEmail({
+        to: trimmedEmail,
+        customerName: trimmedName,
+        serviceTitle: service.title || 'Service',
+        vendorName: owner?.name || business.businessName || 'Vendor',
+        message: trimmedMessage,
+        requestedServices,
+        budget: trimmedBudget,
+        rfqId: rfq._id.toString(),
+      });
+    } catch (mailError) {
+      console.error('Failed to send service RFQ confirmation email to customer:', mailError);
+    }
+
+    return res.status(201).json({
+      success: true,
+      message: 'Quote request submitted successfully',
+      data: {
+        _id: rfq._id,
+        serviceId: rfq.serviceId,
+        businessId: rfq.businessId,
+        customerName: rfq.customerName,
+        customerEmail: rfq.customerEmail,
+        customerPhone: rfq.customerPhone,
+        message: rfq.message,
+        requestedServices: rfq.requestedServices,
+        budget: rfq.budget,
+        status: rfq.status,
+        createdAt: rfq.createdAt,
+      },
+    });
+  } catch (error) {
+    console.error('Error creating service RFQ:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to submit quote request',
+    });
+  }
+};
+
+exports.getVendorRfqs = async (req, res) => {
+  try {
+    const { businessId, page = 1, limit = 20 } = req.query;
+
+    const ownedBusinessFilter = { owner: req.user._id };
+
+    if (businessId) {
+      if (!mongoose.Types.ObjectId.isValid(businessId)) {
+        return res.status(400).json({
+          success: false,
+          message: 'Invalid businessId',
+        });
+      }
+
+      ownedBusinessFilter._id = businessId;
+    }
+
+    const businesses = await Business.find(ownedBusinessFilter)
+      .select('_id businessName')
+      .lean();
+
+    if (!businesses.length) {
+      return res.status(200).json({
+        success: true,
+        total: 0,
+        page: Number(page),
+        totalPages: 0,
+        data: [],
+      });
+    }
+
+    const businessIds = businesses.map((item) => item._id);
+    const businessNameMap = new Map(
+      businesses.map((item) => [item._id.toString(), item.businessName])
+    );
+
+    const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
+    const limitNumber = Math.max(parseInt(limit, 10) || 20, 1);
+    const skip = (pageNumber - 1) * limitNumber;
+
+    const [rfqs, total] = await Promise.all([
+      ServiceRfq.find({
+        vendorId: req.user._id,
+        businessId: { $in: businessIds },
+      })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limitNumber)
+        .populate('serviceId', 'title slug')
+        .populate('customerId', 'name email mobile profileImage')
+        .lean(),
+      ServiceRfq.countDocuments({
+        vendorId: req.user._id,
+        businessId: { $in: businessIds },
+      }),
+    ]);
+
+    const data = rfqs.map((rfq) => ({
+      ...rfq,
+      businessName: businessNameMap.get(rfq.businessId?.toString()) || null,
+      serviceTitle:
+        typeof rfq.serviceId === 'object' && rfq.serviceId?.title
+          ? rfq.serviceId.title
+          : null,
+    }));
+
+    return res.status(200).json({
+      success: true,
+      total,
+      page: pageNumber,
+      totalPages: Math.ceil(total / limitNumber),
+      data,
+    });
+  } catch (error) {
+    console.error('Error fetching vendor RFQs:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to fetch quote requests',
     });
   }
 };

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -199,6 +199,8 @@ const summarizeBuckets = (buckets, rows) => {
 
 const currencyExpression = { $ifNull: ["$currency", "USD"] };
 const amountExpression = (field, fallback = 0) => ({ $ifNull: [field, fallback] });
+const ADMIN_PLATFORM_COMMISSION_RATE = 0.1;
+const ADMIN_PLATFORM_COMMISSION_PERCENT = 10;
 
 const toCurrencySummary = (row) => ({
   currency: row._id || "USD",
@@ -213,9 +215,28 @@ const toCurrencySummary = (row) => ({
 
 const toVendorSalesSummary = (row) => ({
   vendorId: row.vendorId ? String(row.vendorId) : null,
+  businessId: row.businessId ? String(row.businessId) : null,
+  vendorName: row.vendorName || null,
+  businessName: row.businessName || null,
   currency: row.currency || "USD",
   orderCount: row.orderCount || 0,
   totalSalesAmount: row.totalSalesAmount || 0,
+});
+
+const toPlatformRevenueByCurrency = (row) => ({
+  currency: row.currency || row._id || "USD",
+  paidOrderCount: row.paidOrderCount || 0,
+  paidSalesBase: row.paidSalesBase || 0,
+  commissionAmount: row.commissionAmount || 0,
+});
+
+const buildPlatformRevenueSummary = (rows) => ({
+  supported: true,
+  feePercent: ADMIN_PLATFORM_COMMISSION_PERCENT,
+  feeRate: ADMIN_PLATFORM_COMMISSION_RATE,
+  basis: "paid_order_total_amount",
+  description: `${ADMIN_PLATFORM_COMMISSION_PERCENT}% platform commission on paid order totals`,
+  byCurrency: rows.map(toPlatformRevenueByCurrency),
 });
 
 const getVariantAttribute = (variantDoc, key) => {
@@ -1505,6 +1526,7 @@ exports.getAdminSalesSummary = async (req, res) => {
             $group: {
               _id: {
                 vendorId: "$vendorId",
+                businessId: "$businessId",
                 currency: currencyExpression,
               },
               orderCount: { $sum: 1 },
@@ -1515,17 +1537,86 @@ exports.getAdminSalesSummary = async (req, res) => {
             $project: {
               _id: 0,
               vendorId: "$_id.vendorId",
+              businessId: "$_id.businessId",
               currency: "$_id.currency",
               orderCount: 1,
               totalSalesAmount: 1,
+            },
+          },
+          {
+            $lookup: {
+              from: "users",
+              localField: "vendorId",
+              foreignField: "_id",
+              as: "vendorDoc",
+              pipeline: [{ $project: { name: 1 } }],
+            },
+          },
+          {
+            $lookup: {
+              from: "businesses",
+              localField: "businessId",
+              foreignField: "_id",
+              as: "businessDoc",
+              pipeline: [{ $project: { businessName: 1 } }],
+            },
+          },
+          {
+            $addFields: {
+              vendorName: {
+                $ifNull: [{ $arrayElemAt: ["$vendorDoc.name", 0] }, null],
+              },
+              businessName: {
+                $ifNull: [
+                  { $arrayElemAt: ["$businessDoc.businessName", 0] },
+                  null,
+                ],
+              },
+            },
+          },
+          {
+            $project: {
+              vendorDoc: 0,
+              businessDoc: 0,
             },
           },
           { $sort: { totalSalesAmount: -1 } },
           { $limit: 10 },
         ]
       : null;
+    const platformRevenuePipeline = paidVendorMatch
+      ? [
+          { $match: paidVendorMatch },
+          {
+            $group: {
+              _id: currencyExpression,
+              paidOrderCount: { $sum: 1 },
+              paidSalesBase: { $sum: amountExpression("$totalAmount") },
+              commissionAmount: {
+                $sum: {
+                  $multiply: [
+                    amountExpression("$totalAmount"),
+                    ADMIN_PLATFORM_COMMISSION_RATE,
+                  ],
+                },
+              },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              currency: "$_id",
+              paidOrderCount: 1,
+              paidSalesBase: 1,
+              commissionAmount: 1,
+            },
+          },
+          { $sort: { currency: 1 } },
+        ]
+      : null;
 
-    const [salesByCurrency, vendorSales, paymentAgg, statusAgg] = await Promise.all([
+    const [salesByCurrency, vendorSales, platformRevenueRows, paymentAgg, statusAgg] =
+      await Promise.all([
       Order.aggregate([
         { $match: match },
         {
@@ -1561,6 +1652,9 @@ exports.getAdminSalesSummary = async (req, res) => {
       vendorSalesPipeline
         ? Order.aggregate(vendorSalesPipeline)
         : Promise.resolve([]),
+      platformRevenuePipeline
+        ? Order.aggregate(platformRevenuePipeline)
+        : Promise.resolve([]),
       Order.aggregate([
         { $match: match },
         { $group: { _id: "$paymentStatus", count: { $sum: 1 } } },
@@ -1577,11 +1671,7 @@ exports.getAdminSalesSummary = async (req, res) => {
       data: {
         salesByCurrency: salesByCurrency.map(toCurrencySummary),
         topVendors: vendorSales.map(toVendorSalesSummary),
-        platformRevenue: {
-          supported: false,
-          amount: null,
-          reason: "Order records do not persist platform fee amounts yet.",
-        },
+        platformRevenue: buildPlatformRevenueSummary(platformRevenueRows),
         summary: {
           payment: summarizeBuckets(ADMIN_PAYMENT_BUCKETS, paymentAgg),
           status: summarizeBuckets(ADMIN_STATUS_BUCKETS, statusAgg),

--- a/controllers/privateListing.js
+++ b/controllers/privateListing.js
@@ -119,6 +119,7 @@ exports.getServiceBySlug = async (req, res) => {
     const reviews = await Review.find({
       listingId: service._id,
       listingType: 'service',
+      isHidden: { $ne: true },
     })
       .populate('userId', 'name profileImage'); // Adjust fields as needed
 

--- a/controllers/publicListing.js
+++ b/controllers/publicListing.js
@@ -45,6 +45,7 @@ const getVisibleBusinessIds = async () => {
 };
 
 const PUBLIC_LIST_MAX_LIMIT = 50;
+const PUBLIC_ACTIVE_LISTING_FILTER = Object.freeze({ isActive: { $ne: false } });
 
 function clipListPagination(page, limit, defaultLimit = 10) {
   const pageN = Math.max(1, parseInt(page, 10) || 1);
@@ -145,7 +146,7 @@ exports.getAllServices = async (req, res) => {
       verified,
     } = req.query;
 
-    const filters = { isPublished: true };
+    const filters = { isPublished: true, ...PUBLIC_ACTIVE_LISTING_FILTER };
 
     // Search
     if (search) {
@@ -327,7 +328,7 @@ exports.getServiceBySlug = async (req, res) => {
   try {
     const { slug } = req.params;
 
-    const service = await Service.findOne({ slug, isPublished: true })
+    const service = await Service.findOne({ slug, isPublished: true, ...PUBLIC_ACTIVE_LISTING_FILTER })
       .populate('categoryId', 'name')
       .populate('subcategoryId', 'name')
       .populate('ownerId', 'name');
@@ -347,6 +348,7 @@ exports.getServiceBySlug = async (req, res) => {
     const reviews = await Review.find({
       listingId: service._id,
       listingType: 'service',
+      isHidden: { $ne: true },
     })
       .populate('userId', 'name profileImage');
 
@@ -533,7 +535,7 @@ exports.getAllFood = async (req, res) => {
       verified,
     } = req.query;
 
-    const filters = { isPublished: true };
+    const filters = { isPublished: true, ...PUBLIC_ACTIVE_LISTING_FILTER };
 
     // Search filter
     if (search) {
@@ -544,9 +546,6 @@ exports.getAllFood = async (req, res) => {
     }
 
     if (minorityType) filters.minorityType = minorityType;
-    if (city) filters['address.city'] = { $regex: city, $options: 'i' };
-    if (state) filters['address.state'] = { $regex: state, $options: 'i' };
-    if (country) filters['address.country'] = { $regex: country, $options: 'i' };
 
     const visibleBusinessIds = await getVisibleBusinessIds();
     if (!visibleBusinessIds.length) {
@@ -567,7 +566,7 @@ exports.getAllFood = async (req, res) => {
       visibleBusinessIds,
       req.query,
       businessId,
-      { includeLocation: false }
+      { includeLocation: true }
     );
     if (scoped.empty) {
       return res.json(emptyListResponse(page));
@@ -633,7 +632,7 @@ exports.getAllFood = async (req, res) => {
 
     // Fetch foods with business info
 const foodItems = await Food.find(filters)
-  .select('title description price slug coverImage businessId')
+  .select('title description price slug coverImage businessId averageRating totalReviews')
   .populate({
     path: 'businessId',
     select: 'businessName phone email description badge logo', // <- include badge here
@@ -998,7 +997,7 @@ exports.getAllProducts = async (req, res) => {
       verified,
     } = req.query;
 
-    const filters = { isDeleted: false, isPublished: true };
+    const filters = { isDeleted: false, isPublished: true, ...PUBLIC_ACTIVE_LISTING_FILTER };
 
     if (search) {
       filters.$or = [
@@ -1008,9 +1007,6 @@ exports.getAllProducts = async (req, res) => {
     }
 
     if (minorityType) filters.minorityType = minorityType;
-    if (city) filters['address.city'] = { $regex: city, $options: 'i' };
-    if (state) filters['address.state'] = { $regex: state, $options: 'i' };
-    if (country) filters['address.country'] = { $regex: country, $options: 'i' };
 
     const visibleBusinessIds = await getVisibleBusinessIds();
     if (!visibleBusinessIds.length) {
@@ -1030,7 +1026,7 @@ exports.getAllProducts = async (req, res) => {
       visibleBusinessIds,
       req.query,
       businessId,
-      { includeLocation: false }
+      { includeLocation: true }
     );
     if (scoped.empty) {
       return res.json(emptyListResponse(page));
@@ -1136,7 +1132,7 @@ exports.getProductsByFilters = async (req, res) => {
       verified,
     } = req.query;
 
-    const filters = { isDeleted: false, isPublished: true };
+    const filters = { isDeleted: false, isPublished: true, ...PUBLIC_ACTIVE_LISTING_FILTER };
 
     // Category filtering - accept both slug and ID
     if (categoryId || categorySlug) {
@@ -1165,9 +1161,6 @@ exports.getProductsByFilters = async (req, res) => {
     }
 
     if (minorityType) filters.minorityType = minorityType;
-    if (city) filters['address.city'] = { $regex: city, $options: 'i' };
-    if (state) filters['address.state'] = { $regex: state, $options: 'i' };
-    if (country) filters['address.country'] = { $regex: country, $options: 'i' };
 
     const visibleBusinessIds = await getVisibleBusinessIds();
     if (!visibleBusinessIds.length) {
@@ -1290,6 +1283,7 @@ exports.getProductById = async (req, res) => {
       _id: productId,
       isPublished: true,
       isDeleted: false,
+      ...PUBLIC_ACTIVE_LISTING_FILTER,
     })
       .populate({
         path: "businessId",
@@ -1536,7 +1530,8 @@ exports.getProductsByBusinessId = async (req, res) => {
     const filters = { 
       businessId, 
       isDeleted: false, 
-      isPublished: true 
+      isPublished: true,
+      ...PUBLIC_ACTIVE_LISTING_FILTER,
     };
 
     let sortOption = { createdAt: -1 };
@@ -1650,14 +1645,17 @@ exports.searchPublicListings = async (req, res) => {
     const productFilter = {
       isDeleted: false,
       isPublished: true,
+      ...PUBLIC_ACTIVE_LISTING_FILTER,
       ...baseBusinessFilter,
     };
     const serviceFilter = {
       isPublished: true,
+      ...PUBLIC_ACTIVE_LISTING_FILTER,
       ...baseBusinessFilter,
     };
     const foodFilter = {
       isPublished: true,
+      ...PUBLIC_ACTIVE_LISTING_FILTER,
       ...baseBusinessFilter,
     };
 
@@ -1763,7 +1761,7 @@ exports.searchPublicListings = async (req, res) => {
     if (shouldIncludeListingType(parsed.listingType, 'food')) {
       queryJobs.push(
         Food.find(foodFilter)
-          .select('title description coverImage slug price businessId foodType brand categoryId')
+          .select('title description coverImage slug price businessId foodType brand categoryId averageRating totalReviews')
           .populate(businessPopulate)
           .sort({ createdAt: -1 })
           .skip(skip)

--- a/controllers/reviewController.js
+++ b/controllers/reviewController.js
@@ -92,14 +92,16 @@ exports.listReviews = (listingType) => async (req, res) => {
     const { page, limit } = parsePagination(req.query);
     const skip = (page - 1) * limit;
 
+    const visibleReviewFilter = { listingId, listingType, isHidden: { $ne: true } };
+
     const [reviews, total, summary] = await Promise.all([
-      Review.find({ listingId, listingType })
+      Review.find(visibleReviewFilter)
         .populate('userId', 'name profileImage')
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(limit)
         .lean(),
-      Review.countDocuments({ listingId, listingType }),
+      Review.countDocuments(visibleReviewFilter),
       getReviewSummary(listingId, listingType),
     ]);
 

--- a/controllers/serviceController.js
+++ b/controllers/serviceController.js
@@ -20,6 +20,7 @@ const {
   formatValidationErrorResponse,
 } = require('../lib/service/serviceContract');
 const { normalizeImages } = require('../lib/listing/publicListingDto');
+const { applyLeadConfigToDocument } = require('../utils/serviceLeadConfig');
 const { publicMarketplaceBusinessFilter } = require('../lib/marketplace/businessEligibility');
 const { hasActiveServiceBookings } = require('../utils/bookingDeleteGuards');
 const { S3Client } = require('@aws-sdk/client-s3');
@@ -143,6 +144,8 @@ exports.createParentService = async (req, res) => {
       location: location?.address || '',
       businessHours: normalizeBusinessHoursForStorage(businessHours || []),
       bookingToolLink: bookingToolLink || '',
+      externalLink: req.body.externalLink || bookingToolLink || '',
+      rfqEnabled: req.body.rfqEnabled === true || req.body.rfqEnabled === 'true',
 
       // Empty arrays for child services to be added later
       services: [],
@@ -295,6 +298,8 @@ exports.createService = async (req, res) => {
       subcategoryId: finalSubcategoryId,
       businessId,
       bookingToolLink: bookingToolLink || '',
+      externalLink: req.body.externalLink || bookingToolLink || '',
+      rfqEnabled: req.body.rfqEnabled === true || req.body.rfqEnabled === 'true',
       services: normalizedServices,
       coverImage: coverImage || '',
       images: images || [],
@@ -809,13 +814,22 @@ exports.updateService = async (req, res) => {
 
     const updatableFields = [
       'title', 'description', 'coverImage', 'images',
-      'bookingToolLink', 'maxBookingsPerSlot', 'location', 'contact', 'videos'
+      'bookingToolLink', 'externalLink', 'rfqEnabled', 'maxBookingsPerSlot', 'location', 'contact', 'videos'
     ];
 
     for (const field of updatableFields) {
       if (req.body[field] !== undefined) {
         service[field] = req.body[field];
       }
+    }
+
+    try {
+      applyLeadConfigToDocument(service, req.body);
+    } catch (leadConfigError) {
+      return res.status(leadConfigError.statusCode || 400).json({
+        success: false,
+        message: leadConfigError.message || 'Invalid service lead configuration',
+      });
     }
 
     if (req.body.amenities !== undefined) {
@@ -1059,6 +1073,8 @@ exports.getBusinessServiceById = async (req, res) => {
       location: service.location || '',
       businessHours: mappedBusinessHours,
       bookingToolLink: service.bookingToolLink || '',
+      externalLink: service.externalLink || service.bookingToolLink || '',
+      rfqEnabled: Boolean(service.rfqEnabled),
       features: Array.isArray(service.features) ? service.features : [],
       amenities: Array.isArray(service.amenities) ? service.amenities : [],
       faq: Array.isArray(service.faq) ? service.faq : [],

--- a/controllers/vendorOnboarding.controller.js
+++ b/controllers/vendorOnboarding.controller.js
@@ -1296,10 +1296,28 @@ exports.getStatusByApplicationId = async (req, res) => {
 
     // Stage 1 - Onboarding Status
     switch (onboarding.status) {
-      case 'draft':
-        status = 'Stage 1 - Draft (Not Submitted)';
-        nextAction = 'Submit application for review';
+      case 'draft': {
+        const paymentStatus = onboarding.verificationPayment?.status || 'not_started';
+        if (paymentStatus === 'paid') {
+          status = 'Stage 1 - Payment Complete (Not Submitted)';
+          nextAction = 'Submit your application for admin review';
+        } else {
+          status = 'Stage 1 - Draft (Not Submitted)';
+          nextAction = 'Complete your application and pay the verification fee';
+        }
         break;
+      }
+
+      case 'payment_pending': {
+        const paymentStatus = onboarding.verificationPayment?.status || 'pending';
+        status = 'Stage 1 - Payment Pending';
+        if (paymentStatus === 'failed') {
+          nextAction = 'Retry your verification payment to continue onboarding';
+        } else {
+          nextAction = 'Complete your verification payment to continue onboarding';
+        }
+        break;
+      }
 
       case 'submitted':
         status = 'Stage 1 - Under Admin Review';

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ require('./instrument');
 const app = require('./app');
 const connectDB = require('./config/Db');
 const { logReleaseIdentityAtStartup } = require('./utils/releaseIdentity');
+const { startOnboardingReminderScheduler } = require('./jobs/onboardingReminders');
 
 const PORT = process.env.PORT || 3001;
 
@@ -19,6 +20,7 @@ const startServer = async () => {
   try {
     await connectDB();
     logReleaseIdentityAtStartup();
+    startOnboardingReminderScheduler();
     app.listen(PORT, '0.0.0.0', () => {
       console.log(`Server running on port ${PORT}`);
     });

--- a/jobs/onboardingReminders.js
+++ b/jobs/onboardingReminders.js
@@ -1,0 +1,189 @@
+const cron = require('node-cron');
+const VendorOnboarding = require('../models/VendorOnboardingStage1');
+const { sendPaymentReminderEmail } = require('../utils/WellcomeMailer');
+const { deliverVendorOnboardingEmail } = require('../utils/vendorOnboardingEmailDelivery');
+
+const REMINDER_KINDS = Object.freeze({
+  PAYMENT_PENDING: 'payment_pending',
+  PAID_DRAFT_UNSUBMITTED: 'paid_draft_unsubmitted',
+});
+
+function getOnboardingReminderConfig() {
+  const minAgeHours = Number(process.env.ONBOARDING_REMINDER_MIN_AGE_HOURS);
+  const cooldownHours = Number(process.env.ONBOARDING_REMINDER_COOLDOWN_HOURS);
+  const batchLimit = Number(process.env.ONBOARDING_REMINDER_BATCH_LIMIT);
+
+  return {
+    enabled: process.env.ENABLE_ONBOARDING_REMINDERS !== 'false',
+    cronExpression: process.env.ONBOARDING_REMINDER_CRON || '0 9 * * *',
+    minAgeHours: Number.isFinite(minAgeHours) && minAgeHours > 0 ? minAgeHours : 24,
+    cooldownHours: Number.isFinite(cooldownHours) && cooldownHours > 0 ? cooldownHours : 72,
+    batchLimit: Number.isFinite(batchLimit) && batchLimit > 0 ? Math.floor(batchLimit) : 50,
+  };
+}
+
+function getStallCutoff(minAgeHours) {
+  return new Date(Date.now() - minAgeHours * 60 * 60 * 1000);
+}
+
+function wasRecentlyReminded(application, kind, cooldownHours) {
+  const cutoff = new Date(Date.now() - cooldownHours * 60 * 60 * 1000);
+  const log = Array.isArray(application.onboardingReminderLog)
+    ? application.onboardingReminderLog
+    : [];
+
+  return log.some(
+    (entry) =>
+      entry?.kind === kind
+      && entry?.deliveryStatus === 'sent'
+      && entry?.sentAt
+      && new Date(entry.sentAt) >= cutoff
+  );
+}
+
+async function appendReminderLog(application, { kind, delivery }) {
+  if (!Array.isArray(application.onboardingReminderLog)) {
+    application.onboardingReminderLog = [];
+  }
+
+  application.onboardingReminderLog.push({
+    kind,
+    sentAt: new Date(),
+    deliveryStatus: delivery.sent ? 'sent' : delivery.skipped ? 'skipped' : 'failed',
+    messageId: delivery.messageId,
+    error: delivery.error || delivery.reason,
+  });
+
+  await application.save();
+}
+
+async function dispatchReminder(application, kind) {
+  const vendorEmail = application.userId?.email;
+
+  if (!vendorEmail) {
+    console.warn(
+      `Onboarding reminder skipped (${kind}): missing vendor email for application ${application.applicationId}`
+    );
+    return {
+      sent: false,
+      skipped: false,
+      error: 'vendor_email_missing',
+    };
+  }
+
+  const delivery = await deliverVendorOnboardingEmail({
+    label: `onboarding_reminder_${kind}`,
+    send: () => sendPaymentReminderEmail({
+      to: vendorEmail,
+      vendorName: application.userId?.name,
+      businessName: application.businessName,
+      applicationId: application.applicationId,
+      reminderKind: kind,
+    }),
+  });
+
+  await appendReminderLog(application, { kind, delivery });
+  return delivery;
+}
+
+async function runOnboardingReminderBatch() {
+  const config = getOnboardingReminderConfig();
+
+  if (!config.enabled) {
+    return { enabled: false, processed: 0, results: [] };
+  }
+
+  const stallCutoff = getStallCutoff(config.minAgeHours);
+  const results = [];
+  let processed = 0;
+
+  const paymentPendingCandidates = await VendorOnboarding.find({
+    status: 'payment_pending',
+    updatedAt: { $lte: stallCutoff },
+    'verificationPayment.status': { $in: ['pending', 'failed', 'not_started'] },
+  })
+    .populate('userId', 'name email')
+    .limit(config.batchLimit)
+    .exec();
+
+  for (const application of paymentPendingCandidates) {
+    if (wasRecentlyReminded(application, REMINDER_KINDS.PAYMENT_PENDING, config.cooldownHours)) {
+      continue;
+    }
+
+    const delivery = await dispatchReminder(application, REMINDER_KINDS.PAYMENT_PENDING);
+    results.push({
+      applicationId: application.applicationId,
+      kind: REMINDER_KINDS.PAYMENT_PENDING,
+      ...delivery,
+    });
+    processed += 1;
+  }
+
+  const remainingBatch = Math.max(config.batchLimit - processed, 0);
+  if (remainingBatch > 0) {
+    const paidDraftCandidates = await VendorOnboarding.find({
+      status: 'draft',
+      updatedAt: { $lte: stallCutoff },
+      'verificationPayment.status': 'paid',
+      $or: [{ submittedAt: { $exists: false } }, { submittedAt: null }],
+    })
+      .populate('userId', 'name email')
+      .limit(remainingBatch)
+      .exec();
+
+    for (const application of paidDraftCandidates) {
+      if (wasRecentlyReminded(application, REMINDER_KINDS.PAID_DRAFT_UNSUBMITTED, config.cooldownHours)) {
+        continue;
+      }
+
+      const delivery = await dispatchReminder(
+        application,
+        REMINDER_KINDS.PAID_DRAFT_UNSUBMITTED
+      );
+      results.push({
+        applicationId: application.applicationId,
+        kind: REMINDER_KINDS.PAID_DRAFT_UNSUBMITTED,
+        ...delivery,
+      });
+      processed += 1;
+    }
+  }
+
+  console.log(`Onboarding reminder batch complete: processed=${processed}`);
+  return { enabled: true, processed, results };
+}
+
+function startOnboardingReminderScheduler() {
+  const config = getOnboardingReminderConfig();
+
+  if (!config.enabled) {
+    console.log('Onboarding reminder scheduler disabled (ENABLE_ONBOARDING_REMINDERS=false)');
+    return null;
+  }
+
+  if (!cron.validate(config.cronExpression)) {
+    console.error(`Invalid ONBOARDING_REMINDER_CRON expression: ${config.cronExpression}`);
+    return null;
+  }
+
+  const task = cron.schedule(config.cronExpression, async () => {
+    try {
+      await runOnboardingReminderBatch();
+    } catch (error) {
+      const message = error && error.message ? error.message : 'Unknown onboarding reminder error';
+      console.error('Onboarding reminder batch failed:', message);
+    }
+  });
+
+  console.log(`Onboarding reminder scheduler started (cron: ${config.cronExpression})`);
+  return task;
+}
+
+module.exports = {
+  REMINDER_KINDS,
+  getOnboardingReminderConfig,
+  runOnboardingReminderBatch,
+  startOnboardingReminderScheduler,
+  wasRecentlyReminded,
+};

--- a/lib/admin/businessTags.js
+++ b/lib/admin/businessTags.js
@@ -1,0 +1,34 @@
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 50;
+
+function normalizeBusinessTags(input) {
+  const rawList = Array.isArray(input)
+    ? input
+    : typeof input === 'string'
+      ? input.split(',')
+      : [];
+
+  const seen = new Set();
+  const tags = [];
+
+  for (const item of rawList) {
+    const value = String(item ?? '').trim();
+    if (!value) continue;
+
+    const clipped = value.slice(0, MAX_TAG_LENGTH);
+    const key = clipped.toLowerCase();
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    tags.push(clipped);
+    if (tags.length >= MAX_TAGS) break;
+  }
+
+  return tags;
+}
+
+module.exports = {
+  MAX_TAGS,
+  MAX_TAG_LENGTH,
+  normalizeBusinessTags,
+};

--- a/lib/admin/catalogAudit.js
+++ b/lib/admin/catalogAudit.js
@@ -1,0 +1,115 @@
+const {
+  productHasPublishablePrice,
+  serviceHasPublishablePrice,
+  foodHasPublishablePrice,
+  parseListingPrice,
+} = require('../marketplace/listingPricePolicy');
+
+const PLACEHOLDER_TITLES = new Set(['product', 'service', 'food']);
+const MIN_DESCRIPTION_LENGTH = 10;
+
+const CATALOG_AUDIT_FLAGS = Object.freeze([
+  'missing_description',
+  'missing_image',
+  'missing_price',
+  'suspicious_title',
+  'published_incomplete',
+]);
+
+function isBlankImage(value) {
+  const url = String(value || '').trim();
+  if (!url) return true;
+  if (url === 'null' || url === 'undefined') return true;
+  return /^https?:\/\/via\.placeholder\.com/i.test(url);
+}
+
+function hasSuspiciousTitle(title, listingType) {
+  const normalized = String(title || '').trim();
+  if (normalized.length < 3) return true;
+  if (PLACEHOLDER_TITLES.has(normalized.toLowerCase())) return true;
+  if (listingType && normalized.toLowerCase() === String(listingType).toLowerCase()) return true;
+  return false;
+}
+
+function evaluateCatalogListingFlags(listing, listingType, options = {}) {
+  const flags = [];
+  const description = String(listing?.description || '').trim();
+
+  if (description.length < MIN_DESCRIPTION_LENGTH) {
+    flags.push('missing_description');
+  }
+
+  if (isBlankImage(listing?.coverImage)) {
+    flags.push('missing_image');
+  }
+
+  if (listingType === 'product') {
+    if (!productHasPublishablePrice({
+      ...listing,
+      variants: options.variants || [],
+    })) {
+      flags.push('missing_price');
+    }
+  } else if (listingType === 'service') {
+    if (!serviceHasPublishablePrice(listing)) {
+      flags.push('missing_price');
+    }
+  } else if (listingType === 'food') {
+    if (!foodHasPublishablePrice(listing)) {
+      flags.push('missing_price');
+    }
+  }
+
+  if (hasSuspiciousTitle(listing?.title, listingType)) {
+    flags.push('suspicious_title');
+  }
+
+  if (listing?.isPublished === true && flags.length > 0) {
+    flags.push('published_incomplete');
+  }
+
+  return flags;
+}
+
+function severityFromFlags(flags = []) {
+  if (flags.includes('published_incomplete')) return 'high';
+  if (flags.includes('missing_price') || flags.includes('missing_image')) return 'medium';
+  if (flags.length) return 'low';
+  return 'none';
+}
+
+function matchesRequestedFlags(flags, requestedFlags = []) {
+  if (!requestedFlags.length) return flags.length > 0;
+  return requestedFlags.some((flag) => flags.includes(flag));
+}
+
+function buildAuditItem(listing, listingType, options = {}) {
+  const flags = evaluateCatalogListingFlags(listing, listingType, options);
+  const business = listing.businessId;
+
+  return {
+    listingType,
+    id: String(listing._id),
+    title: listing.title || '',
+    description: listing.description || '',
+    coverImage: listing.coverImage || '',
+    price: parseListingPrice(listing?.price),
+    isPublished: Boolean(listing.isPublished),
+    isActive: listing.isActive !== false,
+    businessId: business?._id ? String(business._id) : listing.businessId ? String(listing.businessId) : null,
+    businessName: business?.businessName || business?.name || null,
+    flags,
+    severity: severityFromFlags(flags),
+    createdAt: listing.createdAt,
+    updatedAt: listing.updatedAt,
+  };
+}
+
+module.exports = {
+  CATALOG_AUDIT_FLAGS,
+  MIN_DESCRIPTION_LENGTH,
+  evaluateCatalogListingFlags,
+  severityFromFlags,
+  matchesRequestedFlags,
+  buildAuditItem,
+};

--- a/lib/listing/publicListingDto.js
+++ b/lib/listing/publicListingDto.js
@@ -23,6 +23,8 @@ const CARD_LEGACY_FIELDS = [
   'ownerId',
   'businessHours',
   'bookingToolLink',
+  'externalLink',
+  'rfqEnabled',
   'location',
   'features',
   'amenities',

--- a/models/Food.js
+++ b/models/Food.js
@@ -129,6 +129,21 @@ location: {
       type: Boolean,
       default: false,
     },
+    isActive: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
+    adminRemark: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    adminModeratedAt: Date,
+    adminModeratedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+    },
     totalReviews: {
       type: Number,
       default: 0,

--- a/models/Product.js
+++ b/models/Product.js
@@ -136,8 +136,25 @@ const productSchema = new mongoose.Schema({
   isPublished: { type: Boolean, default: false },
   isFeatured: { type: Boolean, default: false },
   isDeleted: { type: Boolean, default: false },
+  isActive: {
+    type: Boolean,
+    default: true,
+    index: true,
+  },
+  adminRemark: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  adminModeratedAt: Date,
+  adminModeratedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+  },
 
 }, { timestamps: true });
+
+productSchema.index({ isActive: 1, isPublished: 1, isDeleted: 1, createdAt: -1 });
 
 productSchema.index({ isFeatured: 1, isPublished: 1, isDeleted: 1, createdAt: -1 });
 productSchema.index({ businessId: 1, isPublished: 1, isDeleted: 1 });

--- a/models/Review.js
+++ b/models/Review.js
@@ -28,6 +28,13 @@ const reviewSchema = new mongoose.Schema({
   image: {
     type: String,  // Optional image URL if the user provides a review image
   },
+  isHidden: {
+    type: Boolean,
+    default: false,
+  },
+  moderatedAt: {
+    type: Date,
+  },
 }, { timestamps: true });
 
 reviewSchema.index(

--- a/models/Service.js
+++ b/models/Service.js
@@ -89,6 +89,21 @@ const serviceSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  isActive: {
+    type: Boolean,
+    default: true,
+    index: true,
+  },
+  adminRemark: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  adminModeratedAt: Date,
+  adminModeratedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+  },
   coverImage: {
     type: String,
   },
@@ -110,6 +125,22 @@ const serviceSchema = new mongoose.Schema({
       },
       message: 'Please enter a valid URL (must start with http or https).'
     }
+  },
+  externalLink: {
+    type: String,
+    trim: true,
+    default: '',
+    validate: {
+      validator: function (v) {
+        if (!v) return true;
+        return /^https?:\/\/.+\..+/.test(v);
+      },
+      message: 'Please enter a valid external link (must start with http or https).'
+    }
+  },
+  rfqEnabled: {
+    type: Boolean,
+    default: false,
   },
   videos: {
     type: [String],

--- a/models/ServiceRfq.js
+++ b/models/ServiceRfq.js
@@ -1,0 +1,80 @@
+const mongoose = require('mongoose');
+
+const serviceRfqSchema = new mongoose.Schema(
+  {
+    serviceId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Service',
+      required: true,
+      index: true,
+    },
+    businessId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Business',
+      required: true,
+      index: true,
+    },
+    vendorId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    customerId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      index: true,
+    },
+    customerName: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    customerEmail: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    customerPhone: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    message: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    requestedServices: {
+      type: [String],
+      default: [],
+    },
+    budget: {
+      type: String,
+      trim: true,
+      default: '',
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'viewed', 'responded', 'closed'],
+      default: 'pending',
+      index: true,
+    },
+    source: {
+      type: String,
+      trim: true,
+      default: 'service_rfq',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+serviceRfqSchema.index({ businessId: 1, createdAt: -1 });
+serviceRfqSchema.index({ vendorId: 1, createdAt: -1 });
+
+module.exports =
+  mongoose.models.ServiceRfq ||
+  mongoose.model('ServiceRfq', serviceRfqSchema);

--- a/models/VendorOnboardingStage1.js
+++ b/models/VendorOnboardingStage1.js
@@ -190,6 +190,25 @@ const VendorOnboardingStage1Schema = new mongoose.Schema(
 
     profileCompletionNotifiedAt: Date,
 
+    onboardingReminderLog: [
+      {
+        kind: {
+          type: String,
+          enum: ['payment_pending', 'paid_draft_unsubmitted'],
+        },
+        sentAt: {
+          type: Date,
+          default: Date.now,
+        },
+        deliveryStatus: {
+          type: String,
+          enum: ['sent', 'skipped', 'failed'],
+        },
+        messageId: String,
+        error: String,
+      },
+    ],
+
     verificationNotificationLog: [
       {
         event: String,

--- a/routes/admin/adminCatalogRoutes.js
+++ b/routes/admin/adminCatalogRoutes.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const authenticate = require('../../middlewares/authenticate');
+const isAdmin = require('../../middlewares/isAdmin');
+const {
+  listCatalog,
+  getCatalogItem,
+  updateCatalogItem,
+  patchCatalogActive,
+  deleteCatalogItem,
+  auditCatalog,
+} = require('../../controllers/admin/adminCatalog.controller');
+
+const router = express.Router();
+
+router.get('/audit', authenticate, isAdmin, auditCatalog);
+router.get('/:type/:id', authenticate, isAdmin, getCatalogItem);
+router.put('/:type/:id', authenticate, isAdmin, updateCatalogItem);
+router.patch('/:type/:id/active', authenticate, isAdmin, patchCatalogActive);
+router.delete('/:type/:id', authenticate, isAdmin, deleteCatalogItem);
+router.get('/', authenticate, isAdmin, listCatalog);
+
+module.exports = router;

--- a/routes/admin/adminReviewRoutes.js
+++ b/routes/admin/adminReviewRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const authenticate = require('../../middlewares/authenticate');
+const isAdmin = require('../../middlewares/isAdmin');
+const {
+  listAllPlatformReviews,
+  toggleReviewVisibility,
+  removePlatformReview,
+} = require('../../controllers/admin/adminReviewController');
+
+const router = express.Router();
+
+router.use(authenticate, isAdmin);
+
+router.get('/', listAllPlatformReviews);
+router.patch('/:reviewId/moderation', toggleReviewVisibility);
+router.delete('/:reviewId', removePlatformReview);
+
+module.exports = router;

--- a/routes/admin/businessRoutes.js
+++ b/routes/admin/businessRoutes.js
@@ -23,4 +23,25 @@ router.patch(
   businessController.patchBusinessActivationStatus
 );
 
+router.put(
+  "/:id/tags",
+  authenticate,
+  isAdmin,
+  businessController.updateBusinessTags
+);
+
+router.patch(
+  "/:id/featured",
+  authenticate,
+  isAdmin,
+  businessController.updateBusinessFeatured
+);
+
+router.put(
+  "/:id",
+  authenticate,
+  isAdmin,
+  businessController.updateBusinessProfile
+);
+
 module.exports = router;

--- a/routes/enquiryRoutes.js
+++ b/routes/enquiryRoutes.js
@@ -7,10 +7,14 @@ const isCustomer = require('../middlewares/isCustomer');
 const isBusinessOwner = require('../middlewares/isBusinessOwner');
 const {
   createRevealEnquiry,
+  createServiceRfq,
   getVendorEnquiries,
+  getVendorRfqs,
 } = require('../controllers/customer/enquiry');
 
 router.post('/reveal', authenticate, createRevealEnquiry);
+router.post('/rfq', authenticate, isCustomer, createServiceRfq);
 router.get('/vendor', authenticate, isBusinessOwner, getVendorEnquiries);
+router.get('/vendor/rfqs', authenticate, isBusinessOwner, getVendorRfqs);
 
 module.exports = router;

--- a/services/reviewService.js
+++ b/services/reviewService.js
@@ -23,6 +23,7 @@ const getReviewSummary = async (listingId, listingType) => {
       $match: {
         listingId: normalizedListingId,
         listingType,
+        isHidden: { $ne: true },
       },
     },
     {

--- a/tests/admin/admin-catalog-routes-guard.test.js
+++ b/tests/admin/admin-catalog-routes-guard.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const adminCatalogRoutesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminCatalogRoutes.js'
+);
+
+test('admin catalog routes remain guarded', () => {
+  const source = fs.readFileSync(adminCatalogRoutesPath, 'utf8');
+
+  assert.match(source, /router\.get\('\/audit', authenticate, isAdmin, auditCatalog\)/);
+  assert.match(source, /router\.get\('\/', authenticate, isAdmin, listCatalog\)/);
+  assert.match(source, /router\.get\('\/:type\/:id', authenticate, isAdmin, getCatalogItem\)/);
+  assert.match(source, /router\.put\('\/:type\/:id', authenticate, isAdmin, updateCatalogItem\)/);
+  assert.match(source, /router\.patch\('\/:type\/:id\/active', authenticate, isAdmin, patchCatalogActive\)/);
+  assert.match(source, /router\.delete\('\/:type\/:id', authenticate, isAdmin, deleteCatalogItem\)/);
+});
+
+test('admin catalog routes register expected handlers only', () => {
+  const source = fs.readFileSync(adminCatalogRoutesPath, 'utf8');
+  const routeMatches = [...source.matchAll(/router\.(get|post|put|patch|delete)\(/g)];
+
+  assert.equal(routeMatches.length, 6);
+});

--- a/tests/admin/admin-order-summary.test.js
+++ b/tests/admin/admin-order-summary.test.js
@@ -44,8 +44,9 @@ function makeRes() {
   };
 }
 
-test('getAdminSalesSummary returns sales and vendor totals without platform fee invention', async () => {
+test('getAdminSalesSummary returns sales, vendor totals, and platform commission', async () => {
   const vendorId = '507f1f77bcf86cd799439011';
+  const businessId = '507f1f77bcf86cd799439012';
   const { controller, pipelines } = loadOrderController({
     aggregateResponses: [
       [
@@ -60,7 +61,25 @@ test('getAdminSalesSummary returns sales and vendor totals without platform fee 
           shippingAmount: 1300,
         },
       ],
-      [{ vendorId, currency: 'USD', orderCount: 2, totalSalesAmount: 9000 }],
+      [
+        {
+          vendorId,
+          businessId,
+          vendorName: 'Vendor User',
+          businessName: 'Test Vendor LLC',
+          currency: 'USD',
+          orderCount: 2,
+          totalSalesAmount: 9000,
+        },
+      ],
+      [
+        {
+          currency: 'USD',
+          paidOrderCount: 2,
+          paidSalesBase: 9000,
+          commissionAmount: 900,
+        },
+      ],
       [{ _id: 'paid', count: 2 }],
       [{ _id: 'ordered', count: 2 }],
     ],
@@ -94,21 +113,47 @@ test('getAdminSalesSummary returns sales and vendor totals without platform fee 
   assert.deepEqual(res.body.data.topVendors, [
     {
       vendorId,
+      businessId,
+      vendorName: 'Vendor User',
+      businessName: 'Test Vendor LLC',
       currency: 'USD',
       orderCount: 2,
       totalSalesAmount: 9000,
     },
   ]);
   assert.deepEqual(res.body.data.platformRevenue, {
-    supported: false,
-    amount: null,
-    reason: 'Order records do not persist platform fee amounts yet.',
+    supported: true,
+    feePercent: 10,
+    feeRate: 0.1,
+    basis: 'paid_order_total_amount',
+    description: '10% platform commission on paid order totals',
+    byCurrency: [
+      {
+        currency: 'USD',
+        paidOrderCount: 2,
+        paidSalesBase: 9000,
+        commissionAmount: 900,
+      },
+    ],
   });
   assert.equal(res.body.data.summary.payment.paid, 2);
   assert.equal(res.body.data.summary.payment.pending, 0);
   assert.equal(res.body.data.summary.status.ordered, 2);
   assert.equal(pipelines[0][0].$match.paymentStatus, 'paid');
   assert.ok(pipelines[0][0].$match.createdAt.$gte instanceof Date);
+
+  const vendorPipeline = pipelines[1];
+  assert.equal(vendorPipeline[1].$group._id.vendorId, '$vendorId');
+  assert.equal(vendorPipeline[1].$group._id.businessId, '$businessId');
+  assert.equal(vendorPipeline[3].$lookup.from, 'users');
+  assert.equal(vendorPipeline[4].$lookup.from, 'businesses');
+
+  const platformPipeline = pipelines[2];
+  assert.equal(platformPipeline[0].$match.paymentStatus, 'paid');
+  assert.equal(
+    platformPipeline[1].$group.commissionAmount.$sum.$multiply[1],
+    0.1
+  );
 });
 
 test('getAdminSalesSummary omits paid top vendors for non-paid payment filters', async () => {
@@ -128,6 +173,14 @@ test('getAdminSalesSummary omits paid top vendors for non-paid payment filters',
 
   assert.equal(res.statusCode, 200);
   assert.deepEqual(res.body.data.topVendors, []);
+  assert.deepEqual(res.body.data.platformRevenue, {
+    supported: true,
+    feePercent: 10,
+    feeRate: 0.1,
+    basis: 'paid_order_total_amount',
+    description: '10% platform commission on paid order totals',
+    byCurrency: [],
+  });
   assert.equal(pipelines.length, 3);
   assert.equal(pipelines[0][0].$match.paymentStatus, 'refunded');
 });

--- a/tests/admin/admin-review-management.test.js
+++ b/tests/admin/admin-review-management.test.js
@@ -1,0 +1,454 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('node:module');
+
+const controllerPath = path.resolve(
+  __dirname,
+  '../../controllers/admin/adminReviewController.js'
+);
+const reviewControllerPath = path.resolve(
+  __dirname,
+  '../../controllers/reviewController.js'
+);
+const routesPath = path.resolve(
+  __dirname,
+  '../../routes/admin/adminReviewRoutes.js'
+);
+const appPath = path.resolve(__dirname, '../../app.js');
+
+const validReviewId = '507f1f77bcf86cd799439011';
+const validListingId = '507f1f77bcf86cd799439012';
+const validUserId = '507f1f77bcf86cd799439013';
+const validBusinessId = '507f1f77bcf86cd799439014';
+
+const makeRes = () => ({
+  statusCode: null,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const makeReviewFindChain = (reviews) => ({
+  sort() {
+    return this;
+  },
+  skip() {
+    return this;
+  },
+  limit() {
+    return this;
+  },
+  lean: async () => reviews,
+});
+
+const loadAdminReviewController = (overrides = {}) => {
+  const Review = overrides.Review || {
+    find: () => makeReviewFindChain([]),
+    countDocuments: async () => 0,
+    findById: async () => null,
+  };
+  const User = overrides.User || {
+    find: () => ({
+      select: () => ({
+        lean: async () => [],
+      }),
+    }),
+  };
+  const Business = overrides.Business || {
+    find: () => ({
+      select: () => ({
+        lean: async () => [],
+      }),
+    }),
+  };
+  const reviewService = {
+    LISTING_MODELS: overrides.LISTING_MODELS || {
+      product: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [],
+          }),
+        }),
+      },
+      service: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [],
+          }),
+        }),
+      },
+      food: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [],
+          }),
+        }),
+      },
+    },
+    refreshListingReviewStats: overrides.refreshListingReviewStats || (async () => ({
+      totalReviews: 0,
+      averageRating: 0,
+      ratingBreakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 },
+    })),
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request.endsWith('models/Review')) return Review;
+    if (request.endsWith('models/User')) return User;
+    if (request.endsWith('models/Business')) return Business;
+    if (request.endsWith('services/reviewService')) return reviewService;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[controllerPath];
+  const controller = require(controllerPath);
+  Module._load = originalLoad;
+  return controller;
+};
+
+test('admin review routes are guarded and mapped correctly', () => {
+  const routesSource = fs.readFileSync(routesPath, 'utf8');
+  const appSource = fs.readFileSync(appPath, 'utf8');
+
+  assert.match(routesSource, /router\.use\(authenticate, isAdmin\)/);
+  assert.match(routesSource, /router\.get\('\/', listAllPlatformReviews\)/);
+  assert.match(
+    routesSource,
+    /router\.patch\('\/:reviewId\/moderation', toggleReviewVisibility\)/
+  );
+  assert.match(routesSource, /router\.delete\('\/:reviewId', removePlatformReview\)/);
+  assert.match(appSource, /app\.use\('\/api\/admin\/reviews', adminReviewRoutes\)/);
+});
+
+test('listAllPlatformReviews returns enriched user, listing, and business data', async () => {
+  const review = {
+    _id: validReviewId,
+    userId: validUserId,
+    listingId: validListingId,
+    listingType: 'product',
+    rating: 5,
+    comment: 'Excellent quality.',
+    image: '',
+    isHidden: false,
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-02T00:00:00.000Z'),
+  };
+
+  const controller = loadAdminReviewController({
+    Review: {
+      find: () => makeReviewFindChain([review]),
+      countDocuments: async () => 1,
+    },
+    User: {
+      find: () => ({
+        select: () => ({
+          lean: async () => [
+            {
+              _id: validUserId,
+              name: 'Platform Customer',
+              email: 'customer@example.test',
+              profileImage: 'https://example.test/avatar.png',
+            },
+          ],
+        }),
+      }),
+    },
+    LISTING_MODELS: {
+      product: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [
+              {
+                _id: validListingId,
+                title: 'Handmade Candle',
+                slug: 'handmade-candle',
+                businessId: validBusinessId,
+                coverImage: 'https://example.test/candle.jpg',
+                isDeleted: false,
+              },
+            ],
+          }),
+        }),
+      },
+      service: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [],
+          }),
+        }),
+      },
+      food: {
+        find: () => ({
+          select: () => ({
+            lean: async () => [],
+          }),
+        }),
+      },
+    },
+    Business: {
+      find: () => ({
+        select: () => ({
+          lean: async () => [
+            {
+              _id: validBusinessId,
+              businessName: 'Artisan Vendor',
+              slug: 'artisan-vendor',
+              logo: 'https://example.test/logo.png',
+            },
+          ],
+        }),
+      }),
+    },
+  });
+
+  const res = makeRes();
+  await controller.listAllPlatformReviews({ query: { page: '1', limit: '25' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.reviews.length, 1);
+
+  const record = res.body.data.reviews[0];
+  assert.equal(record._id, validReviewId);
+  assert.equal(record.user.email, 'customer@example.test');
+  assert.equal(record.listing.title, 'Handmade Candle');
+  assert.equal(record.listing.listingType, 'product');
+  assert.equal(record.business.businessName, 'Artisan Vendor');
+  assert.equal(record.business._id, validBusinessId);
+});
+
+test('listAllPlatformReviews supports listingType and isHidden filters', async () => {
+  let capturedFilter;
+
+  const controller = loadAdminReviewController({
+    Review: {
+      find: (filter) => {
+        capturedFilter = filter;
+        return makeReviewFindChain([]);
+      },
+      countDocuments: async () => 0,
+    },
+  });
+
+  const res = makeRes();
+  await controller.listAllPlatformReviews(
+    { query: { listingType: 'service', isHidden: 'true', page: '2', limit: '10' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(capturedFilter.listingType, 'service');
+  assert.equal(capturedFilter.isHidden, true);
+});
+
+test('toggleReviewVisibility flips isHidden, sets moderatedAt, and refreshes listing stats', async () => {
+  let refreshArgs;
+  const reviewDoc = {
+    _id: validReviewId,
+    listingId: validListingId,
+    listingType: 'product',
+    isHidden: false,
+    moderatedAt: null,
+    save: async function save() {
+      this.saved = true;
+    },
+  };
+
+  const controller = loadAdminReviewController({
+    Review: {
+      findById: async () => reviewDoc,
+    },
+    refreshListingReviewStats: async (listingId, listingType) => {
+      refreshArgs = { listingId, listingType };
+      return {
+        totalReviews: 2,
+        averageRating: 4.5,
+        ratingBreakdown: { 5: 1, 4: 1, 3: 0, 2: 0, 1: 0 },
+      };
+    },
+  });
+
+  const res = makeRes();
+  await controller.toggleReviewVisibility({ params: { reviewId: validReviewId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.review.isHidden, true);
+  assert.ok(res.body.data.review.moderatedAt);
+  assert.equal(reviewDoc.saved, true);
+  assert.deepEqual(refreshArgs, {
+    listingId: validListingId,
+    listingType: 'product',
+  });
+  assert.equal(res.body.data.summary.totalReviews, 2);
+});
+
+test('toggleReviewVisibility restores a hidden review when toggled again', async () => {
+  const reviewDoc = {
+    _id: validReviewId,
+    listingId: validListingId,
+    listingType: 'food',
+    isHidden: true,
+    moderatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    save: async function save() {
+      this.saved = true;
+    },
+  };
+
+  const controller = loadAdminReviewController({
+    Review: {
+      findById: async () => reviewDoc,
+    },
+  });
+
+  const res = makeRes();
+  await controller.toggleReviewVisibility({ params: { reviewId: validReviewId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.review.isHidden, false);
+  assert.match(res.body.message, /restored/i);
+});
+
+test('removePlatformReview permanently deletes a review and refreshes listing stats', async () => {
+  let refreshArgs;
+  let deleted;
+  const reviewDoc = {
+    _id: validReviewId,
+    listingId: validListingId,
+    listingType: 'service',
+    deleteOne: async function deleteOne() {
+      deleted = true;
+    },
+  };
+
+  const controller = loadAdminReviewController({
+    Review: {
+      findById: async () => reviewDoc,
+    },
+    refreshListingReviewStats: async (listingId, listingType) => {
+      refreshArgs = { listingId, listingType };
+      return {
+        totalReviews: 0,
+        averageRating: 0,
+        ratingBreakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 },
+      };
+    },
+  });
+
+  const res = makeRes();
+  await controller.removePlatformReview({ params: { reviewId: validReviewId } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(deleted, true);
+  assert.equal(res.body.data.reviewId, validReviewId);
+  assert.deepEqual(refreshArgs, {
+    listingId: validListingId,
+    listingType: 'service',
+  });
+  assert.equal(res.body.data.summary.totalReviews, 0);
+});
+
+test('listReviews excludes hidden reviews from public listing queries', async () => {
+  let capturedFilter;
+  const Review = {
+    find: (filter) => {
+      capturedFilter = filter;
+      return {
+        populate() {
+          return {
+            sort() {
+              return {
+                skip() {
+                  return {
+                    limit() {
+                      return {
+                        lean: async () => [],
+                      };
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    countDocuments: async () => 0,
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Review') return Review;
+    if (request === '../services/reviewService') {
+      return {
+        LISTING_MODELS: {
+          product: {
+            findById: () => ({
+              select: () => ({
+                lean: async () => ({ _id: validListingId, isDeleted: false }),
+              }),
+            }),
+          },
+        },
+        getReviewSummary: async () => ({
+          totalReviews: 0,
+          averageRating: 0,
+          ratingBreakdown: { 5: 0, 4: 0, 3: 0, 2: 0, 1: 0 },
+        }),
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[reviewControllerPath];
+  const { listReviews } = require(reviewControllerPath);
+  Module._load = originalLoad;
+
+  const res = makeRes();
+  await listReviews('product')(
+    { params: { productId: validListingId }, query: { page: '1', limit: '10' } },
+    res
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(capturedFilter, {
+    listingId: validListingId,
+    listingType: 'product',
+    isHidden: { $ne: true },
+  });
+});
+
+test('getReviewSummary aggregate excludes hidden reviews from listing stats', async () => {
+  let capturedPipeline;
+  const Review = {
+    aggregate: async (pipeline) => {
+      capturedPipeline = pipeline;
+      return [{ totalReviews: 1, averageRating: 5 }];
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === '../models/Review') return Review;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const servicePath = path.resolve(__dirname, '../../services/reviewService.js');
+  delete require.cache[servicePath];
+  const { getReviewSummary } = require(servicePath);
+  Module._load = originalLoad;
+
+  await getReviewSummary(validListingId, 'product');
+
+  assert.equal(capturedPipeline[0].$match.isHidden.$ne, true);
+});

--- a/tests/admin/business-featured.test.js
+++ b/tests/admin/business-featured.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('admin business routes guard featured update endpoint', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../routes/admin/businessRoutes.js'),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /router\.patch\(\s*['"]\/:id\/featured['"],\s*authenticate,\s*isAdmin,\s*businessController\.updateBusinessFeatured\s*\)/
+  );
+});
+
+test('public business listing supports featured=true query filter', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../controllers/businessController.js'),
+    'utf8'
+  );
+
+  assert.match(source, /featured/);
+  assert.match(source, /filters\.isFeatured\s*=\s*true/);
+});
+
+test('action registry includes business feature audit codes', () => {
+  const { ADMIN_AUDIT_ACTIONS } = require('../../utils/audit/actionRegistry');
+
+  assert.equal(ADMIN_AUDIT_ACTIONS.BUSINESS_FEATURE, 'business.feature');
+  assert.equal(ADMIN_AUDIT_ACTIONS.BUSINESS_UNFEATURE, 'business.unfeature');
+});

--- a/tests/admin/business-tags.test.js
+++ b/tests/admin/business-tags.test.js
@@ -1,0 +1,41 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { normalizeBusinessTags } = require('../../lib/admin/businessTags');
+
+test('normalizeBusinessTags trims, dedupes case-insensitively, and caps count', () => {
+  assert.deepEqual(
+    normalizeBusinessTags([' Organic ', 'organic', 'Local', '', '  ']),
+    ['Organic', 'Local']
+  );
+});
+
+test('normalizeBusinessTags accepts comma-separated strings', () => {
+  assert.deepEqual(normalizeBusinessTags('Atlanta, Minority-Owned ,Atlanta'), [
+    'Atlanta',
+    'Minority-Owned',
+  ]);
+});
+
+test('normalizeBusinessTags clips long tag values', () => {
+  const longTag = 'a'.repeat(80);
+  const [result] = normalizeBusinessTags([longTag]);
+  assert.equal(result.length, 50);
+});
+
+test('admin business routes guard tag update endpoint', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../routes/admin/businessRoutes.js'),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /router\.put\(\s*['"]\/:id\/tags['"],\s*authenticate,\s*isAdmin,\s*businessController\.updateBusinessTags\s*\)/
+  );
+  assert.match(
+    source,
+    /router\.put\(\s*['"]\/:id['"],\s*authenticate,\s*isAdmin,\s*businessController\.updateBusinessProfile\s*\)/
+  );
+});

--- a/tests/admin/catalog-audit.test.js
+++ b/tests/admin/catalog-audit.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  evaluateCatalogListingFlags,
+  buildAuditItem,
+  matchesRequestedFlags,
+} = require('../../lib/admin/catalogAudit');
+
+test('evaluateCatalogListingFlags marks published listing without price and image', () => {
+  const flags = evaluateCatalogListingFlags(
+    {
+      title: 'Product',
+      description: '',
+      coverImage: '',
+      price: null,
+      isPublished: true,
+    },
+    'product',
+    { variants: [] }
+  );
+
+  assert.ok(flags.includes('missing_description'));
+  assert.ok(flags.includes('missing_image'));
+  assert.ok(flags.includes('missing_price'));
+  assert.ok(flags.includes('suspicious_title'));
+  assert.ok(flags.includes('published_incomplete'));
+});
+
+test('evaluateCatalogListingFlags passes complete published product', () => {
+  const flags = evaluateCatalogListingFlags(
+    {
+      title: 'Handmade Candle',
+      description: 'A long enough product description for marketplace display.',
+      coverImage: 'https://cdn.example.com/candle.jpg',
+      price: 24.5,
+      isPublished: true,
+    },
+    'product',
+    { variants: [] }
+  );
+
+  assert.deepEqual(flags, []);
+});
+
+test('buildAuditItem includes business and severity metadata', () => {
+  const item = buildAuditItem(
+    {
+      _id: '507f1f77bcf86cd799439011',
+      title: 'Product',
+      description: 'short',
+      coverImage: '',
+      price: 0,
+      isPublished: true,
+      isActive: true,
+      businessId: { _id: '507f1f77bcf86cd799439012', businessName: 'Vendor Shop' },
+      createdAt: new Date('2026-07-01'),
+      updatedAt: new Date('2026-07-02'),
+    },
+    'product',
+    { variants: [] }
+  );
+
+  assert.equal(item.listingType, 'product');
+  assert.equal(item.businessName, 'Vendor Shop');
+  assert.equal(item.severity, 'high');
+  assert.ok(item.flags.length > 0);
+});
+
+test('matchesRequestedFlags filters by requested audit flags', () => {
+  assert.equal(matchesRequestedFlags(['missing_price', 'missing_image'], ['missing_price']), true);
+  assert.equal(matchesRequestedFlags(['suspicious_title'], ['missing_price']), false);
+  assert.equal(matchesRequestedFlags(['missing_price'], []), true);
+});

--- a/tests/admin/vendor-onboarding-finalize.test.js
+++ b/tests/admin/vendor-onboarding-finalize.test.js
@@ -272,6 +272,12 @@ test('finalizeVerification explicit reject stores reason, notes, next action, an
   assert.equal(res.body.data.rejectionReason, 'Business license appears expired');
   assert.equal(res.body.data.requiredNextAction, 'Upload a current business license and resubmit.');
   assert.equal(mailerCalls.rejection.rejectionReason, 'Business license appears expired');
+  assert.equal(
+    mailerCalls.rejection.requiredNextAction,
+    'Upload a current business license and resubmit.'
+  );
+  assert.equal(application.verificationNotificationLog.length, 1);
+  assert.equal(application.verificationNotificationLog[0].event, 'changes_requested');
   assert.equal(businessUpdates.at(-1).update.$set.isApproved, false);
   assert.equal(businessUpdates.at(-1).update.$set.isActive, false);
 });

--- a/tests/email/vendor-verification-guidance-mail.test.js
+++ b/tests/email/vendor-verification-guidance-mail.test.js
@@ -81,7 +81,7 @@ test('vendor verification guidance email escapes vendor-visible admin notes', as
   assert.ok(message.html.includes('https://mosaicbizhub.com/partners/business/new'));
 });
 
-test('vendor rejection email uses missing-document guidance copy', async () => {
+test('vendor rejection email sends dedicated changes-requested template', async () => {
   const originalMailUser = process.env.MAIL_USER;
   process.env.MAIL_USER = 'mail@example.com';
 
@@ -93,7 +93,8 @@ test('vendor rejection email uses missing-document guidance copy', async () => {
     vendorName: 'Vendor User',
     businessName: 'Missing Docs LLC',
     applicationId: 'MBH-APP-MISSING-001',
-    rejectionReason: 'EIN document',
+    rejectionReason: 'EIN document is unreadable',
+    requiredNextAction: 'Upload a clearer EIN document and resubmit.',
     documentsNeeded: ['EIN document'],
   });
 
@@ -102,9 +103,12 @@ test('vendor rejection email uses missing-document guidance copy', async () => {
   assert.equal(sendMailCalls.length, 1);
   assert.equal(info.messageId, 'message-1');
   const message = sendMailCalls[0];
-  assert.equal(message.subject, 'Action Required: Vendor Application Documents Needed');
+  assert.equal(message.subject, 'Action Required: Vendor Application Changes Requested');
   assert.ok(message.html.includes('Missing Docs LLC'));
-  assert.ok(message.html.includes('Current status:</strong> rejected'));
+  assert.ok(message.html.includes('Current status:</strong> Changes requested'));
+  assert.ok(message.html.includes('EIN document is unreadable'));
+  assert.ok(message.html.includes('Upload a clearer EIN document and resubmit.'));
+  assert.ok(message.html.includes('Documents still needed:'));
   assert.ok(message.html.includes('EIN document'));
   assert.ok(message.html.includes('Open Vendor Dashboard'));
 });

--- a/tests/integration/service-rfq.integration.test.js
+++ b/tests/integration/service-rfq.integration.test.js
@@ -1,0 +1,158 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  startHarness,
+  resetDatabase,
+  stopHarness,
+  getApp,
+} = require('./setup/harness');
+const { createAgent } = require('./helpers/client');
+const {
+  registerAndVerify,
+  login,
+  seedServiceBusiness,
+  seedServiceCategories,
+} = require('./helpers/factories');
+const User = require('../../models/User');
+const ServiceRfq = require('../../models/ServiceRfq');
+
+test.before(async () => {
+  await startHarness();
+});
+
+test.afterEach(async () => {
+  await resetDatabase();
+});
+
+test.after(async () => {
+  await stopHarness();
+});
+
+const canonicalChildPayload = {
+  title: 'RFQ Integration Salon',
+  description: 'Service listing for RFQ proof',
+  price: 45,
+  duration: '60',
+  services: [{ name: 'Consultation', price: 45, durationMinutes: 60 }],
+};
+
+async function setupPublishedService(agent, { rfqEnabled = true, externalLink = '' } = {}) {
+  const vendor = await registerAndVerify(agent, { role: 'business_owner' });
+  const user = await User.findOne({ email: vendor.email });
+  const business = await seedServiceBusiness(user);
+  const { category, subcategory } = await seedServiceCategories();
+
+  const loginRes = await login(agent, vendor.email, vendor.password);
+  assert.equal(loginRes.status, 200);
+
+  const createRes = await agent.post('/api/service/').send({
+    ...canonicalChildPayload,
+    businessId: business._id,
+    categoryId: category._id,
+    subcategoryId: subcategory._id,
+    isPublished: true,
+    rfqEnabled,
+    externalLink,
+    bookingToolLink: externalLink,
+  });
+
+  assert.equal(createRes.status, 201);
+  const serviceId = String(createRes.body?.data?.service?._id || '');
+
+  return { vendor, user, business, serviceId };
+}
+
+test('service RFQ: customer can submit quote request when rfqEnabled', async () => {
+  const vendorAgent = createAgent(getApp());
+  const { business, serviceId } = await setupPublishedService(vendorAgent, {
+    rfqEnabled: true,
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+
+  const submitRes = await customerAgent.post('/api/enquiries/rfq').send({
+    serviceId,
+    name: 'Quote Customer',
+    email: 'quote.customer@example.com',
+    phone: '5551234567',
+    message: 'Please share pricing for a full consultation package.',
+    services: ['Consultation'],
+    budget: '$200-$300',
+  });
+
+  assert.equal(submitRes.status, 201);
+  assert.equal(submitRes.body.success, true);
+
+  const stored = await ServiceRfq.findOne({ serviceId }).lean();
+  assert.ok(stored);
+  assert.equal(stored.customerName, 'Quote Customer');
+  assert.equal(stored.message, 'Please share pricing for a full consultation package.');
+  assert.deepEqual(stored.requestedServices, ['Consultation']);
+
+  const vendorRes = await vendorAgent.get('/api/enquiries/vendor/rfqs').query({
+    businessId: business._id,
+  });
+  assert.equal(vendorRes.status, 200);
+  assert.equal(vendorRes.body.total, 1);
+  assert.equal(vendorRes.body.data[0].customerEmail, 'quote.customer@example.com');
+});
+
+test('service RFQ: rejects submission when rfqEnabled is false', async () => {
+  const vendorAgent = createAgent(getApp());
+  const { serviceId } = await setupPublishedService(vendorAgent, {
+    rfqEnabled: false,
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+
+  const submitRes = await customerAgent.post('/api/enquiries/rfq').send({
+    serviceId,
+    name: 'Quote Customer',
+    email: 'quote.customer@example.com',
+    phone: '5551234567',
+    message: 'Please share pricing for a full consultation package.',
+  });
+
+  assert.equal(submitRes.status, 400);
+  assert.match(submitRes.body.message, /does not accept quote requests/i);
+});
+
+test('service RFQ: rejects submission when external link is configured', async () => {
+  const vendorAgent = createAgent(getApp());
+  const { serviceId } = await setupPublishedService(vendorAgent, {
+    rfqEnabled: true,
+    externalLink: 'https://calendly.com/example-booking',
+  });
+
+  const customerAgent = createAgent(getApp());
+  const customer = await registerAndVerify(customerAgent, { role: 'customer' });
+  await login(customerAgent, customer.email, customer.password);
+
+  const submitRes = await customerAgent.post('/api/enquiries/rfq').send({
+    serviceId,
+    name: 'Quote Customer',
+    email: 'quote.customer@example.com',
+    phone: '5551234567',
+    message: 'Please share pricing for a full consultation package.',
+  });
+
+  assert.equal(submitRes.status, 400);
+  assert.match(submitRes.body.message, /external booking link/i);
+});
+
+test('public service detail exposes externalLink and rfqEnabled', async () => {
+  const vendorAgent = createAgent(getApp());
+  const { serviceId } = await setupPublishedService(vendorAgent, {
+    rfqEnabled: true,
+    externalLink: '',
+  });
+
+  const publicRes = await vendorAgent.get(`/api/public/services/${serviceId}`);
+  assert.equal(publicRes.status, 200);
+  assert.equal(publicRes.body.data.service.rfqEnabled, true);
+  assert.ok(Object.prototype.hasOwnProperty.call(publicRes.body.data.service, 'externalLink'));
+});

--- a/tests/jobs/onboarding-reminders.test.js
+++ b/tests/jobs/onboarding-reminders.test.js
@@ -1,0 +1,180 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+const jobPath = path.resolve(__dirname, '../../jobs/onboardingReminders.js');
+const mailerPath = path.resolve(__dirname, '../../utils/WellcomeMailer.js');
+const emailDeliveryPath = path.resolve(__dirname, '../../utils/vendorOnboardingEmailDelivery.js');
+
+function buildApplication(overrides = {}) {
+  const reminderLog = overrides.onboardingReminderLog || [];
+  return {
+    applicationId: 'MBH-APP-REMINDER-001',
+    businessName: 'Reminder Test LLC',
+    status: 'payment_pending',
+    updatedAt: new Date('2026-07-01T00:00:00Z'),
+    verificationPayment: { status: 'pending' },
+    userId: {
+      _id: '507f1f77bcf86cd799439011',
+      name: 'Vendor User',
+      email: 'vendor@example.com',
+    },
+    onboardingReminderLog: reminderLog,
+    save: async function save() {
+      return this;
+    },
+    ...overrides,
+  };
+}
+
+function loadJob({ applications = [], mailerCalls = [], emailConfigured = true } = {}) {
+  process.env.MAIL_USER = emailConfigured ? 'mail@example.com' : '';
+  process.env.MAIL_PASSWORD = emailConfigured ? 'app-password' : '';
+  process.env.ENABLE_ONBOARDING_REMINDERS = 'true';
+  process.env.ONBOARDING_REMINDER_MIN_AGE_HOURS = '1';
+  process.env.ONBOARDING_REMINDER_COOLDOWN_HOURS = '72';
+  process.env.ONBOARDING_REMINDER_BATCH_LIMIT = '10';
+
+  const vendorOnboardingMock = {
+    find: (query) => ({
+      populate: () => ({
+        limit: () => ({
+          exec: async () => {
+            if (query.status === 'payment_pending') {
+              return applications.filter((app) => app.status === 'payment_pending');
+            }
+            if (query.status === 'draft') {
+              return applications.filter((app) => app.status === 'draft');
+            }
+            return [];
+          },
+        }),
+      }),
+    }),
+  };
+
+  const mailerMock = {
+    sendPaymentReminderEmail: async (payload) => {
+      mailerCalls.push(payload);
+      return { messageId: `reminder-${mailerCalls.length}` };
+    },
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (String(request).includes('models/VendorOnboardingStage1')) {
+      return vendorOnboardingMock;
+    }
+    if (String(request).includes('utils/WellcomeMailer')) {
+      return mailerMock;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[jobPath];
+  delete require.cache[emailDeliveryPath];
+  const job = require(jobPath);
+  Module._load = originalLoad;
+
+  return { job, mailerCalls };
+}
+
+test('runOnboardingReminderBatch sends payment_pending reminder for stalled application', async () => {
+  const application = buildApplication();
+  const { job, mailerCalls } = loadJob({ applications: [application] });
+
+  const result = await job.runOnboardingReminderBatch();
+
+  assert.equal(result.enabled, true);
+  assert.equal(result.processed, 1);
+  assert.equal(mailerCalls.length, 1);
+  assert.equal(mailerCalls[0].reminderKind, 'payment_pending');
+  assert.equal(application.onboardingReminderLog.length, 1);
+  assert.equal(application.onboardingReminderLog[0].kind, 'payment_pending');
+  assert.equal(application.onboardingReminderLog[0].deliveryStatus, 'sent');
+});
+
+test('runOnboardingReminderBatch sends paid draft reminder', async () => {
+  const application = buildApplication({
+    status: 'draft',
+    verificationPayment: { status: 'paid' },
+    submittedAt: undefined,
+  });
+  const { job, mailerCalls } = loadJob({ applications: [application] });
+
+  const result = await job.runOnboardingReminderBatch();
+
+  assert.equal(result.processed, 1);
+  assert.equal(mailerCalls[0].reminderKind, 'paid_draft_unsubmitted');
+  assert.equal(application.onboardingReminderLog[0].kind, 'paid_draft_unsubmitted');
+});
+
+test('wasRecentlyReminded suppresses duplicate sent reminders inside cooldown', async () => {
+  const application = buildApplication({
+    onboardingReminderLog: [{
+      kind: 'payment_pending',
+      sentAt: new Date(),
+      deliveryStatus: 'sent',
+    }],
+  });
+  const { job, mailerCalls } = loadJob({ applications: [application] });
+
+  const result = await job.runOnboardingReminderBatch();
+
+  assert.equal(result.processed, 0);
+  assert.equal(mailerCalls.length, 0);
+});
+
+test('sendPaymentReminderEmail renders onboarding alert CTA', async () => {
+  const originalMailUser = process.env.MAIL_USER;
+  process.env.MAIL_USER = 'mail@example.com';
+
+  const sendMailCalls = [];
+  const nodemailerMock = {
+    createTransport: () => ({
+      sendMail: async (message) => {
+        sendMailCalls.push(message);
+        return { messageId: 'message-1' };
+      },
+    }),
+  };
+
+  const frontendUrlMock = {
+    buildFrontendUrl: (route = '/') => `https://mosaicbizhub.com${route.startsWith('/') ? route : `/${route}`}`,
+    getFrontendLogoUrl: () => 'https://mosaicbizhub.com/logo.png',
+  };
+
+  const smtpTransportMock = {
+    buildSmtpTransportConfig: () => ({}),
+    formatMosaicFromHeader: () => 'Mosaic Biz Hub <mail@example.com>',
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function mockLoad(request, parent, isMain) {
+    if (request === 'nodemailer') return nodemailerMock;
+    if (request === './frontendUrl') return frontendUrlMock;
+    if (request === './smtpTransport') return smtpTransportMock;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  delete require.cache[mailerPath];
+  const mailer = require(mailerPath);
+  Module._load = originalLoad;
+
+  await mailer.sendPaymentReminderEmail({
+    to: 'vendor@example.com',
+    vendorName: 'Vendor User',
+    businessName: 'Reminder LLC',
+    applicationId: 'MBH-APP-REMINDER-EMAIL',
+    reminderKind: 'payment_pending',
+  });
+
+  process.env.MAIL_USER = originalMailUser;
+
+  assert.equal(sendMailCalls.length, 1);
+  assert.equal(sendMailCalls[0].subject, 'Action Required: Complete Your Vendor Onboarding');
+  assert.ok(sendMailCalls[0].html.includes('Onboarding Alert'));
+  assert.ok(sendMailCalls[0].html.includes('Complete Your Payment &amp; Onboarding Setup'));
+  assert.ok(sendMailCalls[0].html.includes('MBH-APP-REMINDER-EMAIL'));
+});

--- a/tests/vendor/vendor-onboarding-status-next-step.test.js
+++ b/tests/vendor/vendor-onboarding-status-next-step.test.js
@@ -178,3 +178,42 @@ test('non-rejected application does not expose rejection metadata', async () => 
   assert.equal(res.body.data.details.stage1.rejectionReason, null);
   assert.equal(res.body.data.details.stage1.requiredNextAction, null);
 });
+
+test('payment_pending application returns explicit payment next action', async () => {
+  const onboarding = buildOnboarding({
+    status: 'payment_pending',
+    verificationPayment: { status: 'pending' },
+  });
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.getStatusByApplicationId(
+    { params: { applicationId: onboarding.applicationId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.status, 'Stage 1 - Payment Pending');
+  assert.equal(
+    res.body.data.nextAction,
+    'Complete your verification payment to continue onboarding'
+  );
+});
+
+test('paid draft application returns submit next action', async () => {
+  const onboarding = buildOnboarding({
+    status: 'draft',
+    verificationPayment: { status: 'paid' },
+  });
+  const controller = loadController(onboarding);
+  const res = mockResponse();
+
+  await controller.getStatusByApplicationId(
+    { params: { applicationId: onboarding.applicationId } },
+    res
+  );
+
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.status, 'Stage 1 - Payment Complete (Not Submitted)');
+  assert.equal(res.body.data.nextAction, 'Submit your application for admin review');
+});

--- a/utils/WellcomeMailer.js
+++ b/utils/WellcomeMailer.js
@@ -289,6 +289,85 @@ exports.sendVendorSubmissionConfirmationEmail = async ({
   return transporter.sendMail(mailOptions);
 };
 
+const onboardingPaymentReminderCopy = Object.freeze({
+  payment_pending: {
+    headline: 'Your verification payment is still pending',
+    detail:
+      'We noticed you started your Mosaic Biz Hub vendor application but have not completed the one-time verification fee yet.',
+    ctaPath: '/partners/business/payment',
+  },
+  paid_draft_unsubmitted: {
+    headline: 'Your application is ready to submit',
+    detail:
+      'Your verification payment is complete. Finish your application details and submit for admin review to keep onboarding moving.',
+    ctaPath: '/partners/business/payment',
+  },
+});
+
+exports.sendPaymentReminderEmail = async (vendorData = {}) => {
+  const {
+    to,
+    vendorName,
+    businessName,
+    applicationId,
+    reminderKind = 'payment_pending',
+    supportEmail,
+  } = vendorData;
+
+  const copy = onboardingPaymentReminderCopy[reminderKind]
+    || onboardingPaymentReminderCopy.payment_pending;
+  const displayName = vendorName || 'there';
+  const displayBusinessName = businessName || 'your business';
+  const contactEmail = supportEmail || process.env.SUPPORT_EMAIL || 'info@mosaicbizhub.com';
+  const actionUrl = buildFrontendUrl(copy.ctaPath);
+
+  const mailOptions = {
+    from: formatMosaicFromHeader(),
+    to,
+    subject: 'Action Required: Complete Your Vendor Onboarding',
+    html: `
+      <div style="font-family:Arial,sans-serif;background:#f8fafc;padding:28px;">
+        <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:8px;padding:28px;border:1px solid #e2e8f0;">
+          <p style="margin:0 0 8px;font-size:12px;font-weight:bold;letter-spacing:0.08em;text-transform:uppercase;color:#b45309;">
+            Onboarding Alert
+          </p>
+          <h2 style="margin:0 0 12px;color:#0f172a;">Hello ${escapeHtml(displayName)},</h2>
+          <p style="color:#475569;line-height:1.6;margin:0 0 16px;">
+            ${escapeHtml(copy.detail)} for <strong>${escapeHtml(displayBusinessName)}</strong>.
+          </p>
+
+          <div style="background:#fff7ed;border:1px solid #fdba74;border-radius:6px;padding:16px;margin:18px 0;">
+            <p style="margin:0 0 8px;color:#9a3412;font-weight:bold;">${escapeHtml(copy.headline)}</p>
+            <p style="margin:0;color:#7c2d12;line-height:1.6;">
+              Pick up where you left off to unlock vendor verification, storefront setup, and marketplace listings.
+            </p>
+          </div>
+
+          <div style="background:#f1f5f9;border:1px solid #cbd5e1;border-radius:6px;padding:14px;margin:18px 0;">
+            <p style="margin:0;color:#334155;"><strong>Application ID:</strong> ${escapeHtml(applicationId || 'N/A')}</p>
+          </div>
+
+          <div style="margin:24px 0;text-align:center;">
+            <a href="${actionUrl}" style="background:#1d4ed8;color:#fff;padding:14px 22px;text-decoration:none;border-radius:6px;font-size:15px;font-weight:bold;display:inline-block;">
+              Complete Your Payment &amp; Onboarding Setup
+            </a>
+          </div>
+
+          <p style="font-size:13px;color:#64748b;line-height:1.5;margin:24px 0 0;">
+            Need help? Contact <a href="mailto:${escapeHtml(contactEmail)}">${escapeHtml(contactEmail)}</a>.
+          </p>
+
+          <p style="font-size:13px;color:#64748b;margin:18px 0 0;">
+            Mosaic Biz Hub Team
+          </p>
+        </div>
+      </div>
+    `,
+  };
+
+  return transporter.sendMail(mailOptions);
+};
+
 
 exports.sendVendorApprovedEmail = async ({
   to,
@@ -408,21 +487,83 @@ exports.sendVendorRejectionEmail = async ({
   applicationId,
   rejectionReason,
   businessName,
-  currentStatus = 'rejected',
+  requiredNextAction,
   documentsNeeded,
   responseWindowDays,
 }) => {
-  return exports.sendVendorVerificationGuidanceEmail({
+  const safeRejectionReason = String(rejectionReason ?? '').trim()
+    || 'Your application did not meet the current verification requirements.';
+  const safeNextAction = String(requiredNextAction ?? '').trim()
+    || 'Update your application and resubmit for review.';
+  const documents = normalizeMailerList(documentsNeeded);
+  const displayName = vendorName || 'there';
+  const displayBusinessName = businessName || 'your business';
+  const correctionUrl = buildFrontendUrl('/partners/business/new');
+  const contactEmail = process.env.SUPPORT_EMAIL || 'info@mosaicbizhub.com';
+
+  const responseDays = Number(responseWindowDays);
+  const responseWindowText = Number.isFinite(responseDays) && responseDays > 0
+    ? `Please complete the next steps within ${Math.round(responseDays)} business day${Math.round(responseDays) === 1 ? '' : 's'}.`
+    : 'Please complete the next steps as soon as you can so our team can continue review.';
+
+  const mailOptions = {
+    from: formatMosaicFromHeader(),
     to,
-    vendorName,
-    businessName,
-    applicationId,
-    currentStatus,
-    outcome: 'missing_documents',
-    reason: rejectionReason,
-    documentsNeeded,
-    responseWindowDays,
-  });
+    subject: 'Action Required: Vendor Application Changes Requested',
+    html: `
+      <div style="font-family:Arial,sans-serif;background:#f8fafc;padding:28px;">
+        <div style="max-width:640px;margin:0 auto;background:#ffffff;border-radius:8px;padding:28px;border:1px solid #e2e8f0;">
+          <h2 style="margin:0 0 12px;color:#0f172a;">Hello ${escapeHtml(displayName)},</h2>
+          <p style="color:#475569;line-height:1.6;margin:0 0 16px;">
+            Thank you for applying to <strong>Mosaic Biz Hub</strong>. After reviewing your application for
+            <strong>${escapeHtml(displayBusinessName)}</strong>, our team needs a few updates before we can approve your vendor profile.
+          </p>
+
+          <div style="background:#f1f5f9;border:1px solid #cbd5e1;border-radius:6px;padding:14px;margin:18px 0;">
+            <p style="margin:0;color:#334155;"><strong>Application ID:</strong> ${escapeHtml(applicationId || 'N/A')}</p>
+            <p style="margin:6px 0 0;color:#334155;"><strong>Current status:</strong> Changes requested</p>
+          </div>
+
+          <div style="background:#fff7ed;border:1px solid #fdba74;border-radius:6px;padding:16px;margin:18px 0;">
+            <p style="margin:0 0 8px;color:#9a3412;font-weight:bold;">Reason for this decision</p>
+            <p style="margin:0;color:#7c2d12;line-height:1.6;">${escapeHtml(safeRejectionReason)}</p>
+          </div>
+
+          <div style="background:#eff6ff;border:1px solid #93c5fd;border-radius:6px;padding:16px;margin:18px 0;">
+            <p style="margin:0 0 8px;color:#1e3a8a;font-weight:bold;">What you need to do next</p>
+            <p style="margin:0;color:#1e40af;line-height:1.6;">${escapeHtml(safeNextAction)}</p>
+          </div>
+
+          ${documents.length ? `
+            <p style="color:#475569;line-height:1.6;margin:18px 0 8px;">
+              <strong>Documents still needed:</strong>
+            </p>
+            ${buildListHtml(documents)}
+          ` : ''}
+
+          <p style="color:#475569;line-height:1.6;margin:18px 0 0;">
+            ${escapeHtml(responseWindowText)}
+          </p>
+
+          <div style="margin:24px 0;text-align:center;">
+            <a href="${correctionUrl}" style="background:#1d4ed8;color:#fff;padding:12px 18px;text-decoration:none;border-radius:6px;font-size:14px;font-weight:bold;">
+              Open Vendor Dashboard
+            </a>
+          </div>
+
+          <p style="font-size:13px;color:#64748b;line-height:1.5;margin:24px 0 0;">
+            Need help? Contact <a href="mailto:${escapeHtml(contactEmail)}">${escapeHtml(contactEmail)}</a>.
+          </p>
+
+          <p style="font-size:13px;color:#64748b;margin:18px 0 0;">
+            Mosaic Biz Hub Team
+          </p>
+        </div>
+      </div>
+    `,
+  };
+
+  return transporter.sendMail(mailOptions);
 };
 
 // exports.sendVendorRejectionEmail = async ({

--- a/utils/audit/actionRegistry.js
+++ b/utils/audit/actionRegistry.js
@@ -17,9 +17,19 @@ const ADMIN_AUDIT_ACTIONS = Object.freeze({
   BUSINESS_DISAPPROVE: 'business.disapprove',
   BUSINESS_ACTIVATE: 'business.activate',
   BUSINESS_DEACTIVATE: 'business.deactivate',
+  BUSINESS_TAGS_UPDATE: 'business.tags_update',
+  BUSINESS_FEATURE: 'business.feature',
+  BUSINESS_UNFEATURE: 'business.unfeature',
 
   PRODUCT_FEATURE: 'product.feature',
   PRODUCT_UNFEATURE: 'product.unfeature',
+
+  CATALOG_UPDATE: 'catalog.update',
+  CATALOG_DEACTIVATE: 'catalog.deactivate',
+  CATALOG_ACTIVATE: 'catalog.activate',
+  CATALOG_DELETE: 'catalog.delete',
+
+  BUSINESS_PROFILE_UPDATE: 'business.profile_update',
 
   CATEGORY_CREATE: 'category.create',
   CATEGORY_UPDATE: 'category.update',
@@ -37,6 +47,7 @@ const ADMIN_AUDIT_TARGET_TYPES = Object.freeze({
   USER: 'user',
   BUSINESS: 'business',
   PRODUCT: 'product',
+  CATALOG_LISTING: 'catalog_listing',
   CATEGORY: 'category',
   CATEGORY_REQUEST: 'category_request',
   SUBSCRIPTION_PLAN: 'subscription_plan',

--- a/utils/rfqMailer.js
+++ b/utils/rfqMailer.js
@@ -1,0 +1,104 @@
+const nodemailer = require('nodemailer');
+const { buildFrontendUrl } = require('./frontendUrl');
+const {
+  buildSmtpTransportConfig,
+  formatMosaicFromHeader,
+} = require('./smtpTransport');
+
+const transporter = nodemailer.createTransport(buildSmtpTransportConfig());
+
+const safe = (value, fallback = 'N/A') => {
+  const normalized = String(value || '').trim();
+  return normalized || fallback;
+};
+
+const buildPartnerInquiriesUrl = (businessSlug) => {
+  if (businessSlug) {
+    return buildFrontendUrl(`/partners/${encodeURIComponent(businessSlug)}/inquiries`);
+  }
+  return buildFrontendUrl('/partners/dashboard');
+};
+
+exports.sendVendorNewServiceRfqEmail = async ({
+  to,
+  vendorName,
+  serviceTitle,
+  customerName,
+  customerEmail,
+  customerPhone,
+  message,
+  requestedServices,
+  budget,
+  rfqId,
+  businessSlug,
+}) => {
+  if (!to || to.length === 0) return;
+
+  const dashboardLink = buildPartnerInquiriesUrl(businessSlug);
+  const selectedServices = Array.isArray(requestedServices) && requestedServices.length > 0
+    ? requestedServices.map((item) => `<li>${safe(item)}</li>`).join('')
+    : '<li>General quote request</li>';
+
+  await transporter.sendMail({
+    from: formatMosaicFromHeader(),
+    to,
+    subject: 'New service quote request received',
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+        <h2>Hi ${safe(vendorName, 'Vendor')},</h2>
+        <p>You have received a new request for quote from a customer on your Mosaic storefront.</p>
+        <p><strong>Quote ID:</strong> ${safe(rfqId)}</p>
+        <p><strong>Service listing:</strong> ${safe(serviceTitle)}</p>
+        <p><strong>Customer:</strong> ${safe(customerName)} (${safe(customerEmail)}, ${safe(customerPhone)})</p>
+        ${budget ? `<p><strong>Budget:</strong> ${safe(budget)}</p>` : ''}
+        <p><strong>Requested services:</strong></p>
+        <ul>${selectedServices}</ul>
+        <p><strong>Message:</strong></p>
+        <p>${safe(message)}</p>
+        <p>Review the request in your vendor dashboard and follow up with the customer directly.</p>
+        <p>
+          <a href="${dashboardLink}" style="display:inline-block;padding:10px 18px;background:#0d6efd;color:#fff;text-decoration:none;border-radius:4px;">
+            View quote requests
+          </a>
+        </p>
+      </div>
+    `,
+  });
+};
+
+exports.sendCustomerServiceRfqConfirmationEmail = async ({
+  to,
+  customerName,
+  serviceTitle,
+  vendorName,
+  message,
+  requestedServices,
+  budget,
+  rfqId,
+}) => {
+  if (!to) return;
+
+  const selectedServices = Array.isArray(requestedServices) && requestedServices.length > 0
+    ? requestedServices.map((item) => `<li>${safe(item)}</li>`).join('')
+    : '<li>General quote request</li>';
+
+  await transporter.sendMail({
+    from: formatMosaicFromHeader(),
+    to,
+    subject: 'Your quote request has been received',
+    html: `
+      <div style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+        <h2>Hi ${safe(customerName, 'Customer')},</h2>
+        <p>Your request for quote has been sent to ${safe(vendorName, 'the vendor')}.</p>
+        <p><strong>Quote ID:</strong> ${safe(rfqId)}</p>
+        <p><strong>Service listing:</strong> ${safe(serviceTitle)}</p>
+        ${budget ? `<p><strong>Budget:</strong> ${safe(budget)}</p>` : ''}
+        <p><strong>Requested services:</strong></p>
+        <ul>${selectedServices}</ul>
+        <p><strong>Your message:</strong></p>
+        <p>${safe(message)}</p>
+        <p>The vendor will review your request and contact you with next steps.</p>
+      </div>
+    `,
+  });
+};

--- a/utils/serviceLeadConfig.js
+++ b/utils/serviceLeadConfig.js
@@ -1,0 +1,68 @@
+const HTTPS_URL_PATTERN = /^https?:\/\/.+\..+/;
+
+const isValidExternalServiceUrl = (value) => {
+  if (!value || typeof value !== 'string') return false;
+  return HTTPS_URL_PATTERN.test(value.trim());
+};
+
+const resolvePublicExternalLink = (service = {}) => {
+  const externalLink = String(service.externalLink || '').trim();
+  if (externalLink && isValidExternalServiceUrl(externalLink)) {
+    return externalLink;
+  }
+
+  const bookingToolLink = String(service.bookingToolLink || '').trim();
+  if (bookingToolLink && isValidExternalServiceUrl(bookingToolLink)) {
+    return bookingToolLink;
+  }
+
+  return '';
+};
+
+const parseBooleanFlag = (value) => value === true || value === 'true';
+
+const parseLeadConfigFromBody = (body = {}) => {
+  const hasExternalInput = body.externalLink !== undefined || body.bookingToolLink !== undefined;
+  const externalRaw = body.externalLink !== undefined ? body.externalLink : body.bookingToolLink;
+  const bookingRaw = body.bookingToolLink !== undefined ? body.bookingToolLink : body.externalLink;
+
+  const externalLink = typeof externalRaw === 'string' ? externalRaw.trim() : '';
+  const bookingToolLink = typeof bookingRaw === 'string' ? bookingRaw.trim() : externalLink;
+
+  return {
+    hasExternalInput,
+    externalLink,
+    bookingToolLink: bookingToolLink || externalLink,
+    rfqEnabled: parseBooleanFlag(body.rfqEnabled),
+  };
+};
+
+const applyLeadConfigToDocument = (target, body = {}) => {
+  const config = parseLeadConfigFromBody(body);
+
+  if (config.hasExternalInput) {
+    if (config.externalLink && !isValidExternalServiceUrl(config.externalLink)) {
+      const error = new Error('externalLink must be a valid http(s) URL');
+      error.statusCode = 400;
+      throw error;
+    }
+
+    target.externalLink = config.externalLink;
+    target.bookingToolLink = config.bookingToolLink;
+  }
+
+  if (body.rfqEnabled !== undefined) {
+    target.rfqEnabled = config.rfqEnabled;
+  }
+
+  return target;
+};
+
+module.exports = {
+  HTTPS_URL_PATTERN,
+  isValidExternalServiceUrl,
+  resolvePublicExternalLink,
+  parseBooleanFlag,
+  parseLeadConfigFromBody,
+  applyLeadConfigToDocument,
+};

--- a/utils/vendorOnboardingProfileFields.js
+++ b/utils/vendorOnboardingProfileFields.js
@@ -34,6 +34,7 @@ const VENDOR_PROTECTED_ONBOARDING_FIELDS = [
   'businessId',
   'submittedAt',
   'profileCompletionNotifiedAt',
+  'onboardingReminderLog',
   'verificationNotificationLog',
   'userId',
   'trustScore',


### PR DESCRIPTION
## Summary
- Add Service RFQ model, lead-config validation, RFQ mailers, and `POST /api/enquiries/rfq` + vendor inbox API.
- Add admin catalog audit, review moderation, featured vendor/tags endpoints, and onboarding reminder cron job.
- Extend service schema with `externalLink`/`rfqEnabled` and expose lead config on public listing DTOs.

## Local CI verification (pre-PR)
- [x] `npm test` — 609/609 passed
- [x] `npm run test:contract` — 20/20 passed
- [x] `npm run test:integration` — 92/92 passed (includes service RFQ integration suite)

## Test plan
- [ ] `POST /api/enquiries/rfq` creates RFQ and triggers vendor + customer emails
- [ ] `GET /api/enquiries/vendor/rfqs` returns vendor-scoped RFQ list
- [ ] Service create/update persists `externalLink` and `rfqEnabled`
- [ ] Admin review hide/restore/delete updates listing stats
- [ ] Admin catalog audit flags incomplete published listings
- [ ] Onboarding reminder job respects cooldown and batch limits
- [ ] Confirm GitHub `CI` workflow (test + contract + integration + build gate) passes on this PR


Made with [Cursor](https://cursor.com)